### PR TITLE
feat: Add --image-platform flag

### DIFF
--- a/artifact/image/image.go
+++ b/artifact/image/image.go
@@ -73,7 +73,7 @@ type Image interface {
 
 // NewFromRemoteName pulls a remote container and creates a
 // SCALIBR filesystem for scanning it.
-func NewFromRemoteName(imageName string, auth remote.Option) (scalibrfs.FS, error) {
+func NewFromRemoteName(imageName string, imageOptions... remote.Option) (scalibrfs.FS, error) {
 	imageName = strings.TrimPrefix(imageName, "https://")
 	var image v1.Image
 	if strings.Contains(imageName, "@") {
@@ -82,7 +82,7 @@ func NewFromRemoteName(imageName string, auth remote.Option) (scalibrfs.FS, erro
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse digest: %w", err)
 		}
-		descriptor, err := remote.Get(ref, auth)
+		descriptor, err := remote.Get(ref, imageOptions...)
 		if err != nil {
 			return nil, fmt.Errorf("couldn’t pull remote image %s: %v", ref, err)
 		}
@@ -96,7 +96,7 @@ func NewFromRemoteName(imageName string, auth remote.Option) (scalibrfs.FS, erro
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse image reference: %w", err)
 		}
-		image, err = remote.Image(tag, auth)
+		image, err = remote.Image(tag, imageOptions...)
 		if err != nil {
 			return nil, fmt.Errorf("couldn’t pull remote image %s: %v", tag, err)
 		}

--- a/binary/cli/cli_test.go
+++ b/binary/cli/cli_test.go
@@ -175,6 +175,15 @@ func TestValidateFlags(t *testing.T) {
 			},
 			wantErr: cmpopts.AnyError,
 		},
+		{
+			desc: "Image Platform with Remote Image",
+			flags: &cli.Flags{
+				RemoteImage: "docker",
+				ImagePlatform: "linux/amd64",
+				ResultFile: "result.textproto",
+			},
+			wantErr: nil,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := cli.ValidateFlags(tc.flags)

--- a/binary/cli/cli_test.go
+++ b/binary/cli/cli_test.go
@@ -168,6 +168,13 @@ func TestValidateFlags(t *testing.T) {
 			},
 			wantErr: cmpopts.AnyError,
 		},
+		{
+			desc: "Image Platform without Remote Image",
+			flags: &cli.Flags{
+				ImagePlatform: "linux/amd64",
+			},
+			wantErr: cmpopts.AnyError,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := cli.ValidateFlags(tc.flags)

--- a/binary/scalibr/scalibr.go
+++ b/binary/scalibr/scalibr.go
@@ -43,6 +43,7 @@ func parseFlags() *cli.Flags {
 	flag.Var(&dirsToSkip, "skip-dirs", "Comma-separated list of file paths to avoid traversing")
 	skipDirRegex := flag.String("skip-dir-regex", "", "If the regex matches a directory, it will be skipped. The regex is matched against the absolute file path.")
 	remoteImage := flag.String("remote-image", "", "The remote image to scan. If specified, SCALIBR pulls and scans this image instead of the local filesystem.")
+	imagePlatform := flag.String("image-platform", "", "The platform of the remote image to scan. If not specified, the platform of the client is used. Format is os/arch (e.g. linux/arm64)")
 	govulncheckDBPath := flag.String("govulncheck-db", "", "Path to the offline DB for the govulncheck detectors to use. Leave empty to run the detectors in online mode.")
 	spdxDocumentName := flag.String("spdx-document-name", "", "The 'name' field for the output SPDX document")
 	spdxDocumentNamespace := flag.String("spdx-document-namespace", "", "The 'documentNamespace' field for the output SPDX document")
@@ -68,6 +69,7 @@ func parseFlags() *cli.Flags {
 		DirsToSkip:            dirsToSkip.GetSlice(),
 		SkipDirRegex:          *skipDirRegex,
 		RemoteImage:           *remoteImage,
+		ImagePlatform:         *imagePlatform,
 		GovulncheckDBPath:     *govulncheckDBPath,
 		SPDXDocumentName:      *spdxDocumentName,
 		SPDXDocumentNamespace: *spdxDocumentNamespace,


### PR DESCRIPTION
When using `--remote-image`, `--image-platform` flag allows SCALIBR to pull images from platforms other than the host's

Currently on a Linux machine:

```
> scalibr -o spdx23-json=result.spdx.json --remote-image  mcr.microsoft.com/windows/nanoserver:ltsc2022 --image-platform windows/amd64
2024/10/31 14:51:24 &{  [spdx23-json=result.spdx.json] default default []   mcr.microsoft.com/windows:ltsc2019        false false true false false}.GetScanConfig(): couldn’t pull remote image mcr.microsoft.com/windows:ltsc2019: no child with platform linux/amd64 in index mcr.microsoft.com/windows:ltsc2019
```

Using `--image-platform`
```
> scalibr -o spdx23-json=result.spdx.json --remote-image  mcr.microsoft.com/windows/nanoserver:ltsc2022 --image-platform windows/amd64
...
(generates a SBOM)
```

