### PR TITLE
refactor: Inline the ecosystem consts

### DIFF
--- a/extractor/filesystem/language/golang/gomod/extractor.go
+++ b/extractor/filesystem/language/golang/gomod/extractor.go
@@ -31,8 +31,6 @@ import (
 	"github.com/google/osv-scalibr/purl"
 )
 
-const goEcosystem string = "Go"
-
 // Extractor extracts go packages from a go.mod file,
 // including the stdlib version by using the top level go version
 //
@@ -147,7 +145,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []s
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return goEcosystem, nil
+	return "Go", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/java/gradlelockfile/extractor.go
+++ b/extractor/filesystem/language/java/gradlelockfile/extractor.go
@@ -36,8 +36,6 @@ const (
 	gradleLockFileEmptyPrefix   = "empty="
 )
 
-const mavenEcosystem string = "Maven"
-
 func isGradleLockFileDepLine(line string) bool {
 	ret := strings.HasPrefix(line, gradleLockFileCommentPrefix) ||
 		strings.HasPrefix(line, gradleLockFileEmptyPrefix)
@@ -132,7 +130,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []s
 
 // Ecosystem returns the OSV ecosystem ('Maven') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return mavenEcosystem, nil
+	return "Maven", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/extractor.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/extractor.go
@@ -38,8 +38,6 @@ type gradleVerificationMetadataFile struct {
 	} `xml:"components>component"`
 }
 
-const mavenEcosystem string = "Maven"
-
 // Extractor extracts Maven packages from Gradle verification metadata files.
 type Extractor struct{}
 
@@ -104,7 +102,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
 
 // Ecosystem returns the OSV ecosystem ('Maven') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return mavenEcosystem, nil
+	return "Maven", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/java/pomxml/extractor.go
+++ b/extractor/filesystem/language/java/pomxml/extractor.go
@@ -97,8 +97,6 @@ type mavenLockFile struct {
 	ManagedDependencies []mavenLockDependency `xml:"dependencyManagement>dependencies>dependency"`
 }
 
-const mavenEcosystem string = "Maven"
-
 type mavenLockProperties struct {
 	m map[string]string
 }
@@ -222,7 +220,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []s
 
 // Ecosystem returns the OSV ecosystem ('Maven') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return mavenEcosystem, nil
+	return "Maven", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/javascript/pnpmlock/extractor.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/extractor.go
@@ -79,9 +79,6 @@ func (l *pnpmLockfile) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
-// PnpmEcosystem is the OSV ecpsystem for pnpm-lock.yaml files.
-const PnpmEcosystem = "npm"
-
 var (
 	numberMatcher = regexp.MustCompile(`^\d`)
 	// Looks for the pattern "name@version", where name is allowed to contain zero or more "@"
@@ -274,7 +271,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []s
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return PnpmEcosystem, nil
+	return "npm", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/php/composerlock/extractor.go
+++ b/extractor/filesystem/language/php/composerlock/extractor.go
@@ -42,9 +42,6 @@ type composerLock struct {
 	PackagesDev []composerPackage `json:"packages-dev"`
 }
 
-// ComposerEcosystem is the OSV ecosystem for packages described in composer.lock files.
-const ComposerEcosystem string = "Packagist"
-
 // Extractor extracts composer.lock files.
 type Extractor struct{}
 
@@ -128,7 +125,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return ComposerEcosystem, nil
+	return "Packagist", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/python/pdmlock/extractor.go
+++ b/extractor/filesystem/language/python/pdmlock/extractor.go
@@ -42,8 +42,6 @@ type pdmLockFile struct {
 	Packages []pdmLockPackage `toml:"package"`
 }
 
-const pdmEcosystem = "PyPI"
-
 // Extractor extracts python packages from pdm.lock files.
 type Extractor struct{}
 
@@ -132,7 +130,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []s
 
 // Ecosystem returns the OSV ecosystem ('PyPI') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return pdmEcosystem, nil
+	return "PyPI", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/python/pipfilelock/extractor.go
+++ b/extractor/filesystem/language/python/pipfilelock/extractor.go
@@ -42,8 +42,6 @@ type pipenvLockFile struct {
 	PackagesDev map[string]pipenvPackage `json:"develop"`
 }
 
-const pipenvEcosystem = "PyPI"
-
 // Extractor extracts python packages from Pipfile.lock files.
 type Extractor struct{}
 
@@ -131,7 +129,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []s
 
 // Ecosystem returns the OSV ecosystem ('PyPI') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return pipenvEcosystem, nil
+	return "PyPI", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/python/poetrylock/extractor.go
+++ b/extractor/filesystem/language/python/poetrylock/extractor.go
@@ -47,8 +47,6 @@ type poetryLockFile struct {
 	Packages []poetryLockPackage `toml:"package"`
 }
 
-const poetryEcosystem = "PyPI"
-
 // Extractor extracts python packages from poetry.lock files.
 type Extractor struct{}
 
@@ -114,7 +112,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []s
 
 // Ecosystem returns the OSV ecosystem ('PyPI') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return poetryEcosystem, nil
+	return "PyPI", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/r/renvlock/extractor.go
+++ b/extractor/filesystem/language/r/renvlock/extractor.go
@@ -38,8 +38,6 @@ type renvLockfile struct {
 	Packages map[string]renvPackage `json:"Packages"`
 }
 
-const cranEcosystem string = "CRAN"
-
 // Extractor extracts CRAN packages from renv.lock files.
 type Extractor struct{}
 
@@ -73,7 +71,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 
 	for _, pkg := range parsedLockfile.Packages {
 		// currently we only support CRAN
-		if pkg.Repository != string(cranEcosystem) {
+		if pkg.Repository != "CRAN" {
 			continue
 		}
 
@@ -101,7 +99,7 @@ func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []s
 
 // Ecosystem returns the OSV ecosystem ('CRAN') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) (string, error) {
-	return cranEcosystem, nil
+	return "CRAN", nil
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/rust/cargolock/extractor.go
+++ b/extractor/filesystem/language/rust/cargolock/extractor.go
@@ -39,8 +39,6 @@ type cargoLockFile struct {
 	Packages []cargoLockPackage `toml:"package"`
 }
 
-const cargoEcosystem string = "crates.io"
-
 // Extractor extracts crates.io packages from Cargo.lock files.
 type Extractor struct{}
 
@@ -97,7 +95,7 @@ func (e Extractor) ToCPEs(_ *extractor.Inventory) ([]string, error) { return []s
 
 // Ecosystem returns the OSV ecosystem ('crates.io') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(_ *extractor.Inventory) (string, error) {
-	return cargoEcosystem, nil
+	return "crates.io", nil
 }
 
 var _ filesystem.Extractor = Extractor{}


### PR DESCRIPTION
Inline all the ecosystem strings in the extractors migrated from osv-scanner.