### PR TITLE
chore: Add a gitignore and .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.go]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.history/
+.vscode/
+.idea/


### PR DESCRIPTION
Add .gitignore and .editorconfig (mostly copied from osv-scanner) to make it easier to develop with common IDEs.

This also tests the copybara integration from github's side.