### PR TITLE
Make ToPURL and ToCPEs also error-less

### DIFF
--- a/binary/proto/proto.go
+++ b/binary/proto/proto.go
@@ -210,14 +210,8 @@ func inventoryToProto(i *extractor.Inventory) (*spb.Inventory, error) {
 	if i == nil {
 		return nil, nil
 	}
-	p, err := converter.ToPURL(i)
-	if err != nil {
-		return nil, err
-	}
-	cpes, err := converter.ToCPEs(i)
-	if err != nil {
-		return nil, err
-	}
+	p := converter.ToPURL(i)
+	cpes := converter.ToCPEs(i)
 	inventoryProto := &spb.Inventory{
 		Name:        i.Name,
 		Version:     i.Version,

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -42,12 +42,12 @@ const (
 var spdxIDInvalidCharRe = regexp.MustCompile(`[^a-zA-Z0-9.-]`)
 
 // ToPURL converts a SCALIBR inventory structure into a package URL.
-func ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return i.Extractor.ToPURL(i)
 }
 
 // ToCPEs converts a SCALIBR inventory structure into CPEs, if they're present in the inventory.
-func ToCPEs(i *extractor.Inventory) ([]string, error) {
+func ToCPEs(i *extractor.Inventory) []string {
 	return i.Extractor.ToCPEs(i)
 }
 
@@ -75,11 +75,7 @@ func ToSPDX23(r *scalibr.ScanResult, c SPDXConfig) *v2_3.Document {
 	relationships := make([]*v2_3.Relationship, 0, 2*len(r.Inventories))
 
 	for _, i := range r.Inventories {
-		p, err := ToPURL(i)
-		if err != nil {
-			log.Warnf("ToPURL(%v): %v, skipping", i, err)
-			continue
-		}
+		p := ToPURL(i)
 		if p == nil {
 			log.Warnf("Inventory %v has no PURL, skipping", i)
 			continue
@@ -224,10 +220,10 @@ func ToCDX(r *scalibr.ScanResult, c CDXConfig) *cyclonedx.BOM {
 			Name:    (*i).Name,
 			Version: (*i).Version,
 		}
-		if p, err := ToPURL(i); err == nil && p != nil {
+		if p := ToPURL(i); p != nil {
 			pkg.PackageURL = p.String()
 		}
-		if cpes, err := ToCPEs(i); err == nil && len(cpes) > 0 {
+		if cpes := ToCPEs(i); len(cpes) > 0 {
 			pkg.CPE = cpes[0]
 		}
 		if len((*i).Locations) > 0 {

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -554,7 +554,6 @@ func TestToPURL(t *testing.T) {
 		desc      string
 		inventory *extractor.Inventory
 		want      *purl.PackageURL
-		wantErr   bool
 		onGoos    string
 	}{
 		{
@@ -579,8 +578,8 @@ func TestToPURL(t *testing.T) {
 				Locations: []string{"irrelevant"},
 				Version:   "irrelevant",
 			},
-			wantErr: true,
-			onGoos:  "linux",
+			want:   nil,
+			onGoos: "linux",
 		},
 	}
 
@@ -590,14 +589,7 @@ func TestToPURL(t *testing.T) {
 				t.Skipf("Skipping test on %s", runtime.GOOS)
 			}
 
-			got, err := converter.ToPURL(tc.inventory)
-			if err != nil && !tc.wantErr || err == nil && tc.wantErr {
-				t.Fatalf("converter.ToPURL(%v): %v", tc.inventory, err)
-			}
-
-			if tc.wantErr == true {
-				return
-			}
+			got := converter.ToPURL(tc.inventory)
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("converter.ToPURL(%v) returned unexpected diff (-want +got):\n%s", tc.inventory, diff)
@@ -611,7 +603,6 @@ func TestToCPEs(t *testing.T) {
 		desc      string
 		inventory *extractor.Inventory
 		want      []string
-		wantErr   bool
 	}{
 		{
 			desc: "Valid fileststem extractor",
@@ -628,14 +619,7 @@ func TestToCPEs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := converter.ToCPEs(tc.inventory)
-			if err != nil && !tc.wantErr || err == nil && tc.wantErr {
-				t.Fatalf("converter.ToCPEs(%v): %v", tc.inventory, err)
-			}
-
-			if tc.wantErr == true {
-				return
-			}
+			got := converter.ToCPEs(tc.inventory)
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("converter.ToCPEs(%v) returned unexpected diff (-want +got):\n%s", tc.inventory, diff)

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -571,7 +571,7 @@ func TestToPURL(t *testing.T) {
 			},
 		},
 		{
-			desc: "Windows-only returns error on Linux",
+			desc: "Windows-only returns nil on Linux",
 			inventory: &extractor.Inventory{
 				Name:      "irrelevant",
 				Extractor: dismpatch.Extractor{},

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -24,9 +24,9 @@ import (
 type Extractor interface {
 	plugin.Plugin
 	// ToPURL converts an inventory created by this extractor into a PURL.
-	ToPURL(i *Inventory) (*purl.PackageURL, error)
+	ToPURL(i *Inventory) *purl.PackageURL
 	// ToCPEs converts an inventory created by this extractor into CPEs, if supported.
-	ToCPEs(i *Inventory) ([]string, error)
+	ToCPEs(i *Inventory) []string
 	// Ecosystem returns the Ecosystem of the given inventory created by this extractor.
 	// For software packages this corresponds to an OSV ecosystem value, e.g. PyPI.
 	Ecosystem(i *Inventory) string

--- a/extractor/filesystem/containers/containerd/extractor_dummy.go
+++ b/extractor/filesystem/containers/containerd/extractor_dummy.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"runtime"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/purl"
 )
@@ -68,13 +70,15 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL not implemented.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return nil, fmt.Errorf("not supported")
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	log.Warnf("Trying to use containerd on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // ToCPEs not implemented.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return []string{}, fmt.Errorf("not supported")
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string {
+	log.Warnf("Trying to use containerd on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // Ecosystem not defined.

--- a/extractor/filesystem/containers/containerd/extractor_linux.go
+++ b/extractor/filesystem/containers/containerd/extractor_linux.go
@@ -487,10 +487,10 @@ func runhcsInitPid(scanRoot string, runtimeName string, namespace string, id str
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) { return nil, nil }
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL { return nil }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns no ecosystem since the Inventory is not a software package.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "" }

--- a/extractor/filesystem/language/cpp/conanlock/extractor.go
+++ b/extractor/filesystem/language/cpp/conanlock/extractor.go
@@ -228,16 +228,16 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeConan,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV ecosystem ('ConanCenter') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/dart/pubspec/extractor.go
+++ b/extractor/filesystem/language/dart/pubspec/extractor.go
@@ -114,17 +114,17 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypePub,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return []string{}, nil
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string {
+	return []string{}
 }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.

--- a/extractor/filesystem/language/dotnet/packageslockjson/extractor.go
+++ b/extractor/filesystem/language/dotnet/packageslockjson/extractor.go
@@ -174,16 +174,16 @@ func Parse(r io.Reader) (PackagesLockJSON, error) {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeNuget,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "NuGet" }

--- a/extractor/filesystem/language/dotnet/packageslockjson/extractor_test.go
+++ b/extractor/filesystem/language/dotnet/packageslockjson/extractor_test.go
@@ -251,10 +251,7 @@ func TestToPURL(t *testing.T) {
 		Name:    "Name",
 		Version: "1.2.3",
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/language/erlang/mixlock/extractor.go
+++ b/extractor/filesystem/language/erlang/mixlock/extractor.go
@@ -113,16 +113,16 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeHex,
 		Name:    strings.ToLower(i.Name),
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/golang/gobinary/extractor.go
+++ b/extractor/filesystem/language/golang/gobinary/extractor.go
@@ -207,16 +207,16 @@ func parseDependency(d *debug.Module) (string, string) {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeGolang,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "Go" }

--- a/extractor/filesystem/language/golang/gobinary/extractor_test.go
+++ b/extractor/filesystem/language/golang/gobinary/extractor_test.go
@@ -303,10 +303,7 @@ func TestToPURL(t *testing.T) {
 		Name:    "name",
 		Version: "1.2.3",
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/language/golang/gomod/extractor.go
+++ b/extractor/filesystem/language/golang/gomod/extractor.go
@@ -132,16 +132,16 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeGolang,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/java/archive/extractor.go
+++ b/extractor/filesystem/language/java/archive/extractor.go
@@ -420,18 +420,18 @@ func isManifest(path string) bool {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*Metadata)
 	return &purl.PackageURL{
 		Type:      purl.TypeMaven,
 		Namespace: strings.ToLower(m.GroupID),
 		Name:      strings.ToLower(m.ArtifactID),
 		Version:   i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "Maven" }

--- a/extractor/filesystem/language/java/archive/extractor_test.go
+++ b/extractor/filesystem/language/java/archive/extractor_test.go
@@ -605,10 +605,7 @@ func TestToPURL(t *testing.T) {
 		Namespace: "groupid",
 		Version:   "1.2.3",
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/language/java/gradlelockfile/extractor.go
+++ b/extractor/filesystem/language/java/gradlelockfile/extractor.go
@@ -115,18 +115,18 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*javalockfile.Metadata)
 	return &purl.PackageURL{
 		Type:      purl.TypeMaven,
 		Namespace: strings.ToLower(m.GroupID),
 		Name:      strings.ToLower(m.ArtifactID),
 		Version:   i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV ecosystem ('Maven') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/extractor.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/extractor.go
@@ -85,19 +85,19 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*javalockfile.Metadata)
 	return &purl.PackageURL{
 		Type:      purl.TypeMaven,
 		Namespace: strings.ToLower(m.GroupID),
 		Name:      strings.ToLower(m.ArtifactID),
 		Version:   i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return []string{}, nil
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string {
+	return []string{}
 }
 
 // Ecosystem returns the OSV ecosystem ('Maven') of the software extracted by this extractor.

--- a/extractor/filesystem/language/java/pomxml/extractor.go
+++ b/extractor/filesystem/language/java/pomxml/extractor.go
@@ -205,18 +205,18 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*javalockfile.Metadata)
 	return &purl.PackageURL{
 		Type:      purl.TypeMaven,
 		Namespace: strings.ToLower(m.GroupID),
 		Name:      strings.ToLower(m.ArtifactID),
 		Version:   i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV ecosystem ('Maven') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/javascript/packagejson/extractor.go
+++ b/extractor/filesystem/language/javascript/packagejson/extractor.go
@@ -240,16 +240,16 @@ func removeEmptyPersons(persons []*Person) []*Person {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeNPM,
 		Name:    strings.ToLower(i.Name),
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 // OSV requires the name field to be a npm package. This is a javascript extractor, there is no

--- a/extractor/filesystem/language/javascript/packagejson/extractor_test.go
+++ b/extractor/filesystem/language/javascript/packagejson/extractor_test.go
@@ -394,10 +394,7 @@ func TestToPURL(t *testing.T) {
 		Name:    "name",
 		Version: "1.2.3",
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/language/javascript/packagelockjson/extractor.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/extractor.go
@@ -370,16 +370,16 @@ func (e Extractor) extractPkgLock(_ context.Context, input *filesystem.ScanInput
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeNPM,
 		Name:    strings.ToLower(i.Name),
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(_ *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(_ *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV ecosystem ('npm') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(_ *extractor.Inventory) string { return "npm" }

--- a/extractor/filesystem/language/javascript/packagelockjson/extractor_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/extractor_test.go
@@ -157,10 +157,7 @@ func TestToPURL(t *testing.T) {
 		Name:    "name",
 		Version: "1.2.3",
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/language/javascript/pnpmlock/extractor.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/extractor.go
@@ -259,16 +259,16 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeNPM,
 		Name:    strings.ToLower(i.Name),
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/javascript/yarnlock/extractor.go
+++ b/extractor/filesystem/language/javascript/yarnlock/extractor.go
@@ -222,16 +222,16 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeNPM,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string { return "npm" }

--- a/extractor/filesystem/language/php/composerlock/extractor.go
+++ b/extractor/filesystem/language/php/composerlock/extractor.go
@@ -110,17 +110,17 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeComposer,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return []string{}, nil
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string {
+	return []string{}
 }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.

--- a/extractor/filesystem/language/python/pdmlock/extractor.go
+++ b/extractor/filesystem/language/python/pdmlock/extractor.go
@@ -121,12 +121,12 @@ func parseGroupsToDepGroups(groups []string) []string {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return pypipurl.MakePackageURL(i), nil
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return pypipurl.MakePackageURL(i)
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV ecosystem ('PyPI') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/python/pipfilelock/extractor.go
+++ b/extractor/filesystem/language/python/pipfilelock/extractor.go
@@ -120,12 +120,12 @@ func addPkgDetails(details map[string]*extractor.Inventory, packages map[string]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return pypipurl.MakePackageURL(i), nil
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return pypipurl.MakePackageURL(i)
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV ecosystem ('PyPI') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/python/poetrylock/extractor.go
+++ b/extractor/filesystem/language/python/poetrylock/extractor.go
@@ -103,12 +103,12 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return pypipurl.MakePackageURL(i), nil
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return pypipurl.MakePackageURL(i)
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV ecosystem ('PyPI') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/python/requirements/extractor.go
+++ b/extractor/filesystem/language/python/requirements/extractor.go
@@ -298,12 +298,12 @@ func splitPerRequirementOptions(s string) (string, []string) {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return pypipurl.MakePackageURL(i), nil
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return pypipurl.MakePackageURL(i)
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "PyPI" }

--- a/extractor/filesystem/language/python/requirements/extractor_test.go
+++ b/extractor/filesystem/language/python/requirements/extractor_test.go
@@ -411,10 +411,7 @@ func TestToPURL(t *testing.T) {
 		Name:    "name",
 		Version: "1.2.3",
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/language/python/wheelegg/extractor.go
+++ b/extractor/filesystem/language/python/wheelegg/extractor.go
@@ -265,12 +265,12 @@ func parse(r io.Reader) (*extractor.Inventory, error) {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return pypipurl.MakePackageURL(i), nil
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return pypipurl.MakePackageURL(i)
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "PyPI" }

--- a/extractor/filesystem/language/python/wheelegg/extractor_test.go
+++ b/extractor/filesystem/language/python/wheelegg/extractor_test.go
@@ -468,10 +468,7 @@ func TestToPURL(t *testing.T) {
 		Name:    "name",
 		Version: "1.2.3",
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/language/r/renvlock/extractor.go
+++ b/extractor/filesystem/language/r/renvlock/extractor.go
@@ -86,16 +86,16 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeCran,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV ecosystem ('CRAN') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/language/ruby/gemfilelock/extractor.go
+++ b/extractor/filesystem/language/ruby/gemfilelock/extractor.go
@@ -138,17 +138,17 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeGem,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return []string{}, nil
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string {
+	return []string{}
 }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.

--- a/extractor/filesystem/language/ruby/gemspec/extractor.go
+++ b/extractor/filesystem/language/ruby/gemspec/extractor.go
@@ -199,16 +199,16 @@ func extract(path string, r io.Reader) (*extractor.Inventory, error) {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeGem,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "RubyGems" }

--- a/extractor/filesystem/language/ruby/gemspec/extractor_test.go
+++ b/extractor/filesystem/language/ruby/gemspec/extractor_test.go
@@ -233,10 +233,7 @@ func TestToPURL(t *testing.T) {
 		Name:    "name",
 		Version: "1.2.3",
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/language/rust/cargolock/extractor.go
+++ b/extractor/filesystem/language/rust/cargolock/extractor.go
@@ -82,16 +82,16 @@ func (e Extractor) Extract(_ context.Context, input *filesystem.ScanInput) ([]*e
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeCargo,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(_ *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(_ *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV ecosystem ('crates.io') of the software extracted by this extractor.
 func (e Extractor) Ecosystem(_ *extractor.Inventory) string {

--- a/extractor/filesystem/os/apk/extractor.go
+++ b/extractor/filesystem/os/apk/extractor.go
@@ -210,7 +210,7 @@ func toDistro(m *Metadata) string {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*Metadata)
 	q := map[string]string{}
 	distro := toDistro(m)
@@ -229,11 +229,11 @@ func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		Namespace:  toNamespace(m),
 		Version:    i.Version,
 		Qualifiers: purl.QualifiersFromMap(q),
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/os/apk/extractor_test.go
+++ b/extractor/filesystem/os/apk/extractor_test.go
@@ -335,10 +335,7 @@ func TestToPURL(t *testing.T) {
 				Metadata:  tt.metadata,
 				Locations: []string{"location"},
 			}
-			got, err := e.ToPURL(i)
-			if err != nil {
-				t.Fatalf("ToPURL(%v): %v", i, err)
-			}
+			got := e.ToPURL(i)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 			}

--- a/extractor/filesystem/os/cos/extractor.go
+++ b/extractor/filesystem/os/cos/extractor.go
@@ -189,7 +189,7 @@ func toDistro(m *Metadata) string {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*Metadata)
 	q := map[string]string{}
 	distro := toDistro(m)
@@ -201,11 +201,11 @@ func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		Name:       i.Name,
 		Version:    i.Version,
 		Qualifiers: purl.QualifiersFromMap(q),
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns no Ecosystem since the ecosystem is not known by OSV yet.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string { return "" }

--- a/extractor/filesystem/os/cos/extractor_test.go
+++ b/extractor/filesystem/os/cos/extractor_test.go
@@ -385,10 +385,7 @@ func TestToPURL(t *testing.T) {
 				Metadata:  tt.metadata,
 				Locations: []string{"location"},
 			}
-			got, err := e.ToPURL(i)
-			if err != nil {
-				t.Fatalf("ToPURL(%v): %v", i, err)
-			}
+			got := e.ToPURL(i)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 			}

--- a/extractor/filesystem/os/dpkg/extractor.go
+++ b/extractor/filesystem/os/dpkg/extractor.go
@@ -309,7 +309,7 @@ func toDistro(m *Metadata) string {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*Metadata)
 	q := map[string]string{}
 	distro := toDistro(m)
@@ -331,11 +331,11 @@ func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		Namespace:  toNamespace(m),
 		Version:    i.Version,
 		Qualifiers: purl.QualifiersFromMap(q),
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/os/dpkg/extractor_test.go
+++ b/extractor/filesystem/os/dpkg/extractor_test.go
@@ -970,10 +970,7 @@ func TestToPURL(t *testing.T) {
 				Metadata:  tt.metadata,
 				Locations: []string{"location"},
 			}
-			got, err := e.ToPURL(i)
-			if err != nil {
-				t.Fatalf("ToPURL(%v): %v", i, err)
-			}
+			got := e.ToPURL(i)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 			}

--- a/extractor/filesystem/os/flatpak/extractor.go
+++ b/extractor/filesystem/os/flatpak/extractor.go
@@ -230,7 +230,7 @@ func toDistro(m *Metadata) string {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*Metadata)
 	q := map[string]string{}
 	distro := toDistro(m)
@@ -243,11 +243,11 @@ func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		Name:       i.Name,
 		Version:    i.Version,
 		Qualifiers: purl.QualifiersFromMap(q),
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns no Ecosystem since the ecosystem is not known by OSV yet.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string { return "" }

--- a/extractor/filesystem/os/flatpak/extractor_test.go
+++ b/extractor/filesystem/os/flatpak/extractor_test.go
@@ -355,10 +355,7 @@ func TestToPURL(t *testing.T) {
 				Metadata:  tt.metadata,
 				Locations: []string{"location"},
 			}
-			got, err := e.ToPURL(i)
-			if err != nil {
-				t.Fatalf("ToPURL(%v): %v", i, err)
-			}
+			got := e.ToPURL(i)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 			}

--- a/extractor/filesystem/os/homebrew/extractor.go
+++ b/extractor/filesystem/os/homebrew/extractor.go
@@ -116,16 +116,16 @@ func SplitPath(path string) *BrewPath {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypeBrew,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns no Ecosystem since the ecosystem is not known by OSV yet.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "" }

--- a/extractor/filesystem/os/homebrew/extractor_test.go
+++ b/extractor/filesystem/os/homebrew/extractor_test.go
@@ -185,10 +185,7 @@ func TestToPURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var e filesystem.Extractor = homebrew.Extractor{}
 			for _, i := range tt.inventory {
-				got, err := e.ToPURL(i)
-				if err != nil {
-					t.Fatalf("ToPURL(%v): %v", i, err)
-				}
+				got := e.ToPURL(i)
 				if diff := cmp.Diff(tt.want, got); diff != "" {
 					t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 				}

--- a/extractor/filesystem/os/rpm/extractor_dummy.go
+++ b/extractor/filesystem/os/rpm/extractor_dummy.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"runtime"
 	"time"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/purl"
 	"github.com/google/osv-scalibr/stats"
@@ -75,13 +77,15 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return nil, fmt.Errorf("not supported")
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	log.Warnf("Trying to use rpm on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return []string{}, fmt.Errorf("not supported")
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string {
+	log.Warnf("Trying to use rpm on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // Ecosystem is not defined.

--- a/extractor/filesystem/os/rpm/extractor_linux.go
+++ b/extractor/filesystem/os/rpm/extractor_linux.go
@@ -279,7 +279,7 @@ func toDistro(m *Metadata) string {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*Metadata)
 	q := map[string]string{}
 	if m.Epoch > 0 {
@@ -301,11 +301,11 @@ func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		Name:       i.Name,
 		Version:    i.Version,
 		Qualifiers: purl.QualifiersFromMap(q),
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/os/rpm/extractor_test.go
+++ b/extractor/filesystem/os/rpm/extractor_test.go
@@ -638,10 +638,7 @@ func TestToPURL(t *testing.T) {
 				Metadata:  tt.metadata,
 				Locations: []string{"location"},
 			}
-			got, err := e.ToPURL(i)
-			if err != nil {
-				t.Fatalf("ToPURL(%v): %v", i, err)
-			}
+			got := e.ToPURL(i)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 			}

--- a/extractor/filesystem/os/snap/extractor.go
+++ b/extractor/filesystem/os/snap/extractor.go
@@ -203,7 +203,7 @@ func toDistro(m *Metadata) string {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*Metadata)
 	q := map[string]string{}
 	distro := toDistro(m)
@@ -217,11 +217,11 @@ func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		Name:       m.Name,
 		Version:    m.Version,
 		Qualifiers: purl.QualifiersFromMap(q),
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (Extractor) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/os/snap/extractor_test.go
+++ b/extractor/filesystem/os/snap/extractor_test.go
@@ -367,10 +367,7 @@ func TestToPURL(t *testing.T) {
 				Metadata:  tt.metadata,
 				Locations: []string{"location"},
 			}
-			got, err := e.ToPURL(i)
-			if err != nil {
-				t.Fatalf("ToPURL(%v): %v", i, err)
-			}
+			got := e.ToPURL(i)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 			}

--- a/extractor/filesystem/osv/osv.go
+++ b/extractor/filesystem/osv/osv.go
@@ -149,7 +149,7 @@ func (fw fileWrapper) Path() string {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Wrapper) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Wrapper) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*Metadata)
 	name := i.Name
 	namespace := ""
@@ -163,11 +163,11 @@ func (e Wrapper) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		Namespace: namespace,
 		Name:      name,
 		Version:   i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Wrapper) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Wrapper) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.
 func (e Wrapper) Ecosystem(i *extractor.Inventory) string {

--- a/extractor/filesystem/osv/osv_test.go
+++ b/extractor/filesystem/osv/osv_test.go
@@ -279,10 +279,7 @@ func TestToPURL(t *testing.T) {
 		Namespace: "namespace",
 		Version:   "1.2.3",
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/sbom/cdx/extractor.go
+++ b/extractor/filesystem/sbom/cdx/extractor.go
@@ -138,13 +138,13 @@ func hasFileExtension(path string, extension string) bool {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return i.Metadata.(*Metadata).PURL, nil
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return i.Metadata.(*Metadata).PURL
 }
 
 // ToCPEs converts an inventory created by this extractor into a list of CPEs.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return i.Metadata.(*Metadata).CPEs, nil
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string {
+	return i.Metadata.(*Metadata).CPEs
 }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.

--- a/extractor/filesystem/sbom/cdx/extractor_test.go
+++ b/extractor/filesystem/sbom/cdx/extractor_test.go
@@ -195,10 +195,7 @@ func TestToPURL(t *testing.T) {
 		},
 		Locations: []string{"location"},
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}
@@ -214,10 +211,7 @@ func TestToCPEs(t *testing.T) {
 		},
 		Locations: []string{"location"},
 	}
-	got, err := e.ToCPEs(i)
-	if err != nil {
-		t.Fatalf("ToCPEs(%v): %v", i, err)
-	}
+	got := e.ToCPEs(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToCPEs(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/filesystem/sbom/spdx/extractor.go
+++ b/extractor/filesystem/sbom/spdx/extractor.go
@@ -139,13 +139,13 @@ func hasFileExtension(path string, extension string) bool {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return i.Metadata.(*Metadata).PURL, nil
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return i.Metadata.(*Metadata).PURL
 }
 
 // ToCPEs converts an inventory created by this extractor into a list of CPEs.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return i.Metadata.(*Metadata).CPEs, nil
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string {
+	return i.Metadata.(*Metadata).CPEs
 }
 
 // Ecosystem returns the OSV Ecosystem of the software extracted by this extractor.

--- a/extractor/filesystem/sbom/spdx/extractor_test.go
+++ b/extractor/filesystem/sbom/spdx/extractor_test.go
@@ -253,10 +253,7 @@ func TestToPURL(t *testing.T) {
 		},
 		Locations: []string{"location"},
 	}
-	got, err := e.ToPURL(i)
-	if err != nil {
-		t.Fatalf("ToPURL(%v): %v", i, err)
-	}
+	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}
@@ -272,10 +269,7 @@ func TestToCPEs(t *testing.T) {
 		},
 		Locations: []string{"location"},
 	}
-	got, err := e.ToCPEs(i)
-	if err != nil {
-		t.Fatalf("ToCPEs(%v): %v", i, err)
-	}
+	got := e.ToCPEs(i)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("ToCPEs(%v) (-want +got):\n%s", i, diff)
 	}

--- a/extractor/standalone/containers/containerd/extractor_dummy.go
+++ b/extractor/standalone/containers/containerd/extractor_dummy.go
@@ -19,9 +19,11 @@ package containerd
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/standalone"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/purl"
 )
@@ -66,13 +68,15 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e *Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return nil, fmt.Errorf("only supported on Linux")
+func (e *Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	log.Warnf("Trying to use containerd on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // ToCPEs converts an inventory created by this extractor into CPEs, if supported.
-func (e *Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return nil, fmt.Errorf("only supported on Linux")
+func (e *Extractor) ToCPEs(i *extractor.Inventory) []string {
+	log.Warnf("Trying to use containerd on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // Ecosystem returns no ecosystem since the Inventory is not a software package.

--- a/extractor/standalone/containers/containerd/extractor_linux.go
+++ b/extractor/standalone/containers/containerd/extractor_linux.go
@@ -292,12 +292,12 @@ func taskMetadata(ctx context.Context, client CtrdClient, task *task.Process, na
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return nil, nil
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return nil
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns no ecosystem since the Inventory is not a software package.
 func (e Extractor) Ecosystem(i *extractor.Inventory) string { return "" }

--- a/extractor/standalone/windows/dismpatch/extractor_dummy.go
+++ b/extractor/standalone/windows/dismpatch/extractor_dummy.go
@@ -19,9 +19,11 @@ package dismpatch
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/standalone"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/purl"
 )
@@ -47,11 +49,13 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	log.Warnf("Trying to use dismpatch on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // ToCPEs converts an inventory created by this extractor into CPEs, if supported.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string {
+	log.Warnf("Trying to use dismpatch on %s, which is not supported", runtime.GOOS)
+	return nil
 }

--- a/extractor/standalone/windows/dismpatch/extractor_windows.go
+++ b/extractor/standalone/windows/dismpatch/extractor_windows.go
@@ -60,7 +60,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	p := &purl.PackageURL{
 		Type:      purl.TypeGeneric,
 		Namespace: "microsoft",
@@ -75,11 +75,11 @@ func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		p.Version = i.Version
 	}
 
-	return p, nil
+	return p
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // runDISM executes the dism command line tool.
 func runDISM(ctx context.Context) (string, error) {

--- a/extractor/standalone/windows/ospackages/extractor_dummy.go
+++ b/extractor/standalone/windows/ospackages/extractor_dummy.go
@@ -19,9 +19,11 @@ package ospackages
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/standalone"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/purl"
 )
@@ -47,13 +49,15 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e *Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+func (e *Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	log.Warnf("Trying to use ospackages on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // ToCPEs converts an inventory created by this extractor into CPEs, if supported.
-func (e *Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+func (e *Extractor) ToCPEs(i *extractor.Inventory) []string {
+	log.Warnf("Trying to use ospackages on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // Ecosystem returns no ecosystem since OSV does not support windows ospackages yet.

--- a/extractor/standalone/windows/ospackages/extractor_windows.go
+++ b/extractor/standalone/windows/ospackages/extractor_windows.go
@@ -172,13 +172,13 @@ func (e *Extractor) enumerateSubkeys(key registry.Key, path string) ([]string, e
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	if strings.HasPrefix(i.Name, googetPrefix) {
 		return &purl.PackageURL{
 			Type:    purl.TypeGooget,
 			Name:    i.Name,
 			Version: i.Version,
-		}, nil
+		}
 	}
 
 	return &purl.PackageURL{
@@ -186,11 +186,11 @@ func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		Namespace: "microsoft",
 		Name:      i.Name,
 		Version:   i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns no ecosystem since OSV does not support windows ospackages yet.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "" }

--- a/extractor/standalone/windows/regosversion/extractor_dummy.go
+++ b/extractor/standalone/windows/regosversion/extractor_dummy.go
@@ -19,9 +19,11 @@ package regosversion
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/standalone"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/purl"
 )
@@ -47,13 +49,15 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e *Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+func (e *Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	log.Warnf("Trying to use regosversion on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // ToCPEs converts an inventory created by this extractor into CPEs, if supported.
-func (e *Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+func (e *Extractor) ToCPEs(i *extractor.Inventory) []string {
+	log.Warnf("Trying to use regosversion on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // Ecosystem returns no ecosystem since OSV does not support windows regosversion yet.

--- a/extractor/standalone/windows/regosversion/extractor_windows.go
+++ b/extractor/standalone/windows/regosversion/extractor_windows.go
@@ -124,7 +124,7 @@ func (e Extractor) windowsRevision(key registry.Key) (uint64, error) {
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL) {
 	return &purl.PackageURL{
 		Type:      purl.TypeGeneric,
 		Namespace: "microsoft",
@@ -132,11 +132,11 @@ func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
 		Qualifiers: purl.QualifiersFromMap(map[string]string{
 			purl.BuildNumber: i.Version,
 		}),
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string) { return []string{} }
 
 // Ecosystem returns no ecosystem since OSV does not support windows regosversion yet.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "" }

--- a/extractor/standalone/windows/regpatchlevel/extractor_dummy.go
+++ b/extractor/standalone/windows/regpatchlevel/extractor_dummy.go
@@ -19,9 +19,11 @@ package regpatchlevel
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/standalone"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/purl"
 )
@@ -47,13 +49,15 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e *Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+func (e *Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	log.Warnf("Trying to use regpatchlevel on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // ToCPEs converts an inventory created by this extractor into CPEs, if supported.
-func (e *Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+func (e *Extractor) ToCPEs(i *extractor.Inventory) []string {
+	log.Warnf("Trying to use regpatchlevel on %s, which is not supported", runtime.GOOS)
+	return nil
 }
 
 // Ecosystem returns no ecosystem since OSV does not support windows regpatchlevel yet.

--- a/extractor/standalone/windows/regpatchlevel/extractor_windows.go
+++ b/extractor/standalone/windows/regpatchlevel/extractor_windows.go
@@ -124,17 +124,17 @@ func (e *Extractor) handleKey(registryPath, keyName string) (*extractor.Inventor
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL) {
 	return &purl.PackageURL{
 		Type:      purl.TypeGeneric,
 		Namespace: "microsoft",
 		Name:      i.Name,
 		Version:   i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
-func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string) { return []string{} }
 
 // Ecosystem returns no ecosystem since OSV does not support windows regpatchlevel yet.
 func (Extractor) Ecosystem(i *extractor.Inventory) string { return "" }

--- a/inventoryindex/inventory_index.go
+++ b/inventoryindex/inventory_index.go
@@ -31,10 +31,7 @@ type InventoryIndex struct {
 func New(inv []*extractor.Inventory) (*InventoryIndex, error) {
 	invMap := make(map[string]map[string][]*extractor.Inventory)
 	for _, i := range inv {
-		p, err := toPURL(i)
-		if err != nil {
-			return nil, err
-		}
+		p := toPURL(i)
 		if p == nil {
 			continue
 		}
@@ -85,6 +82,6 @@ func (ix *InventoryIndex) GetSpecific(name string, packageType string) []*extrac
 	return i
 }
 
-func toPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func toPURL(i *extractor.Inventory) *purl.PackageURL {
 	return i.Extractor.ToPURL(i)
 }

--- a/scalibr_test.go
+++ b/scalibr_test.go
@@ -276,9 +276,9 @@ func (fakeExNeedsNetwork) FileRequired(path string, fileinfo fs.FileInfo) bool {
 func (fakeExNeedsNetwork) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory []*extractor.Inventory, err error) {
 	return nil, nil
 }
-func (e fakeExNeedsNetwork) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) { return nil, nil }
-func (e fakeExNeedsNetwork) ToCPEs(i *extractor.Inventory) ([]string, error)         { return nil, nil }
-func (e fakeExNeedsNetwork) Ecosystem(i *extractor.Inventory) string                 { return "" }
+func (e fakeExNeedsNetwork) ToPURL(i *extractor.Inventory) *purl.PackageURL { return nil }
+func (e fakeExNeedsNetwork) ToCPEs(i *extractor.Inventory) []string         { return nil }
+func (e fakeExNeedsNetwork) Ecosystem(i *extractor.Inventory) string        { return "" }
 
 func (fakeExNeedsNetwork) Requirements() *plugin.Capabilities {
 	return &plugin.Capabilities{Network: true}

--- a/testing/fakeextractor/fake_extractor.go
+++ b/testing/fakeextractor/fake_extractor.go
@@ -114,16 +114,16 @@ func (e *fakeExtractor) Extract(ctx context.Context, input *filesystem.ScanInput
 }
 
 // ToPURL returns a fake PURL based on the inventory name+version.
-func (e *fakeExtractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+func (e *fakeExtractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	return &purl.PackageURL{
 		Type:    purl.TypePyPi,
 		Name:    i.Name,
 		Version: i.Version,
-	}, nil
+	}
 }
 
 // ToCPEs always returns an empty array.
-func (e *fakeExtractor) ToCPEs(i *extractor.Inventory) ([]string, error) { return []string{}, nil }
+func (e *fakeExtractor) ToCPEs(i *extractor.Inventory) []string { return []string{} }
 
 // Ecosystem returns a fake ecosystem.
 func (e *fakeExtractor) Ecosystem(i *extractor.Inventory) string {


### PR DESCRIPTION
Much like https://github.com/google/osv-scalibr/commit/9f86538b542446508e8fab14eff6eaab11c6e913, this removes error values from a couple of other accessors that never return errors except in wrong-OS situations, where there should already be an earlier error (or a panic on unchecked type-cast).
