### PR TITLE
feat: Add python extractors to list and documentation

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -35,7 +35,7 @@ SCALIBR supports extracting software package information from a variety of OS an
   * Composer (OSV)
 * Python
   * Installed PyPI packages (global and venv)
-  * Lockfiles: requirements.txt, poetry (OSV), Pipfile.lock (OSV)
+  * Lockfiles: requirements.txt, poetry.lock, Pipfile.lock, pdm.lock
 * Ruby
   * Installed Gem packages
   * Lockfiles: Gemfile.lock (OSV)

--- a/extractor/filesystem/language/python/pipfilelock/extractor.go
+++ b/extractor/filesystem/language/python/pipfilelock/extractor.go
@@ -48,7 +48,7 @@ const pipenvEcosystem = "PyPI"
 type Extractor struct{}
 
 // Name of the extractor
-func (e Extractor) Name() string { return "python/pipfilelock" }
+func (e Extractor) Name() string { return "python/Pipfilelock" }
 
 // Version of the extractor
 func (e Extractor) Version() int { return 0 }

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -25,8 +25,8 @@ import (
 	"github.com/google/osv-scanner/pkg/lockfile"
 
 	// SCALIBR internal extractors.
-
 	"github.com/google/osv-scalibr/extractor/filesystem"
+
 	"github.com/google/osv-scalibr/extractor/filesystem/containers/containerd"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packageslockjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gobinary"

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -26,13 +26,16 @@ import (
 
 	// SCALIBR internal extractors.
 
-	"github.com/google/osv-scalibr/extractor/filesystem/containers/containerd"
 	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/containers/containerd"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packageslockjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gobinary"
 	javaarchive "github.com/google/osv-scalibr/extractor/filesystem/language/java/archive"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/packagejson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/packagelockjson"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfilelock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/poetrylock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/wheelegg"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ruby/gemspec"
@@ -49,7 +52,6 @@ import (
 	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/purl"
-
 )
 
 // LINT.IfChange
@@ -61,7 +63,13 @@ var (
 	// Javascript extractors.
 	Javascript []filesystem.Extractor = []filesystem.Extractor{packagejson.New(packagejson.DefaultConfig()), packagelockjson.New(packagelockjson.DefaultConfig())}
 	// Python extractors.
-	Python []filesystem.Extractor = []filesystem.Extractor{wheelegg.New(wheelegg.DefaultConfig()), requirements.New(requirements.DefaultConfig())}
+	Python []filesystem.Extractor = []filesystem.Extractor{
+		wheelegg.New(wheelegg.DefaultConfig()),
+		requirements.New(requirements.DefaultConfig()),
+		pipfilelock.Extractor{},
+		pdmlock.Extractor{},
+		poetrylock.Extractor{},
+	}
 	// Go extractors.
 	Go []filesystem.Extractor = []filesystem.Extractor{gobinary.New(gobinary.DefaultConfig())}
 	// Ruby extractors.
@@ -118,8 +126,6 @@ var (
 		osv.Wrapper{ExtractorName: "javascript/pnpm", ExtractorVersion: 0, PURLType: purl.TypeNPM, Extractor: lockfile.PnpmLockExtractor{}},
 		osv.Wrapper{ExtractorName: "javascript/yarn", ExtractorVersion: 0, PURLType: purl.TypeNPM, Extractor: lockfile.YarnLockExtractor{}},
 		osv.Wrapper{ExtractorName: "php/composer", ExtractorVersion: 0, PURLType: purl.TypeComposer, Extractor: lockfile.ComposerLockExtractor{}},
-		osv.Wrapper{ExtractorName: "python/Pipfile", ExtractorVersion: 0, PURLType: purl.TypePyPi, Extractor: lockfile.PipenvLockExtractor{}},
-		osv.Wrapper{ExtractorName: "python/poetry", ExtractorVersion: 0, PURLType: purl.TypePyPi, Extractor: lockfile.PoetryLockExtractor{}},
 		osv.Wrapper{ExtractorName: "ruby/gemfile", ExtractorVersion: 0, PURLType: purl.TypeGem, Extractor: lockfile.GemfileLockExtractor{}},
 		osv.Wrapper{ExtractorName: "rust/cargo", ExtractorVersion: 0, PURLType: purl.TypeCargo, Extractor: lockfile.CargoLockExtractor{}},
 	}

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -52,17 +52,17 @@ func TestExtractorsFromNames(t *testing.T) {
 		{
 			desc:     "Find all extractors of a type",
 			names:    []string{"python"},
-			wantExts: []string{"python/wheelegg", "python/requirements"},
+			wantExts: []string{"python/pdmlock", "python/Pipfilelock", "python/poetrylock", "python/wheelegg", "python/requirements"},
 		},
 		{
 			desc:     "Case-insensitive",
 			names:    []string{"Python"},
-			wantExts: []string{"python/wheelegg", "python/requirements"},
+			wantExts: []string{"python/pdmlock", "python/Pipfilelock", "python/poetrylock", "python/wheelegg", "python/requirements"},
 		},
 		{
 			desc:     "Remove duplicates",
 			names:    []string{"python", "python"},
-			wantExts: []string{"python/wheelegg", "python/requirements"},
+			wantExts: []string{"python/pdmlock", "python/Pipfilelock", "python/poetrylock", "python/wheelegg", "python/requirements"},
 		},
 		{
 			desc:     "Nonexistent plugin",
@@ -114,8 +114,8 @@ func TestExtractorFromName(t *testing.T) {
 		},
 		{
 			desc:    "Works for upper case names",
-			name:    "python/Pipfile",
-			wantExt: "python/Pipfile",
+			name:    "python/Pipfilelock",
+			wantExt: "python/Pipfilelock",
 		},
 	}
 


### PR DESCRIPTION
Add the newly added python extractors to list.go, and update the documentation accordingly.

This does change the name of python/Pipfile extractor to python/Pipfilelock. This is required as in the future we likely would want to add an actual python/Pipfile extractor.  