### PR TITLE
Add CycloneDX export option

### DIFF
--- a/binary/cdx/cdx.go
+++ b/binary/cdx/cdx.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cdx provides utilities for writing CycloneDX documents to the filesystem.
+package cdx
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/CycloneDX/cyclonedx-go"
+)
+
+// Write writes an CDX document into a file in the choosen format
+func Write(doc *cyclonedx.BOM, path string, format string) error {
+	var cdxFormat cyclonedx.BOMFileFormat
+	switch format {
+	case "cdx-json":
+		cdxFormat = cyclonedx.BOMFileFormatJSON
+	case "cdx-xml":
+		cdxFormat = cyclonedx.BOMFileFormatXML
+	default:
+		return fmt.Errorf("%s has an invalid CDX format or not supported by SCALIBR", path)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	encoder := cyclonedx.NewBOMEncoder(f, cdxFormat).SetPretty(true)
+	return encoder.Encode(doc)
+}

--- a/binary/cdx/cdx_test.go
+++ b/binary/cdx/cdx_test.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdx_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv-scalibr/binary/cdx"
+)
+
+var doc *cyclonedx.BOM
+
+func init() {
+	doc = cyclonedx.NewBOM()
+	doc.Metadata = &cyclonedx.Metadata{
+		Timestamp: "2006-01-02T15:04:05Z",
+		Component: &cyclonedx.Component{
+			Name: "BOM name",
+		},
+	}
+}
+
+func TestWrite(t *testing.T) {
+	testDirPath := t.TempDir()
+	testCases := []struct {
+		desc   string
+		format string
+		want   string
+	}{
+		{
+			desc:   "xml",
+			format: "cdx-xml",
+			want:   "testdata/doc.cyclonedx.xml",
+		},
+		{
+			desc:   "json",
+			format: "cdx-json",
+			want:   "testdata/doc.cyclonedx.json",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fullPath := filepath.Join(testDirPath, "output")
+			err := cdx.Write(doc, fullPath, tc.format)
+			if err != nil {
+				t.Fatalf("cdx.Write(%v, %s, %s) returned an error: %v", doc, fullPath, tc.format, err)
+			}
+
+			got, err := os.ReadFile(fullPath)
+			if err != nil {
+				t.Fatalf("error while reading %s: %v", fullPath, err)
+			}
+			want, err := os.ReadFile(tc.want)
+			if err != nil {
+				t.Fatalf("error while reading %s: %v", tc.want, err)
+			}
+			wantStr := strings.TrimSpace(string(want))
+			gotStr := strings.TrimSpace(string(got))
+			if runtime.GOOS == "windows" {
+				wantStr = strings.ReplaceAll(wantStr, "\r", "")
+				gotStr = strings.ReplaceAll(gotStr, "\r", "")
+			}
+
+			if diff := cmp.Diff(wantStr, gotStr); diff != "" {
+				t.Errorf("cdx.Write(%v, %s, %s) produced unexpected results, diff (-want +got):\n%s", doc, fullPath, tc.format, diff)
+			}
+		})
+	}
+}
+
+func TestWrite_InvalidFormat(t *testing.T) {
+	testDirPath := t.TempDir()
+	fullPath := filepath.Join(testDirPath, "output")
+	format := "invalid-format"
+	if err := cdx.Write(doc, fullPath, format); err == nil ||
+		!strings.Contains(err.Error(), "invalid CDX format") {
+		t.Errorf("cdx.Write(%s, %s) didn't return an invalid extension error: %v", fullPath, format, err)
+	}
+}

--- a/binary/cdx/testdata/doc.cyclonedx.json
+++ b/binary/cdx/testdata/doc.cyclonedx.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2006-01-02T15:04:05Z",
+    "component": {
+      "type": "",
+      "name": "BOM name"
+    }
+  }
+}

--- a/binary/cdx/testdata/doc.cyclonedx.xml
+++ b/binary/cdx/testdata/doc.cyclonedx.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
+  <metadata>
+    <timestamp>2006-01-02T15:04:05Z</timestamp>
+    <component type="">
+      <name>BOM name</name>
+    </component>
+  </metadata>
+</bom>

--- a/binary/cli/cli_test.go
+++ b/binary/cli/cli_test.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	scalibr "github.com/google/osv-scalibr"
 	"github.com/google/osv-scalibr/binary/cli"
 	"github.com/google/osv-scalibr/detector/govulncheck/binary"
 	"github.com/google/osv-scalibr/plugin"
