### PR TITLE
detector/binary/govulncheck: report only symbol level vulns

### DIFF
--- a/detector/govulncheck/binary/detector_test.go
+++ b/detector/govulncheck/binary/detector_test.go
@@ -50,8 +50,12 @@ func TestScan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("detector.Scan(%v): %v", ix, err)
 	}
-	if len(findings) == 0 {
-		t.Fatalf("detector.Scan(%v): expected findings, got none: %v", ix, findings)
+	// There are two vulns in the test vulndb defined for two
+	// module dependencies of the test binary. Both dependencies
+	// are used at a vulnerable version. However, for only one
+	// there is a vulnerable symbol present in the binary.
+	if len(findings) != 1 {
+		t.Fatalf("detector.Scan(%v): expected 1 finding, got: %v", ix, findings)
 	}
 	got := findings[0]
 	wantTitle := "Excessive memory growth in net/http and golang.org/x/net/http2"

--- a/detector/govulncheck/binary/message.go
+++ b/detector/govulncheck/binary/message.go
@@ -16,7 +16,19 @@ package binary
 
 // govulncheckMessage contains the relevant parts of the json output of govulncheck.
 type govulncheckMessage struct {
-	OSV *osvEntry `json:"osv,omitempty"`
+	OSV     *osvEntry           `json:"osv,omitempty"`
+	Finding *govulncheckFinding `json:"finding,omitempty"`
+}
+
+// govulncheckFinding is a trimmed down version of govulncheck finding.
+type govulncheckFinding struct {
+	OSV   string              `json:"osv,omitempty"`
+	Trace []*govulncheckFrame `json:"trace,omitempty"`
+}
+
+type govulncheckFrame struct {
+	// Function is the detected symbol.
+	Function string `json:"function,omitempty"`
 }
 
 // osvEntry represents a vulnerability in the Go OSV format, documented
@@ -37,6 +49,7 @@ type osvEntry struct {
 	// affected by the vulnerability.
 	Affected []affected
 }
+
 type affected struct {
 	// The affected Go module. Required.
 	// Note that this field is called "package" in the OSV specification.
@@ -46,6 +59,7 @@ type affected struct {
 	// Details on the affected packages and symbols within the module.
 	EcosystemSpecific ecosystemSpecific `json:"ecosystem_specific"`
 }
+
 type module struct {
 	// The Go module path.
 	Path string `json:"name"`

--- a/detector/govulncheck/binary/testdata/vulndb/ID/GO-2024-2887.json
+++ b/detector/govulncheck/binary/testdata/vulndb/ID/GO-2024-2887.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "1.3.1",
+  "id": "GO-2024-2887",
+  "modified": "0001-01-01T00:00:00Z",
+  "published": "0001-01-01T00:00:00Z",
+  "aliases": [
+    "CVE-2024-24790"
+  ],
+  "summary": "Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in net/netip",
+  "details": "The various Is methods (IsPrivate, IsLoopback, etc) did not work as expected for IPv4-mapped IPv6 addresses, returning false for addresses which would return true in their traditional IPv4 forms.",
+  "affected": [
+    {
+      "package": {
+        "name": "stdlib",
+        "ecosystem": "Go"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.21.11"
+            },
+            {
+              "introduced": "1.22.0-0"
+            },
+            {
+              "fixed": "1.22.4"
+            }
+          ]
+        }
+      ],
+      "ecosystem_specific": {
+        "imports": [
+          {
+            "path": "net/netip",
+            "symbols": [
+              "Addr.IsGlobalUnicast",
+              "Addr.IsInterfaceLocalMulticast",
+              "Addr.IsLinkLocalMulticast",
+              "Addr.IsLoopback",
+              "Addr.IsMulticast",
+              "Addr.IsPrivate"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "FIX",
+      "url": "https://go.dev/cl/590316"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://go.dev/issue/67680"
+    },
+    {
+      "type": "WEB",
+      "url": "https://groups.google.com/g/golang-announce/c/XbxouI9gY7k/m/TuoGEhxIEwAJ"
+    }
+  ],
+  "credits": [
+    {
+      "name": "Enze Wang of Alioth (@zer0yu)"
+    },
+    {
+      "name": "Jianjun Chen of Zhongguancun Lab (@chenjj)"
+    }
+  ],
+  "database_specific": {
+    "url": "https://pkg.go.dev/vuln/GO-2024-2887",
+    "review_status": "REVIEWED"
+  }
+}

--- a/detector/govulncheck/binary/testdata/vulndb/index/modules.json
+++ b/detector/govulncheck/binary/testdata/vulndb/index/modules.json
@@ -1,1 +1,1 @@
-[{"path":"golang.org/x/net","vulns":[{"id":"GO-2022-1144","modified":"2023-06-12T18:45:41Z","fixed":"0.4.0"}]},{"path":"stdlib","vulns":[{"id":"GO-2022-1144","modified":"2023-06-12T18:45:41Z","fixed":"1.19.4"}]}]
+[{"path":"golang.org/x/net","vulns":[{"id":"GO-2022-1144","modified":"2023-06-12T18:45:41Z","fixed":"0.4.0"}]},{"path":"stdlib","vulns":[{"id":"GO-2022-1144","modified":"2023-06-12T18:45:41Z","fixed":"1.19.4"},{"id":"GO-2024-2887","modified":"2024-06-04T17:58:12Z","fixed":"1.22.4"}]}]

--- a/detector/govulncheck/binary/testdata/vulndb/index/vulns.json
+++ b/detector/govulncheck/binary/testdata/vulndb/index/vulns.json
@@ -1,1 +1,1 @@
-[{"id":"GO-2022-1144","modified":"2023-06-12T18:45:41Z","aliases":["CVE-2022-41717","GHSA-xrjj-mj9h-534m"]}]
+[{"id":"GO-2022-1144","modified":"2023-06-12T18:45:41Z","aliases":["CVE-2022-41717","GHSA-xrjj-mj9h-534m"]},{"id":"GO-2024-2887","modified":"2024-06-04T17:58:12Z","aliases":["CVE-2024-24790"]}]


### PR DESCRIPTION
Currently, every single OSV reported by govulncheck JSON is converted to a scalibr finding. This seems incorrect. govulncheck JSON will emit all OSVs that apply to module dependencies, regardless of the version at which the binary is using them. The results of version checking manifest as govulncheck findings at the scan module level. Further, we are interested in govulncheck findings at the scan symbol level. This CL takes govulncheck findings at the symbol level (i.e., detected symbols in the binary) and converts those to scalibr findings.

We also add tests that fail for the code before this change, but succeed with this change.