-	scalibr "github.com/google/osv-scalibr"
 )
 
 func TestValidateFlags(t *testing.T) {
@@ -438,6 +438,14 @@ func TestWriteScanResults(t *testing.T) {
 			},
 			wantFilename:      "result.spdx",
 			wantContentPrefix: "SPDXVersion: SPDX-2.3",
+		},
+		{
+			desc: "Create CDX",
+			flags: &cli.Flags{
+				Output: []string{"cdx-json=" + filepath.Join(testDirPath, "result.cyclonedx.json")},
+			},
+			wantFilename:      "result.cyclonedx.json",
+			wantContentPrefix: "{\n  \"$schema\": \"http://cyclonedx.org/schema/bom-1.5.schema.json\"",
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/binary/scalibr.go
+++ b/binary/scalibr.go
@@ -34,7 +34,7 @@ func parseFlags() *cli.Flags {
 	root := flag.String("root", "", `The root dir used by detectors and by file walking during extraction (e.g.: "/", "c:\" or ".")`)
 	resultFile := flag.String("result", "", "The path of the output scan result file")
 	var output cli.Array
-	flag.Var(&output, "o", "The path of the scanner outputs in various formats, e.g. -o textproto=result.textproto -o spdx23-json=result.spdx.json")
+	flag.Var(&output, "o", "The path of the scanner outputs in various formats, e.g. -o textproto=result.textproto -o spdx23-json=result.spdx.json -o cdx-json=result.cyclonedx.json")
 	extractorsToRun := flag.String("extractors", "default", "Comma-separated list of extractor plugins to run")
 	detectorsToRun := flag.String("detectors", "default", "Comma-separated list of detectors plugins to run")
 	dirsToSkip := flag.String("skip-dirs", "", "Comma-separated list of file paths to avoid traversing")
@@ -43,6 +43,9 @@ func parseFlags() *cli.Flags {
 	spdxDocumentName := flag.String("spdx-document-name", "", "The 'name' field for the output SPDX document")
 	spdxDocumentNamespace := flag.String("spdx-document-namespace", "", "The 'documentNamespace' field for the output SPDX document")
 	spdxCreators := flag.String("spdx-creators", "", "The 'creators' field for the output SPDX document. Format is --spdx-creators=creatortype1:creator1,creatortype2:creator2")
+	cdxComponentName := flag.String("cdx-component-name", "", "The 'metadata.component.name' field for the output CDX document")
+	cdxComponentVersion := flag.String("cdx-component-version", "", "The 'metadata.component.version' field for the output CDX document")
+	cdxAuthors := flag.String("cdx-authors", "", "The 'authors' field for the output CDX document. Format is --cdx-authors=author1,author2")
 	verbose := flag.Bool("verbose", false, "Enable this to print debug logs")
 	explicitExtractors := flag.Bool("explicit-extractors", false, "If set, the program will exit with an error if not all extractors required by enabled detectors are explicitly enabled.")
 
@@ -62,6 +65,9 @@ func parseFlags() *cli.Flags {
 		SPDXDocumentName:      *spdxDocumentName,
 		SPDXDocumentNamespace: *spdxDocumentNamespace,
 		SPDXCreators:          *spdxCreators,
+		CDXComponentName:      *cdxComponentName,
+		CDXComponentVersion:   *cdxComponentVersion,
+		CDXAuthors:            *cdxAuthors,
 		Verbose:               *verbose,
 		ExplicitExtractors:    *explicitExtractors,
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/google/osv-scalibr
 go 1.22
 
 require (
+	github.com/CycloneDX/cyclonedx-go v0.8.0
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5
 	github.com/containerd/containerd v1.7.18
 	github.com/erikvarga/go-rpmdb v0.0.0-20240208180226-b97e041ef9af

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/CycloneDX/cyclonedx-go v0.8.0 h1:FyWVj6x6hoJrui5uRQdYZcSievw3Z32Z88uYzG/0D6M=
+github.com/CycloneDX/cyclonedx-go v0.8.0/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
 github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5 h1:IEjq88XO4PuBDcvmjQJcQGg+w+UaafSy8G5Kcb5tBhI=
 github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5/go.mod h1:exZ0C/1emQJAw5tHOaUDyY1ycttqBAPcxuzf7QbY6ec=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
SPDX format is already supported, but not CycloneDX: https://cyclonedx.org/ This patch adds the ability to export a JSON or XML cycloneDX BOM.

The SBOM is pretty basic for now (ex.: just the components, not the deps), but enough for doing VM.

Test plan: added unit tests

Manual testing:
```
$ ./scalibr -o cdx-json=/tmp/result.cyclonedx.json --root ~/test
2024/07/09 17:43:27 Scan status: SUCCEEDED
2024/07/09 17:43:27 Found 7513 software inventories, 0 security findings
2024/07/09 17:43:27 Writing scan results to /tmp/result.cyclonedx.json

$ jq -e < /tmp/result.cyclonedx.json >/dev/null
$ echo $?
0
```