### PR TITLE
refactor: run `gofmt` across all files

### DIFF
--- a/artifact/image/symlink/symlink_test.go
+++ b/artifact/image/symlink/symlink_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/google/osv-scalibr/artifact/image/symlink"
 )
 
-var ()
-
 func TestTargetOutsideRoot(t *testing.T) {
 
 	tests := []struct {

--- a/artifact/image/unpack/unpack_test.go
+++ b/artifact/image/unpack/unpack_test.go
@@ -171,8 +171,8 @@ func TestUnpackSquashed(t *testing.T) {
 		dir:   mustMkdirTemp(t),
 		image: mustImageFromPath(t, filepath.Join("testdata", "basic.tar")),
 		want: map[string]contentAndMode{
-			"sample.txt":        contentAndMode{content: "sample text file\n", mode: fs.FileMode(0644)},
-			"larger-sample.txt": contentAndMode{content: strings.Repeat("sample text file\n", 400), mode: fs.FileMode(0644)},
+			"sample.txt":        {content: "sample text file\n", mode: fs.FileMode(0644)},
+			"larger-sample.txt": {content: strings.Repeat("sample text file\n", 400), mode: fs.FileMode(0644)},
 		},
 	}, {
 		name:  "large files are skipped",
@@ -180,7 +180,7 @@ func TestUnpackSquashed(t *testing.T) {
 		dir:   mustMkdirTemp(t),
 		image: mustImageFromPath(t, filepath.Join("testdata", "basic.tar")),
 		want: map[string]contentAndMode{
-			"sample.txt": contentAndMode{content: "sample text file\n", mode: fs.FileMode(0644)},
+			"sample.txt": {content: "sample text file\n", mode: fs.FileMode(0644)},
 		},
 	}, {
 		name:  "image with restricted file permissions",
@@ -188,7 +188,7 @@ func TestUnpackSquashed(t *testing.T) {
 		dir:   mustMkdirTemp(t),
 		image: mustImageFromPath(t, filepath.Join("testdata", "permissions.tar")),
 		want: map[string]contentAndMode{
-			"sample.txt": contentAndMode{content: "sample text file\n", mode: fs.FileMode(0600)},
+			"sample.txt": {content: "sample text file\n", mode: fs.FileMode(0600)},
 		},
 	}, {
 		name: "image with symlinks",
@@ -352,12 +352,12 @@ func TestUnpackLayers(t *testing.T) {
 		want: []digestAndContent{{
 			digest: "SQUASHED",
 			content: map[string]contentAndMode{
-				"sample.txt": contentAndMode{content: "sample text file\n", mode: fs.FileMode(0600)},
+				"sample.txt": {content: "sample text file\n", mode: fs.FileMode(0600)},
 			},
 		}, {
 			digest: "sha256:854d994f7942ac6711ff410417b58270562d322a251be74df7829c15ec31e369",
 			content: map[string]contentAndMode{
-				"sample.txt": contentAndMode{content: "sample text file\n", mode: fs.FileMode(0600)},
+				"sample.txt": {content: "sample text file\n", mode: fs.FileMode(0600)},
 			},
 		}},
 	}, {
@@ -368,18 +368,18 @@ func TestUnpackLayers(t *testing.T) {
 		want: []digestAndContent{{
 			digest: "SQUASHED",
 			content: map[string]contentAndMode{
-				"sample.txt":        contentAndMode{content: "sample text file\n", mode: fs.FileMode(0644)},
-				"larger-sample.txt": contentAndMode{content: strings.Repeat("sample text file\n", 400), mode: fs.FileMode(0644)},
+				"sample.txt":        {content: "sample text file\n", mode: fs.FileMode(0644)},
+				"larger-sample.txt": {content: strings.Repeat("sample text file\n", 400), mode: fs.FileMode(0644)},
 			},
 		}, {
 			digest: "sha256:abfb541589db284238458b23f1607a184905159aa161c7325b725b4e2eaa1c2c",
 			content: map[string]contentAndMode{
-				"sample.txt": contentAndMode{content: "sample text file\n", mode: fs.FileMode(0644)},
+				"sample.txt": {content: "sample text file\n", mode: fs.FileMode(0644)},
 			},
 		}, {
 			digest: "sha256:c2df653a81c5c96005972035fa076987c9e450e54a03de57aabdadc00e4939c4",
 			content: map[string]contentAndMode{
-				"larger-sample.txt": contentAndMode{content: strings.Repeat("sample text file\n", 400), mode: fs.FileMode(0644)},
+				"larger-sample.txt": {content: strings.Repeat("sample text file\n", 400), mode: fs.FileMode(0644)},
 			},
 		}},
 	}, {

--- a/artifact/image/whiteout/whiteout_test.go
+++ b/artifact/image/whiteout/whiteout_test.go
@@ -52,7 +52,7 @@ func TestWhiteout(t *testing.T) {
 			},
 			dirs: []string{},
 			want: map[string]struct{}{
-				".wh.hello_world.txt": struct{}{},
+				".wh.hello_world.txt": {},
 			},
 		},
 		{
@@ -64,8 +64,8 @@ func TestWhiteout(t *testing.T) {
 			},
 			dirs: []string{},
 			want: map[string]struct{}{
-				".wh.foo.txt": struct{}{},
-				".wh.bar.txt": struct{}{},
+				".wh.foo.txt": {},
+				".wh.bar.txt": {},
 			},
 		},
 		{
@@ -80,8 +80,8 @@ func TestWhiteout(t *testing.T) {
 				"dir2",
 			},
 			want: map[string]struct{}{
-				"dir1/.wh.foo.txt": struct{}{},
-				"dir2/.wh.bar.txt": struct{}{},
+				"dir1/.wh.foo.txt": {},
+				"dir2/.wh.bar.txt": {},
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func TestWhiteout(t *testing.T) {
 				"dir1",
 			},
 			want: map[string]struct{}{
-				".wh..wh..opa.dir1": struct{}{},
+				".wh..wh..opa.dir1": {},
 			},
 		},
 		{
@@ -110,9 +110,9 @@ func TestWhiteout(t *testing.T) {
 				"dir3/dir4",
 			},
 			want: map[string]struct{}{
-				".wh..wh..opa.dir1":     struct{}{},
-				".wh..wh..opa.dir2":     struct{}{},
-				"dir3/dir4/.wh.bar.txt": struct{}{},
+				".wh..wh..opa.dir1":     {},
+				".wh..wh..opa.dir2":     {},
+				"dir3/dir4/.wh.bar.txt": {},
 			},
 		},
 	}

--- a/binary/cli/cli_test.go
+++ b/binary/cli/cli_test.go
@@ -187,27 +187,27 @@ func TestGetScanConfig_ScanRoots(t *testing.T) {
 		{
 			desc: "Default scan roots",
 			flags: map[string]*cli.Flags{
-				"darwin":  &cli.Flags{},
-				"linux":   &cli.Flags{},
-				"windows": &cli.Flags{},
+				"darwin":  {},
+				"linux":   {},
+				"windows": {},
 			},
 			wantScanRoots: map[string][]string{
-				"darwin":  []string{"/"},
-				"linux":   []string{"/"},
-				"windows": []string{"C:\\"},
+				"darwin":  {"/"},
+				"linux":   {"/"},
+				"windows": {"C:\\"},
 			},
 		},
 		{
 			desc: "Scan root are provided and used",
 			flags: map[string]*cli.Flags{
-				"darwin":  &cli.Flags{Root: "/root"},
-				"linux":   &cli.Flags{Root: "/root"},
-				"windows": &cli.Flags{Root: "C:\\myroot"},
+				"darwin":  {Root: "/root"},
+				"linux":   {Root: "/root"},
+				"windows": {Root: "C:\\myroot"},
 			},
 			wantScanRoots: map[string][]string{
-				"darwin":  []string{"/root"},
-				"linux":   []string{"/root"},
-				"windows": []string{"C:\\myroot"},
+				"darwin":  {"/root"},
+				"linux":   {"/root"},
+				"windows": {"C:\\myroot"},
 			},
 		},
 	} {
@@ -246,58 +246,58 @@ func TestGetScanConfig_DirsToSkip(t *testing.T) {
 		{
 			desc: "Skip default dirs",
 			flags: map[string]*cli.Flags{
-				"darwin":  &cli.Flags{Root: "/"},
-				"linux":   &cli.Flags{Root: "/"},
-				"windows": &cli.Flags{Root: "C:\\"},
+				"darwin":  {Root: "/"},
+				"linux":   {Root: "/"},
+				"windows": {Root: "C:\\"},
 			},
 			wantDirsToSkip: map[string][]string{
-				"darwin":  []string{"/dev", "/proc", "/sys"},
-				"linux":   []string{"/dev", "/proc", "/sys"},
-				"windows": []string{"C:\\Windows"},
+				"darwin":  {"/dev", "/proc", "/sys"},
+				"linux":   {"/dev", "/proc", "/sys"},
+				"windows": {"C:\\Windows"},
 			},
 		},
 		{
 			desc: "Skip additional dirs",
 			flags: map[string]*cli.Flags{
-				"darwin": &cli.Flags{
+				"darwin": {
 					Root:       "/",
 					DirsToSkip: []string{"/boot,/mnt,C:\\boot", "C:\\mnt"},
 				},
-				"linux": &cli.Flags{
+				"linux": {
 					Root:       "/",
 					DirsToSkip: []string{"/boot,/mnt", "C:\\boot,C:\\mnt"},
 				},
-				"windows": &cli.Flags{
+				"windows": {
 					Root:       "C:\\",
 					DirsToSkip: []string{"C:\\boot,C:\\mnt"},
 				},
 			},
 			wantDirsToSkip: map[string][]string{
-				"darwin":  []string{"/dev", "/proc", "/sys", "/boot", "/mnt"},
-				"linux":   []string{"/dev", "/proc", "/sys", "/boot", "/mnt"},
-				"windows": []string{"C:\\Windows", "C:\\boot", "C:\\mnt"},
+				"darwin":  {"/dev", "/proc", "/sys", "/boot", "/mnt"},
+				"linux":   {"/dev", "/proc", "/sys", "/boot", "/mnt"},
+				"windows": {"C:\\Windows", "C:\\boot", "C:\\mnt"},
 			},
 		},
 		{
 			desc: "Ignore paths outside root",
 			flags: map[string]*cli.Flags{
-				"darwin": &cli.Flags{
+				"darwin": {
 					Root:       "/root",
 					DirsToSkip: []string{"/root/dir1,/dir2"},
 				},
-				"linux": &cli.Flags{
+				"linux": {
 					Root:       "/root",
 					DirsToSkip: []string{"/root/dir1,/dir2"},
 				},
-				"windows": &cli.Flags{
+				"windows": {
 					Root:       "C:\\root",
 					DirsToSkip: []string{"C:\\root\\dir1,c:\\dir2"},
 				},
 			},
 			wantDirsToSkip: map[string][]string{
-				"darwin":  []string{"/root/dir1"},
-				"linux":   []string{"/root/dir1"},
-				"windows": []string{"C:\\root\\dir1"},
+				"darwin":  {"/root/dir1"},
+				"linux":   {"/root/dir1"},
+				"windows": {"C:\\root\\dir1"},
 			},
 		},
 	} {

--- a/binary/proto/proto_test.go
+++ b/binary/proto/proto_test.go
@@ -209,12 +209,12 @@ func TestScanResultToProto(t *testing.T) {
 		Version: "1.0.0",
 		Metadata: &packagejson.JavascriptPackageJSONMetadata{
 			Maintainers: []*packagejson.Person{
-				&packagejson.Person{
+				{
 					Name:  "maintainer1",
 					Email: "maintainer1@corp.com",
 					URL:   "https://blog.maintainer1.com",
 				},
-				&packagejson.Person{
+				{
 					Name:  "maintainer2",
 					Email: "maintainer2@corp.com",
 				},
@@ -233,8 +233,8 @@ func TestScanResultToProto(t *testing.T) {
 			Name:      "software",
 			Version:   "1.0.0",
 			Qualifiers: []*spb.Qualifier{
-				&spb.Qualifier{Key: "arch", Value: "amd64"},
-				&spb.Qualifier{Key: "distro", Value: "jammy"},
+				{Key: "arch", Value: "amd64"},
+				{Key: "distro", Value: "jammy"},
 			},
 		},
 		Ecosystem: "Debian",
@@ -261,8 +261,8 @@ func TestScanResultToProto(t *testing.T) {
 			Name:      "software",
 			Version:   "1.0.0",
 			Qualifiers: []*spb.Qualifier{
-				&spb.Qualifier{Key: "arch", Value: "amd64"},
-				&spb.Qualifier{Key: "distro", Value: "jammy"},
+				{Key: "arch", Value: "amd64"},
+				{Key: "distro", Value: "jammy"},
 			},
 		},
 		Ecosystem: "Debian",
@@ -422,10 +422,10 @@ func TestScanResultToProto(t *testing.T) {
 			Name:      "openssh-clients",
 			Version:   "5.3p1",
 			Qualifiers: []*spb.Qualifier{
-				&spb.Qualifier{Key: "arch", Value: "x86_64"},
-				&spb.Qualifier{Key: "distro", Value: "rhel-8.9"},
-				&spb.Qualifier{Key: "epoch", Value: "2"},
-				&spb.Qualifier{Key: "sourcerpm", Value: "openssh-5.3p1-124.el6_10.src.rpm"},
+				{Key: "arch", Value: "x86_64"},
+				{Key: "distro", Value: "rhel-8.9"},
+				{Key: "epoch", Value: "2"},
+				{Key: "sourcerpm", Value: "openssh-5.3p1-124.el6_10.src.rpm"},
 			},
 		},
 		Ecosystem: "Red Hat",
@@ -534,12 +534,12 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   endTime,
 				Status:    success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  success,
 					},
-					&plugin.Status{
+					{
 						Name:    "det",
 						Version: 3,
 						Status:  success,
@@ -555,7 +555,7 @@ func TestScanResultToProto(t *testing.T) {
 					cdxInventory,
 				},
 				Findings: []*detector.Finding{
-					&detector.Finding{
+					{
 						Adv: &detector.Advisory{
 							ID: &detector.AdvisoryID{
 								Publisher: "CVE",
@@ -585,12 +585,12 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   timestamppb.New(endTime),
 				Status:    successProto,
 				PluginStatus: []*spb.PluginStatus{
-					&spb.PluginStatus{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  successProto,
 					},
-					&spb.PluginStatus{
+					{
 						Name:    "det",
 						Version: 3,
 						Status:  successProto,
@@ -606,7 +606,7 @@ func TestScanResultToProto(t *testing.T) {
 					cdxInventoryProto,
 				},
 				Findings: []*spb.Finding{
-					&spb.Finding{
+					{
 						Adv: &spb.Advisory{
 							Id: &spb.AdvisoryId{
 								Publisher: "CVE",
@@ -639,7 +639,7 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   endTime,
 				Status:    success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  success,
@@ -653,7 +653,7 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   timestamppb.New(endTime),
 				Status:    successProto,
 				PluginStatus: []*spb.PluginStatus{
-					&spb.PluginStatus{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  successProto,
@@ -672,7 +672,7 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   endTime,
 				Status:    success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  success,
@@ -686,7 +686,7 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   timestamppb.New(endTime),
 				Status:    successProto,
 				PluginStatus: []*spb.PluginStatus{
-					&spb.PluginStatus{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  successProto,
@@ -707,7 +707,7 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   endTime,
 				Status:    success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  success,
@@ -721,7 +721,7 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   timestamppb.New(endTime),
 				Status:    successProto,
 				PluginStatus: []*spb.PluginStatus{
-					&spb.PluginStatus{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  successProto,
@@ -742,12 +742,12 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   endTime,
 				Status:    success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  success,
 					},
-					&plugin.Status{
+					{
 						Name:    "det",
 						Version: 3,
 						Status:  success,
@@ -755,7 +755,7 @@ func TestScanResultToProto(t *testing.T) {
 				},
 				Inventories: []*extractor.Inventory{purlDPKGInventory, purlPythonInventory, purlJavascriptInventory, cpeInventory, cdxInventory},
 				Findings: []*detector.Finding{
-					&detector.Finding{
+					{
 						Adv: &detector.Advisory{
 							ID: &detector.AdvisoryID{
 								Publisher: "CVE",
@@ -781,12 +781,12 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   timestamppb.New(endTime),
 				Status:    successProto,
 				PluginStatus: []*spb.PluginStatus{
-					&spb.PluginStatus{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  successProto,
 					},
-					&spb.PluginStatus{
+					{
 						Name:    "det",
 						Version: 3,
 						Status:  successProto,
@@ -794,7 +794,7 @@ func TestScanResultToProto(t *testing.T) {
 				},
 				Inventories: []*spb.Inventory{purlDPKGInventoryProto, purlPythonInventoryProto, purlJavascriptInventoryProto, cpeInventoryProto, cdxInventoryProto},
 				Findings: []*spb.Finding{
-					&spb.Finding{
+					{
 						Adv: &spb.Advisory{
 							Id: &spb.AdvisoryId{
 								Publisher: "CVE",
@@ -823,12 +823,12 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   endTime,
 				Status:    success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  success,
 					},
-					&plugin.Status{
+					{
 						Name:    "det",
 						Version: 3,
 						Status:  success,
@@ -836,7 +836,7 @@ func TestScanResultToProto(t *testing.T) {
 				},
 				Inventories: []*extractor.Inventory{purlDPKGInventory, purlPythonInventory, purlJavascriptInventory, cpeInventory, cdxInventory},
 				Findings: []*detector.Finding{
-					&detector.Finding{
+					{
 						Adv: &detector.Advisory{
 							Type:           detector.TypeVulnerability,
 							Title:          "Title",
@@ -862,12 +862,12 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   endTime,
 				Status:    success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  success,
 					},
-					&plugin.Status{
+					{
 						Name:    "det",
 						Version: 3,
 						Status:  success,
@@ -875,7 +875,7 @@ func TestScanResultToProto(t *testing.T) {
 				},
 				Inventories: []*extractor.Inventory{purlDPKGInventory, purlPythonInventory, purlJavascriptInventory, cpeInventory, cdxInventory},
 				Findings: []*detector.Finding{
-					&detector.Finding{
+					{
 						Extra: "extra details",
 					},
 				},
@@ -890,12 +890,12 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   endTime,
 				Status:    failure,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  failure,
 					},
-					&plugin.Status{
+					{
 						Name:    "det",
 						Version: 3,
 						Status:  failure,
@@ -908,12 +908,12 @@ func TestScanResultToProto(t *testing.T) {
 				EndTime:   timestamppb.New(endTime),
 				Status:    failureProto,
 				PluginStatus: []*spb.PluginStatus{
-					&spb.PluginStatus{
+					{
 						Name:    "ext",
 						Version: 2,
 						Status:  failureProto,
 					},
-					&spb.PluginStatus{
+					{
 						Name:    "det",
 						Version: 3,
 						Status:  failureProto,

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -110,7 +110,7 @@ func ToSPDX23(r *scalibr.ScanResult, c SPDXConfig) *v2_3.Document {
 			IsFilesAnalyzedTagPresent: false,
 			PackageSourceInfo:         pSourceInfo,
 			PackageExternalReferences: []*v2_3.PackageExternalReference{
-				&v2_3.PackageExternalReference{
+				{
 					Category: "PACKAGE-MANAGER",
 					RefType:  "purl",
 					Locator:  p.String(),
@@ -138,7 +138,7 @@ func ToSPDX23(r *scalibr.ScanResult, c SPDXConfig) *v2_3.Document {
 		namespace = "https://spdx.google/" + uuid.New().String()
 	}
 	creators := []common.Creator{
-		common.Creator{
+		{
 			CreatorType: "Tool",
 			Creator:     "SCALIBR",
 		},

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -47,7 +47,7 @@ func TestToSPDX23(t *testing.T) {
 		{
 			desc: "Package with no custom config",
 			scanResult: &scalibr.ScanResult{
-				Inventories: []*extractor.Inventory{&extractor.Inventory{
+				Inventories: []*extractor.Inventory{{
 					Name: "software", Version: "1.2.3", Extractor: pipEx,
 				}},
 			},
@@ -59,14 +59,14 @@ func TestToSPDX23(t *testing.T) {
 				DocumentNamespace: "https://spdx.google/81855ad8-681d-4d86-91e9-1e00167939cb",
 				CreationInfo: &v2_3.CreationInfo{
 					Creators: []common.Creator{
-						common.Creator{
+						{
 							CreatorType: "Tool",
 							Creator:     "SCALIBR",
 						},
 					},
 				},
 				Packages: []*v2_3.Package{
-					&v2_3.Package{
+					{
 						PackageName:           "main",
 						PackageSPDXIdentifier: "SPDXRef-Package-main-52fdfc07-2182-454f-963f-5f0f9a621d72",
 						PackageVersion:        "0",
@@ -77,7 +77,7 @@ func TestToSPDX23(t *testing.T) {
 						PackageDownloadLocation:   converter.NoAssertion,
 						IsFilesAnalyzedTagPresent: false,
 					},
-					&v2_3.Package{
+					{
 						PackageName:           "software",
 						PackageSPDXIdentifier: "SPDXRef-Package-software-9566c74d-1003-4c4d-bbbb-0407d1e2c649",
 						PackageVersion:        "1.2.3",
@@ -89,7 +89,7 @@ func TestToSPDX23(t *testing.T) {
 						IsFilesAnalyzedTagPresent: false,
 						PackageSourceInfo:         "Identified by the python/wheelegg extractor",
 						PackageExternalReferences: []*v2_3.PackageExternalReference{
-							&v2_3.PackageExternalReference{
+							{
 								Category: "PACKAGE-MANAGER",
 								RefType:  "purl",
 								Locator:  "pkg:pypi/software@1.2.3",
@@ -98,7 +98,7 @@ func TestToSPDX23(t *testing.T) {
 					},
 				},
 				Relationships: []*v2_3.Relationship{
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-main-52fdfc07-2182-454f-963f-5f0f9a621d72",
 						},
@@ -107,7 +107,7 @@ func TestToSPDX23(t *testing.T) {
 						},
 						Relationship: "CONTAINS",
 					},
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-software-9566c74d-1003-4c4d-bbbb-0407d1e2c649",
 						},
@@ -122,7 +122,7 @@ func TestToSPDX23(t *testing.T) {
 		{
 			desc: "Package with custom config",
 			scanResult: &scalibr.ScanResult{
-				Inventories: []*extractor.Inventory{&extractor.Inventory{
+				Inventories: []*extractor.Inventory{{
 					Name: "software", Version: "1.2.3", Extractor: pipEx,
 				}},
 			},
@@ -130,7 +130,7 @@ func TestToSPDX23(t *testing.T) {
 				DocumentName:      "Custom name",
 				DocumentNamespace: "Custom namespace",
 				Creators: []common.Creator{
-					common.Creator{
+					{
 						CreatorType: "Person",
 						Creator:     "Custom creator",
 					},
@@ -144,18 +144,18 @@ func TestToSPDX23(t *testing.T) {
 				DocumentNamespace: "Custom namespace",
 				CreationInfo: &v2_3.CreationInfo{
 					Creators: []common.Creator{
-						common.Creator{
+						{
 							CreatorType: "Tool",
 							Creator:     "SCALIBR",
 						},
-						common.Creator{
+						{
 							CreatorType: "Person",
 							Creator:     "Custom creator",
 						},
 					},
 				},
 				Packages: []*v2_3.Package{
-					&v2_3.Package{
+					{
 						PackageName:           "main",
 						PackageSPDXIdentifier: "SPDXRef-Package-main-6694d2c4-22ac-4208-a007-2939487f6999",
 						PackageVersion:        "0",
@@ -166,7 +166,7 @@ func TestToSPDX23(t *testing.T) {
 						PackageDownloadLocation:   converter.NoAssertion,
 						IsFilesAnalyzedTagPresent: false,
 					},
-					&v2_3.Package{
+					{
 						PackageName:           "software",
 						PackageSPDXIdentifier: "SPDXRef-Package-software-eb9d18a4-4784-445d-87f3-c67cf22746e9",
 						PackageVersion:        "1.2.3",
@@ -178,7 +178,7 @@ func TestToSPDX23(t *testing.T) {
 						IsFilesAnalyzedTagPresent: false,
 						PackageSourceInfo:         "Identified by the python/wheelegg extractor",
 						PackageExternalReferences: []*v2_3.PackageExternalReference{
-							&v2_3.PackageExternalReference{
+							{
 								Category: "PACKAGE-MANAGER",
 								RefType:  "purl",
 								Locator:  "pkg:pypi/software@1.2.3",
@@ -187,7 +187,7 @@ func TestToSPDX23(t *testing.T) {
 					},
 				},
 				Relationships: []*v2_3.Relationship{
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-main-6694d2c4-22ac-4208-a007-2939487f6999",
 						},
@@ -196,7 +196,7 @@ func TestToSPDX23(t *testing.T) {
 						},
 						Relationship: "CONTAINS",
 					},
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-software-eb9d18a4-4784-445d-87f3-c67cf22746e9",
 						},
@@ -213,13 +213,13 @@ func TestToSPDX23(t *testing.T) {
 			scanResult: &scalibr.ScanResult{
 				Inventories: []*extractor.Inventory{
 					// PURL field missing
-					&extractor.Inventory{Extractor: pipEx},
+					{Extractor: pipEx},
 					// No name
-					&extractor.Inventory{
+					{
 						Version: "1.2.3", Extractor: pipEx,
 					},
 					// No version
-					&extractor.Inventory{
+					{
 						Name: "software", Extractor: pipEx,
 					},
 				},
@@ -232,13 +232,13 @@ func TestToSPDX23(t *testing.T) {
 				DocumentNamespace: "https://spdx.google/5fb90bad-b37c-4821-b6d9-5526a41a9504",
 				CreationInfo: &v2_3.CreationInfo{
 					Creators: []common.Creator{
-						common.Creator{
+						{
 							CreatorType: "Tool",
 							Creator:     "SCALIBR",
 						},
 					},
 				},
-				Packages: []*v2_3.Package{&v2_3.Package{
+				Packages: []*v2_3.Package{{
 					PackageName:           "main",
 					PackageSPDXIdentifier: "SPDXRef-Package-main-95af5a25-3679-41ba-a2ff-6cd471c483f1",
 					PackageVersion:        "0",
@@ -255,7 +255,7 @@ func TestToSPDX23(t *testing.T) {
 		{
 			desc: "Invalid chars in package name replaced",
 			scanResult: &scalibr.ScanResult{
-				Inventories: []*extractor.Inventory{&extractor.Inventory{
+				Inventories: []*extractor.Inventory{{
 					Name: "softw@re&", Version: "1.2.3", Extractor: pipEx,
 				}},
 			},
@@ -267,14 +267,14 @@ func TestToSPDX23(t *testing.T) {
 				DocumentNamespace: "https://spdx.google/0f070244-8615-4bda-8831-3f6a8eb668d2",
 				CreationInfo: &v2_3.CreationInfo{
 					Creators: []common.Creator{
-						common.Creator{
+						{
 							CreatorType: "Tool",
 							Creator:     "SCALIBR",
 						},
 					},
 				},
 				Packages: []*v2_3.Package{
-					&v2_3.Package{
+					{
 						PackageName:           "main",
 						PackageSPDXIdentifier: "SPDXRef-Package-main-680b4e7c-8b76-4a1b-9d49-d4955c848621",
 						PackageVersion:        "0",
@@ -285,7 +285,7 @@ func TestToSPDX23(t *testing.T) {
 						PackageDownloadLocation:   converter.NoAssertion,
 						IsFilesAnalyzedTagPresent: false,
 					},
-					&v2_3.Package{
+					{
 						PackageName:           "softw@re&",
 						PackageSPDXIdentifier: "SPDXRef-Package-softw-re--6325253f-ec73-4dd7-a9e2-8bf921119c16",
 						PackageVersion:        "1.2.3",
@@ -297,7 +297,7 @@ func TestToSPDX23(t *testing.T) {
 						IsFilesAnalyzedTagPresent: false,
 						PackageSourceInfo:         "Identified by the python/wheelegg extractor",
 						PackageExternalReferences: []*v2_3.PackageExternalReference{
-							&v2_3.PackageExternalReference{
+							{
 								Category: "PACKAGE-MANAGER",
 								RefType:  "purl",
 								Locator:  "pkg:pypi/softw%40re%26@1.2.3",
@@ -306,7 +306,7 @@ func TestToSPDX23(t *testing.T) {
 					},
 				},
 				Relationships: []*v2_3.Relationship{
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-main-680b4e7c-8b76-4a1b-9d49-d4955c848621",
 						},
@@ -315,7 +315,7 @@ func TestToSPDX23(t *testing.T) {
 						},
 						Relationship: "CONTAINS",
 					},
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-softw-re--6325253f-ec73-4dd7-a9e2-8bf921119c16",
 						},
@@ -330,7 +330,7 @@ func TestToSPDX23(t *testing.T) {
 		{
 			desc: "One location reported",
 			scanResult: &scalibr.ScanResult{
-				Inventories: []*extractor.Inventory{&extractor.Inventory{
+				Inventories: []*extractor.Inventory{{
 					Name: "software", Version: "1.2.3", Extractor: pipEx, Locations: []string{"/file1"},
 				}},
 			},
@@ -342,14 +342,14 @@ func TestToSPDX23(t *testing.T) {
 				DocumentNamespace: "https://spdx.google/6bf84c71-74cb-4476-b64c-c3dbd968b0f7",
 				CreationInfo: &v2_3.CreationInfo{
 					Creators: []common.Creator{
-						common.Creator{
+						{
 							CreatorType: "Tool",
 							Creator:     "SCALIBR",
 						},
 					},
 				},
 				Packages: []*v2_3.Package{
-					&v2_3.Package{
+					{
 						PackageName:           "main",
 						PackageSPDXIdentifier: "SPDXRef-Package-main-0bf50598-7592-4e66-8a5b-df2c7fc48445",
 						PackageVersion:        "0",
@@ -360,7 +360,7 @@ func TestToSPDX23(t *testing.T) {
 						PackageDownloadLocation:   converter.NoAssertion,
 						IsFilesAnalyzedTagPresent: false,
 					},
-					&v2_3.Package{
+					{
 						PackageName:           "software",
 						PackageSPDXIdentifier: "SPDXRef-Package-software-92d2572b-cd06-48d2-96c5-2f5054e2d083",
 						PackageVersion:        "1.2.3",
@@ -372,7 +372,7 @@ func TestToSPDX23(t *testing.T) {
 						IsFilesAnalyzedTagPresent: false,
 						PackageSourceInfo:         "Identified by the python/wheelegg extractor from /file1",
 						PackageExternalReferences: []*v2_3.PackageExternalReference{
-							&v2_3.PackageExternalReference{
+							{
 								Category: "PACKAGE-MANAGER",
 								RefType:  "purl",
 								Locator:  "pkg:pypi/software@1.2.3",
@@ -381,7 +381,7 @@ func TestToSPDX23(t *testing.T) {
 					},
 				},
 				Relationships: []*v2_3.Relationship{
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-main-0bf50598-7592-4e66-8a5b-df2c7fc48445",
 						},
@@ -390,7 +390,7 @@ func TestToSPDX23(t *testing.T) {
 						},
 						Relationship: "CONTAINS",
 					},
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-software-92d2572b-cd06-48d2-96c5-2f5054e2d083",
 						},
@@ -405,7 +405,7 @@ func TestToSPDX23(t *testing.T) {
 		{
 			desc: "Multiple locations reported",
 			scanResult: &scalibr.ScanResult{
-				Inventories: []*extractor.Inventory{&extractor.Inventory{
+				Inventories: []*extractor.Inventory{{
 					Name: "software", Version: "1.2.3", Extractor: pipEx, Locations: []string{"/file1", "/file2", "/file3"},
 				}},
 			},
@@ -417,14 +417,14 @@ func TestToSPDX23(t *testing.T) {
 				DocumentNamespace: "https://spdx.google/255aa5b7-d44b-4c40-b84c-892b9bffd436",
 				CreationInfo: &v2_3.CreationInfo{
 					Creators: []common.Creator{
-						common.Creator{
+						{
 							CreatorType: "Tool",
 							Creator:     "SCALIBR",
 						},
 					},
 				},
 				Packages: []*v2_3.Package{
-					&v2_3.Package{
+					{
 						PackageName:           "main",
 						PackageSPDXIdentifier: "SPDXRef-Package-main-172ed857-94bb-458b-8c3b-525da1786f9f",
 						PackageVersion:        "0",
@@ -435,7 +435,7 @@ func TestToSPDX23(t *testing.T) {
 						PackageDownloadLocation:   converter.NoAssertion,
 						IsFilesAnalyzedTagPresent: false,
 					},
-					&v2_3.Package{
+					{
 						PackageName:           "software",
 						PackageSPDXIdentifier: "SPDXRef-Package-software-ff094279-db19-44eb-97a1-9d0f7bbacbe0",
 						PackageVersion:        "1.2.3",
@@ -447,7 +447,7 @@ func TestToSPDX23(t *testing.T) {
 						IsFilesAnalyzedTagPresent: false,
 						PackageSourceInfo:         "Identified by the python/wheelegg extractor from 3 locations, including /file1 and /file2",
 						PackageExternalReferences: []*v2_3.PackageExternalReference{
-							&v2_3.PackageExternalReference{
+							{
 								Category: "PACKAGE-MANAGER",
 								RefType:  "purl",
 								Locator:  "pkg:pypi/software@1.2.3",
@@ -456,7 +456,7 @@ func TestToSPDX23(t *testing.T) {
 					},
 				},
 				Relationships: []*v2_3.Relationship{
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-main-172ed857-94bb-458b-8c3b-525da1786f9f",
 						},
@@ -465,7 +465,7 @@ func TestToSPDX23(t *testing.T) {
 						},
 						Relationship: "CONTAINS",
 					},
-					&v2_3.Relationship{
+					{
 						RefA: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-software-ff094279-db19-44eb-97a1-9d0f7bbacbe0",
 						},
@@ -511,7 +511,7 @@ func TestToCDX(t *testing.T) {
 		{
 			desc: "Package with custom config",
 			scanResult: &scalibr.ScanResult{
-				Inventories: []*extractor.Inventory{&extractor.Inventory{
+				Inventories: []*extractor.Inventory{{
 					Name: "software", Version: "1.2.3", Extractor: pipEx,
 				}},
 			},

--- a/detector/cis/generic_linux/etcpasswdpermissions/detector.go
+++ b/detector/cis/generic_linux/etcpasswdpermissions/detector.go
@@ -95,7 +95,7 @@ func (Detector) ScanFS(ctx context.Context, fs fs.FS, ix *inventoryindex.Invento
 	recommendation := "Run the following command to set permissions on /etc/passwd :\n" +
 		"# chown root:root /etc/passwd\n" +
 		"# chmod 644 /etc/passwd"
-	return []*detector.Finding{&detector.Finding{
+	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
 				Publisher: "CIS",

--- a/detector/cis/generic_linux/etcpasswdpermissions/detector_test.go
+++ b/detector/cis/generic_linux/etcpasswdpermissions/detector_test.go
@@ -94,7 +94,7 @@ func TestScan(t *testing.T) {
 		{
 			desc: "Permissions incorrect",
 			fsys: &fakeFS{exists: true, perms: 0777, uid: 0, gid: 0},
-			wantFindings: []*detector.Finding{&detector.Finding{
+			wantFindings: []*detector.Finding{{
 				Adv:    wantAdv,
 				Target: &detector.TargetDetails{Location: []string{"/etc/passwd"}},
 				Extra:  "file permissions 777, expected 644\n",
@@ -103,7 +103,7 @@ func TestScan(t *testing.T) {
 		{
 			desc: "Permissions and uid incorrect",
 			fsys: &fakeFS{exists: true, perms: 0777, uid: 10, gid: 0},
-			wantFindings: []*detector.Finding{&detector.Finding{
+			wantFindings: []*detector.Finding{{
 				Adv:    wantAdv,
 				Target: &detector.TargetDetails{Location: []string{"/etc/passwd"}},
 				Extra:  "file permissions 777, expected 644\nfile owner 10, expected 0/root\n",
@@ -112,7 +112,7 @@ func TestScan(t *testing.T) {
 		{
 			desc: "Permissions and gid incorrect",
 			fsys: &fakeFS{exists: true, perms: 0777, uid: 0, gid: 10},
-			wantFindings: []*detector.Finding{&detector.Finding{
+			wantFindings: []*detector.Finding{{
 				Adv:    wantAdv,
 				Target: &detector.TargetDetails{Location: []string{"/etc/passwd"}},
 				Extra:  "file permissions 777, expected 644\nfile group 10, expected 0/root\n",

--- a/detector/cve/cve202011978/detector.go
+++ b/detector/cve/cve202011978/detector.go
@@ -197,7 +197,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 		log.Infof("Error removing file: %v", err)
 	}
 
-	return []*detector.Finding{&detector.Finding{
+	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
 				Publisher: "SCALIBR",

--- a/detector/cve/cve202016846/detector.go
+++ b/detector/cve/cve202016846/detector.go
@@ -163,7 +163,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 		log.Infof("Error removing file: %v", err)
 	}
 
-	return []*detector.Finding{&detector.Finding{
+	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
 				Publisher: "SCALIBR",

--- a/detector/cve/cve202233891/detector.go
+++ b/detector/cve/cve202233891/detector.go
@@ -52,7 +52,7 @@ var (
 	seededRand        = rand.New(rand.NewSource(time.Now().UnixNano()))
 	sparkServersPorts = []int{4040, 8080}
 	sparkUIPackages   = []sparkUIPackageNames{
-		sparkUIPackageNames{
+		{
 			packageType: "pypi",
 			name:        "pyspark",
 			affectedVersions: []string{
@@ -135,7 +135,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	if !vulnerable {
 		return nil, nil
 	}
-	return []*detector.Finding{&detector.Finding{
+	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
 				Publisher: "SCALIBR",

--- a/detector/cve/cve202338408/detector.go
+++ b/detector/cve/cve202338408/detector.go
@@ -116,7 +116,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	}
 	locations = append(locations, socketFiles...)
 
-	return []*detector.Finding{&detector.Finding{
+	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
 				Publisher: "SCALIBR",

--- a/detector/cve/cve20236019/detector.go
+++ b/detector/cve/cve20236019/detector.go
@@ -88,7 +88,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 		log.Infof("Exploit attempt failed")
 		return nil, nil
 	}
-	return []*detector.Finding{&detector.Finding{
+	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
 				Publisher: "SCALIBR",

--- a/detector/cve/cve20242912/detector.go
+++ b/detector/cve/cve20242912/detector.go
@@ -215,7 +215,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	}
 	log.Infof("Payload file removed")
 
-	return []*detector.Finding{&detector.Finding{
+	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
 				Publisher: "SCALIBR",

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -79,8 +79,8 @@ func TestRun(t *testing.T) {
 				withDetectorName(finding2, "det2"),
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "det1", Version: 1, Status: success},
-				&plugin.Status{Name: "det2", Version: 2, Status: success},
+				{Name: "det1", Version: 1, Status: success},
+				{Name: "det2", Version: 2, Status: success},
 			},
 		},
 		{
@@ -91,8 +91,8 @@ func TestRun(t *testing.T) {
 			},
 			wantFindings: []*detector.Finding{withDetectorName(finding1, "det1")},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "det1", Version: 1, Status: success},
-				&plugin.Status{Name: "det2", Version: 2, Status: &plugin.ScanStatus{
+				{Name: "det1", Version: 1, Status: success},
+				{Name: "det2", Version: 2, Status: &plugin.ScanStatus{
 					Status: plugin.ScanStatusFailed, FailureReason: "detection failed",
 				}},
 			},
@@ -105,8 +105,8 @@ func TestRun(t *testing.T) {
 			},
 			wantFindings: []*detector.Finding{withDetectorName(finding1, "det1"), withDetectorName(finding1, "det2")},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "det1", Version: 1, Status: success},
-				&plugin.Status{Name: "det2", Version: 2, Status: success},
+				{Name: "det1", Version: 1, Status: success},
+				{Name: "det2", Version: 2, Status: success},
 			},
 		},
 		{
@@ -119,8 +119,8 @@ func TestRun(t *testing.T) {
 			},
 			wantFindings: []*detector.Finding{},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "det1", Version: 1, Status: success},
-				&plugin.Status{Name: "det2", Version: 2, Status: success},
+				{Name: "det1", Version: 1, Status: success},
+				{Name: "det2", Version: 2, Status: success},
 			},
 			wantErr: cmpopts.AnyError,
 		},
@@ -131,7 +131,7 @@ func TestRun(t *testing.T) {
 			},
 			wantFindings: []*detector.Finding{},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "det1", Version: 1, Status: success},
+				{Name: "det1", Version: 1, Status: success},
 			},
 			wantErr: cmpopts.AnyError,
 		},
@@ -142,7 +142,7 @@ func TestRun(t *testing.T) {
 			},
 			wantFindings: []*detector.Finding{},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "det1", Version: 1, Status: success},
+				{Name: "det1", Version: 1, Status: success},
 			},
 			wantErr: cmpopts.AnyError,
 		},

--- a/detector/weakcredentials/etcshadow/detector.go
+++ b/detector/weakcredentials/etcshadow/detector.go
@@ -102,7 +102,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	}
 	problemDescription := buf.String()
 
-	return []*detector.Finding{&detector.Finding{
+	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
 				Publisher: "SCALIBR",

--- a/detector/weakcredentials/etcshadow/detector_test.go
+++ b/detector/weakcredentials/etcshadow/detector_test.go
@@ -134,7 +134,7 @@ func TestScan(t *testing.T) {
 		{
 			desc: "File with hashes, some cracked",
 			fsys: &fakeFS{files: map[string]string{"etc/shadow": sampleEtcShadow}},
-			wantFindings: []*detector.Finding{&detector.Finding{
+			wantFindings: []*detector.Finding{{
 				Adv:    wantAdv,
 				Target: &detector.TargetDetails{Location: []string{"/etc/shadow"}},
 				Extra: "The following users have weak passwords:\n" +

--- a/detector/weakcredentials/filebrowser/detector.go
+++ b/detector/weakcredentials/filebrowser/detector.go
@@ -86,7 +86,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 		if !isVulnerable(ctx, fileBrowserIP, fileBrowserPort) {
 			continue
 		}
-		return []*detector.Finding{&detector.Finding{
+		return []*detector.Finding{{
 			Adv: &detector.Advisory{
 				ID: &detector.AdvisoryID{
 					Publisher: "SCALIBR",

--- a/extractor/filesystem/containers/containerd/extractor_test.go
+++ b/extractor/filesystem/containers/containerd/extractor_test.go
@@ -105,7 +105,7 @@ func TestExtract(t *testing.T) {
 			},
 			onGoos: "linux",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-pod-identity-agent:0.1.15",
 					Version: "sha256:832ad48c9872fdcae32f2ea369d9874fa34f2ea369d9874fa34f271b4dbc58ce04393c757befa462",
 					Metadata: &containerd.Metadata{
@@ -178,7 +178,7 @@ func TestExtract(t *testing.T) {
 			// TODO(b/350963790): Enable this test case once the extractor is supported on Windows.
 			onGoos: "ignore",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "mcr.microsoft.com/windows/nanoserver:ltsc2022",
 					Version: "sha256:31c8aa02d47af7d65c11da9c3a279c8407c32afd3fc6bec2e9a544db8e3715b3",
 					Metadata: &containerd.Metadata{

--- a/extractor/filesystem/extractor_test.go
+++ b/extractor/filesystem/extractor_test.go
@@ -71,56 +71,56 @@ func TestInitWalkContext(t *testing.T) {
 		{
 			desc: "valid config with filesToExtract raises no error",
 			scanRoots: map[string][]string{
-				"darwin":  []string{"/scanroot/"},
-				"linux":   []string{"/scanroot/"},
-				"windows": []string{"C:\\scanroot\\"},
+				"darwin":  {"/scanroot/"},
+				"linux":   {"/scanroot/"},
+				"windows": {"C:\\scanroot\\"},
 			},
 			filesToExtract: map[string][]string{
-				"darwin":  []string{"/scanroot/file1.txt", "/scanroot/file2.txt"},
-				"linux":   []string{"/scanroot/file1.txt", "/scanroot/file2.txt"},
-				"windows": []string{"C:\\scanroot\\file1.txt", "C:\\scanroot\\file2.txt"},
+				"darwin":  {"/scanroot/file1.txt", "/scanroot/file2.txt"},
+				"linux":   {"/scanroot/file1.txt", "/scanroot/file2.txt"},
+				"windows": {"C:\\scanroot\\file1.txt", "C:\\scanroot\\file2.txt"},
 			},
 			wantErr: nil,
 		},
 		{
 			desc: "valid config with dirsToSkip raises no error",
 			scanRoots: map[string][]string{
-				"darwin":  []string{"/scanroot/", "/someotherroot/"},
-				"linux":   []string{"/scanroot/", "/someotherroot/"},
-				"windows": []string{"C:\\scanroot\\", "D:\\someotherroot\\"},
+				"darwin":  {"/scanroot/", "/someotherroot/"},
+				"linux":   {"/scanroot/", "/someotherroot/"},
+				"windows": {"C:\\scanroot\\", "D:\\someotherroot\\"},
 			},
 			dirsToSkip: map[string][]string{
-				"darwin":  []string{"/scanroot/mydir/", "/someotherroot/mydir/"},
-				"linux":   []string{"/scanroot/mydir/", "/someotherroot/mydir/"},
-				"windows": []string{"C:\\scanroot\\mydir\\", "D:\\someotherroot\\mydir\\"},
+				"darwin":  {"/scanroot/mydir/", "/someotherroot/mydir/"},
+				"linux":   {"/scanroot/mydir/", "/someotherroot/mydir/"},
+				"windows": {"C:\\scanroot\\mydir\\", "D:\\someotherroot\\mydir\\"},
 			},
 			wantErr: nil,
 		},
 		{
 			desc: "filesToExtract not relative to any root raises error",
 			scanRoots: map[string][]string{
-				"darwin":  []string{"/scanroot/"},
-				"linux":   []string{"/scanroot/"},
-				"windows": []string{"C:\\scanroot\\"},
+				"darwin":  {"/scanroot/"},
+				"linux":   {"/scanroot/"},
+				"windows": {"C:\\scanroot\\"},
 			},
 			filesToExtract: map[string][]string{
-				"darwin":  []string{"/scanroot/myfile.txt", "/myotherroot/file1.txt"},
-				"linux":   []string{"/scanroot/myfile.txt", "/myotherroot/file1.txt"},
-				"windows": []string{"C:\\scanroot\\myfile.txt", "D:\\myotherroot\\file1.txt"},
+				"darwin":  {"/scanroot/myfile.txt", "/myotherroot/file1.txt"},
+				"linux":   {"/scanroot/myfile.txt", "/myotherroot/file1.txt"},
+				"windows": {"C:\\scanroot\\myfile.txt", "D:\\myotherroot\\file1.txt"},
 			},
 			wantErr: filesystem.ErrNotRelativeToScanRoots,
 		},
 		{
 			desc: "dirsToSkip not relative to any root raises error",
 			scanRoots: map[string][]string{
-				"darwin":  []string{"/scanroot/"},
-				"linux":   []string{"/scanroot/"},
-				"windows": []string{"C:\\scanroot\\"},
+				"darwin":  {"/scanroot/"},
+				"linux":   {"/scanroot/"},
+				"windows": {"C:\\scanroot\\"},
 			},
 			dirsToSkip: map[string][]string{
-				"darwin":  []string{"/scanroot/mydir/", "/myotherroot/mydir/"},
-				"linux":   []string{"/scanroot/mydir/", "/myotherroot/mydir/"},
-				"windows": []string{"C:\\scanroot\\mydir\\", "D:\\myotherroot\\mydir\\"},
+				"darwin":  {"/scanroot/mydir/", "/myotherroot/mydir/"},
+				"linux":   {"/scanroot/mydir/", "/myotherroot/mydir/"},
+				"windows": {"C:\\scanroot\\mydir\\", "D:\\myotherroot\\mydir\\"},
 			},
 			wantErr: filesystem.ErrNotRelativeToScanRoots,
 		},
@@ -193,20 +193,20 @@ func TestRunFS(t *testing.T) {
 			desc: "Extractors successful",
 			ex:   []filesystem.Extractor{fakeEx1, fakeEx2},
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name1,
 					Locations: []string{path1},
 					Extractor: fakeEx1,
 				},
-				&extractor.Inventory{
+				{
 					Name:      name2,
 					Locations: []string{path2},
 					Extractor: fakeEx2,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 6,
 		},
@@ -216,15 +216,15 @@ func TestRunFS(t *testing.T) {
 			// ScanRoot is CWD
 			dirsToSkip: []string{path.Join(cwd, "dir1")},
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name2,
 					Locations: []string{path2},
 					Extractor: fakeEx2,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 5,
 		},
@@ -233,15 +233,15 @@ func TestRunFS(t *testing.T) {
 			ex:         []filesystem.Extractor{fakeEx1, fakeEx2},
 			dirsToSkip: []string{"dir1"},
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name2,
 					Locations: []string{path2},
 					Extractor: fakeEx2,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 5,
 		},
@@ -250,15 +250,15 @@ func TestRunFS(t *testing.T) {
 			ex:           []filesystem.Extractor{fakeEx1, fakeEx2},
 			skipDirRegex: ".*1",
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name2,
 					Locations: []string{path2},
 					Extractor: fakeEx2,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 5,
 		},
@@ -267,15 +267,15 @@ func TestRunFS(t *testing.T) {
 			ex:           []filesystem.Extractor{fakeEx1, fakeEx2},
 			skipDirRegex: "/sub$",
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name1,
 					Locations: []string{path1},
 					Extractor: fakeEx1,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 5,
 		},
@@ -284,20 +284,20 @@ func TestRunFS(t *testing.T) {
 			ex:           []filesystem.Extractor{fakeEx1, fakeEx2},
 			skipDirRegex: "asdf",
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name1,
 					Locations: []string{path1},
 					Extractor: fakeEx1,
 				},
-				&extractor.Inventory{
+				{
 					Name:      name2,
 					Locations: []string{path2},
 					Extractor: fakeEx2,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 6,
 		},
@@ -305,20 +305,20 @@ func TestRunFS(t *testing.T) {
 			desc: "Duplicate inventory results kept separate",
 			ex:   []filesystem.Extractor{fakeEx1, fakeEx2WithInv1},
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name1,
 					Locations: []string{path1},
 					Extractor: fakeEx1,
 				},
-				&extractor.Inventory{
+				{
 					Name:      name1,
 					Locations: []string{path2},
 					Extractor: fakeEx2WithInv1,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 6,
 		},
@@ -328,15 +328,15 @@ func TestRunFS(t *testing.T) {
 			// ScanRoot is CWD
 			filesToExtract: []string{path.Join(cwd, path2)},
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name2,
 					Locations: []string{path2},
 					Extractor: fakeEx2,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 1,
 		},
@@ -345,15 +345,15 @@ func TestRunFS(t *testing.T) {
 			ex:             []filesystem.Extractor{fakeEx1, fakeEx2},
 			filesToExtract: []string{path2},
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name2,
 					Locations: []string{path2},
 					Extractor: fakeEx2,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 1,
 		},
@@ -365,7 +365,7 @@ func TestRunFS(t *testing.T) {
 			},
 			wantInv: []*extractor.Inventory{},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
 			},
 			wantInodeCount: 6,
 		},
@@ -373,14 +373,14 @@ func TestRunFS(t *testing.T) {
 			desc: "Extraction fails with partial results",
 			ex:   []filesystem.Extractor{fakeExWithPartialResult},
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name1,
 					Locations: []string{path1},
 					Extractor: fakeExWithPartialResult,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
+				{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
 					Status: plugin.ScanStatusPartiallySucceeded, FailureReason: fmt.Sprintf("%s: extraction failed", path1),
 				}},
 			},
@@ -393,7 +393,7 @@ func TestRunFS(t *testing.T) {
 			},
 			wantInv: []*extractor.Inventory{},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
+				{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
 					Status: plugin.ScanStatusFailed, FailureReason: fmt.Sprintf("%s: extraction failed", path1),
 				}},
 			},
@@ -409,7 +409,7 @@ func TestRunFS(t *testing.T) {
 			},
 			wantInv: []*extractor.Inventory{},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
+				{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
 					Status:        plugin.ScanStatusFailed,
 					FailureReason: fmt.Sprintf("%s: extraction failed\n%s: extraction failed", path1, path2),
 				}},
@@ -422,8 +422,8 @@ func TestRunFS(t *testing.T) {
 			maxInodes: 2,
 			wantInv:   []*extractor.Inventory{},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 2,
 			wantErr:        cmpopts.AnyError,
@@ -433,20 +433,20 @@ func TestRunFS(t *testing.T) {
 			ex:        []filesystem.Extractor{fakeEx1, fakeEx2},
 			maxInodes: 6,
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name1,
 					Locations: []string{path1},
 					Extractor: fakeEx1,
 				},
-				&extractor.Inventory{
+				{
 					Name:      name2,
 					Locations: []string{path2},
 					Extractor: fakeEx2,
 				},
 			},
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 6,
 		},
@@ -454,12 +454,12 @@ func TestRunFS(t *testing.T) {
 			desc: "Extractors successful store absolute path when requested",
 			ex:   []filesystem.Extractor{fakeEx1, fakeEx2},
 			wantInv: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      name1,
 					Locations: []string{filepath.Join(cwd, path1)},
 					Extractor: fakeEx1,
 				},
-				&extractor.Inventory{
+				{
 					Name:      name2,
 					Locations: []string{filepath.Join(cwd, path2)},
 					Extractor: fakeEx2,
@@ -467,8 +467,8 @@ func TestRunFS(t *testing.T) {
 			},
 			storeAbsPath: true,
 			wantStatus: []*plugin.Status{
-				&plugin.Status{Name: "ex1", Version: 1, Status: success},
-				&plugin.Status{Name: "ex2", Version: 2, Status: success},
+				{Name: "ex1", Version: 1, Status: success},
+				{Name: "ex2", Version: 2, Status: success},
 			},
 			wantInodeCount: 6,
 		},
@@ -487,14 +487,14 @@ func TestRunFS(t *testing.T) {
 				DirsToSkip:     tc.dirsToSkip,
 				SkipDirRegex:   skipDirRegex,
 				MaxInodes:      tc.maxInodes,
-				ScanRoots: []*scalibrfs.ScanRoot{&scalibrfs.ScanRoot{
+				ScanRoots: []*scalibrfs.ScanRoot{{
 					FS: fsys, Path: ".",
 				}},
 				Stats:             fc,
 				StoreAbsolutePath: tc.storeAbsPath,
 			}
 			wc, err := filesystem.InitWalkContext(
-				context.Background(), config, []*scalibrfs.ScanRoot{&scalibrfs.ScanRoot{
+				context.Background(), config, []*scalibrfs.ScanRoot{{
 					FS: fsys, Path: cwd,
 				}},
 			)
@@ -612,7 +612,7 @@ func TestRunFS_ReadError(t *testing.T) {
 			map[string]fe.NamesErr{"file": {Names: []string{"software"}, Err: nil}}),
 	}
 	wantStatus := []*plugin.Status{
-		&plugin.Status{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
+		{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
 			Status: plugin.ScanStatusFailed, FailureReason: "Open(file): failed to open",
 		}},
 	}
@@ -620,7 +620,7 @@ func TestRunFS_ReadError(t *testing.T) {
 	config := &filesystem.Config{
 		Extractors: ex,
 		DirsToSkip: []string{},
-		ScanRoots: []*scalibrfs.ScanRoot{&scalibrfs.ScanRoot{
+		ScanRoots: []*scalibrfs.ScanRoot{{
 			FS: fsys, Path: ".",
 		}},
 		Stats: stats.NoopCollector{},

--- a/extractor/filesystem/language/dotnet/packageslockjson/extractor_test.go
+++ b/extractor/filesystem/language/dotnet/packageslockjson/extractor_test.go
@@ -139,42 +139,42 @@ func TestExtractor(t *testing.T) {
 			name: "valid packages.lock.json",
 			path: "testdata/valid/packages.lock.json",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "Core.Dep",
 					Version:   "1.24.0",
 					Locations: []string{"testdata/valid/packages.lock.json"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Some.Dep.One",
 					Version:   "1.1.1",
 					Locations: []string{"testdata/valid/packages.lock.json"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Some.Dep.Two",
 					Version:   "4.6.0",
 					Locations: []string{"testdata/valid/packages.lock.json"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Some.Dep.Three",
 					Version:   "1.0.2",
 					Locations: []string{"testdata/valid/packages.lock.json"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Some.Dep.Four",
 					Version:   "4.5.0",
 					Locations: []string{"testdata/valid/packages.lock.json"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Some.Longer.Name.Dep",
 					Version:   "4.7.2",
 					Locations: []string{"testdata/valid/packages.lock.json"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Some.Dep.Five",
 					Version:   "4.7.2",
 					Locations: []string{"testdata/valid/packages.lock.json"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Another.Longer.Name.Dep",
 					Version:   "4.5.4",
 					Locations: []string{"testdata/valid/packages.lock.json"},

--- a/extractor/filesystem/language/javascript/packagejson/extractor_test.go
+++ b/extractor/filesystem/language/javascript/packagejson/extractor_test.go
@@ -145,7 +145,7 @@ func TestExtract(t *testing.T) {
 			name: "top level package.json",
 			path: "testdata/package.json",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "testdata",
 					Version:   "10.46.8",
 					Locations: []string{"testdata/package.json"},
@@ -163,17 +163,17 @@ func TestExtract(t *testing.T) {
 			name: "accepts",
 			path: "testdata/deps/accepts/package.json",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "accepts",
 					Version:   "1.3.8",
 					Locations: []string{"testdata/deps/accepts/package.json"},
 					Metadata: &packagejson.JavascriptPackageJSONMetadata{
 						Contributors: []*packagejson.Person{
-							&packagejson.Person{
+							{
 								Name:  "Douglas Christopher Wilson",
 								Email: "doug@somethingdoug.com",
 							},
-							&packagejson.Person{
+							{
 								Name:  "Jonathan Ong",
 								Email: "me@jongleberry.com",
 								URL:   "http://jongleberry.com",
@@ -187,13 +187,13 @@ func TestExtract(t *testing.T) {
 			name: "no person name",
 			path: "testdata/deps/no-person-name/package.json",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "accepts",
 					Version:   "1.3.8",
 					Locations: []string{"testdata/deps/no-person-name/package.json"},
 					Metadata: &packagejson.JavascriptPackageJSONMetadata{
 						Contributors: []*packagejson.Person{
-							&packagejson.Person{
+							{
 								Name:  "Jonathan Ong",
 								Email: "me@jongleberry.com",
 								URL:   "http://jongleberry.com",
@@ -207,17 +207,17 @@ func TestExtract(t *testing.T) {
 			name: "nested acorn",
 			path: "testdata/deps/with/deps/acorn/package.json",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "acorn",
 					Version:   "1.2.2",
 					Locations: []string{"testdata/deps/with/deps/acorn/package.json"},
 					Metadata: &packagejson.JavascriptPackageJSONMetadata{
 						Maintainers: []*packagejson.Person{
-							&packagejson.Person{
+							{
 								Name:  "Marijn Haverbeke",
 								Email: "marijnh@gmail.com",
 							},
-							&packagejson.Person{
+							{
 								Name:  "Ingvar Stepanyan",
 								Email: "me@rreverser.com",
 							},
@@ -260,7 +260,7 @@ func TestExtract(t *testing.T) {
 			name: "Undici package with nonstandard contributors parsed correctly",
 			path: "testdata/undici-package.json",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "undici",
 					Version: "5.28.3",
 					Locations: []string{
@@ -268,15 +268,15 @@ func TestExtract(t *testing.T) {
 					},
 					Metadata: &packagejson.JavascriptPackageJSONMetadata{
 						Contributors: []*packagejson.Person{
-							&packagejson.Person{
+							{
 								Name: "Daniele Belardi",
 								URL:  "https://github.com/dnlup",
 							},
-							&packagejson.Person{
+							{
 								Name: "Tomas Della Vedova",
 								URL:  "https://github.com/delvedor",
 							},
-							&packagejson.Person{
+							{
 								Name: "Invalid URL NoCrash",
 							},
 						},
@@ -288,7 +288,7 @@ func TestExtract(t *testing.T) {
 			name: "npm package with engine field set",
 			path: "testdata/not-vscode.json",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "jsonparse",
 					Version:   "1.3.1",
 					Locations: []string{"testdata/not-vscode.json"},

--- a/extractor/filesystem/language/ruby/gemspec/extractor_test.go
+++ b/extractor/filesystem/language/ruby/gemspec/extractor_test.go
@@ -133,7 +133,7 @@ func TestExtract(t *testing.T) {
 			name: "yaml gemspec",
 			path: "testdata/yaml-0.2.1.gemspec",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "yaml",
 					Version:   "0.2.1",
 					Locations: []string{"testdata/yaml-0.2.1.gemspec"},
@@ -145,7 +145,7 @@ func TestExtract(t *testing.T) {
 			name: "rss gemspec",
 			path: "testdata/rss-0.2.9.gemspec",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "rss",
 					Version:   "0.2.9",
 					Locations: []string{"testdata/rss-0.2.9.gemspec"},

--- a/extractor/filesystem/os/cos/extractor_test.go
+++ b/extractor/filesystem/os/cos/extractor_test.go
@@ -155,7 +155,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/single.json",
 			osrelease: cosOSRlease,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "python-exec",
 					Version:   "17162.336.16",
 					Locations: []string{"testdata/single.json"},
@@ -175,7 +175,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/multiple.json",
 			osrelease: cosOSRlease,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "python-exec",
 					Version:   "17162.336.16",
 					Locations: []string{"testdata/multiple.json"},
@@ -187,7 +187,7 @@ func TestExtract(t *testing.T) {
 						OSVersionID: "101",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "zlib",
 					Version:   "17162.336.17",
 					Locations: []string{"testdata/multiple.json"},
@@ -199,7 +199,7 @@ func TestExtract(t *testing.T) {
 						OSVersionID: "101",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "baselayout",
 					Version:   "17162.336.18",
 					Locations: []string{"testdata/multiple.json"},
@@ -211,7 +211,7 @@ func TestExtract(t *testing.T) {
 						OSVersionID: "101",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "ncurses",
 					Version:   "17162.336.19",
 					Locations: []string{"testdata/multiple.json"},
@@ -231,7 +231,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/single.json",
 			osrelease: cosOSRleaseNoVersionID,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "python-exec",
 					Version:   "17162.336.16",
 					Locations: []string{"testdata/single.json"},
@@ -249,7 +249,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/single.json",
 			osrelease: cosOSRleaseNoVersions,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "python-exec",
 					Version:   "17162.336.16",
 					Locations: []string{"testdata/single.json"},

--- a/extractor/filesystem/os/dpkg/extractor_test.go
+++ b/extractor/filesystem/os/dpkg/extractor_test.go
@@ -196,7 +196,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/valid",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "accountsservice",
 					Version: "22.08.8-6",
 					Metadata: &dpkg.Metadata{
@@ -211,7 +211,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/valid"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "acl",
 					Version: "2.3.1-3",
 					Metadata: &dpkg.Metadata{
@@ -226,7 +226,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/valid"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "adduser",
 					Version: "3.131",
 					Metadata: &dpkg.Metadata{
@@ -241,7 +241,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/valid"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "admin-session",
 					Version: "2023.06.26.c543406313-00",
 					Metadata: &dpkg.Metadata{
@@ -256,7 +256,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/valid"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "attr",
 					Version: "1:2.5.1-4",
 					Metadata: &dpkg.Metadata{
@@ -272,7 +272,7 @@ func TestExtract(t *testing.T) {
 					Locations: []string{"testdata/valid"},
 				},
 				// Expect source name.
-				&extractor.Inventory{
+				{
 					Name:    "libacl1",
 					Version: "2.3.1-3",
 					Metadata: &dpkg.Metadata{
@@ -289,7 +289,7 @@ func TestExtract(t *testing.T) {
 					Locations: []string{"testdata/valid"},
 				},
 				// Expect source name and version.
-				&extractor.Inventory{
+				{
 					Name:    "util-linux-extra",
 					Version: "2.38.1-5+b1",
 					Metadata: &dpkg.Metadata{
@@ -314,7 +314,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/noversion",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "foo",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -327,7 +327,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/noversion"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "bar",
 					Version: "2.0",
 					Metadata: &dpkg.Metadata{
@@ -349,7 +349,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/nopackage",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "foo",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -362,7 +362,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/nopackage"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "bar",
 					Version: "2.0",
 					Metadata: &dpkg.Metadata{
@@ -384,7 +384,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/statusfield",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "wantinstall_installed",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -397,7 +397,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/statusfield"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "wantdeinstall_installed",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -410,7 +410,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/statusfield"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "wantpurge_installed",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -435,7 +435,7 @@ func TestExtract(t *testing.T) {
 				IncludeNotInstalled: true,
 			},
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "wantinstall_installed",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -448,7 +448,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/statusfield"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "wantdeinstall_installed",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -461,7 +461,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/statusfield"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "wantdeinstall_configfiles",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -474,7 +474,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/statusfield"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "wantinstall_unpacked",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -487,7 +487,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/statusfield"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "wantpurge_installed",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -500,7 +500,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/statusfield"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "wantinstall_halfinstalled",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -513,7 +513,7 @@ func TestExtract(t *testing.T) {
 					},
 					Locations: []string{"testdata/statusfield"},
 				},
-				&extractor.Inventory{
+				{
 					Name:    "wantnostatus",
 					Version: "1.0",
 					Metadata: &dpkg.Metadata{
@@ -549,7 +549,7 @@ func TestExtract(t *testing.T) {
 			osrelease: `VERSION_ID="12"
 			ID=debian`,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "acl",
 					Version: "2.3.1-3",
 					Metadata: &dpkg.Metadata{
@@ -571,7 +571,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/single",
 			osrelease: `ID=debian`,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "acl",
 					Version: "2.3.1-3",
 					Metadata: &dpkg.Metadata{
@@ -592,7 +592,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/single",
 			osrelease: "VERSION_CODENAME=bookworm",
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "acl",
 					Version: "2.3.1-3",
 					Metadata: &dpkg.Metadata{
@@ -616,7 +616,7 @@ func TestExtract(t *testing.T) {
 			ID=ubuntu
 			ID_LIKE=debian`,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "acl",
 					Version: "2.3.1-3",
 					Metadata: &dpkg.Metadata{
@@ -642,7 +642,7 @@ func TestExtract(t *testing.T) {
 			ID=ubuntu
 			ID_LIKE=debian`,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "acl",
 					Version: "2.3.1-3",
 					Metadata: &dpkg.Metadata{
@@ -667,7 +667,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/status.d/foo",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "foo",
 					Version: "1.2.3",
 					Metadata: &dpkg.Metadata{
@@ -697,7 +697,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/transitional",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "iceweasel",
 					Version: "78.13.0esr-1~deb10u1",
 					Metadata: &dpkg.Metadata{
@@ -842,7 +842,7 @@ func (l *testLogger) Debug(args ...any) {
 func TestExtractNonexistentOSRelease(t *testing.T) {
 	path := "testdata/single"
 	want := []*extractor.Inventory{
-		&extractor.Inventory{
+		{
 			Name:    "acl",
 			Version: "2.3.1-3",
 			Metadata: &dpkg.Metadata{

--- a/extractor/filesystem/os/flatpak/extractor_test.go
+++ b/extractor/filesystem/os/flatpak/extractor_test.go
@@ -154,7 +154,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/valid.xml",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "org.gimp.GIMP",
 					Version: "2.10.38",
 					Metadata: &flatpak.Metadata{
@@ -177,7 +177,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/noname.xml",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:    "org.gimp.GIMP",
 					Version: "2.10.38",
 					Metadata: &flatpak.Metadata{

--- a/extractor/filesystem/os/homebrew/extractor.go
+++ b/extractor/filesystem/os/homebrew/extractor.go
@@ -89,7 +89,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		return []*extractor.Inventory{}, nil
 	}
 	return []*extractor.Inventory{
-		&extractor.Inventory{
+		{
 			Name:      p.AppName,
 			Version:   p.AppVersion,
 			Locations: []string{input.Path},

--- a/extractor/filesystem/os/homebrew/extractor_test.go
+++ b/extractor/filesystem/os/homebrew/extractor_test.go
@@ -167,7 +167,7 @@ func TestToPURL(t *testing.T) {
 		{
 			name: "cask_firefox",
 			inventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "firefox",
 					Version:   "129.0",
 					Locations: []string{"System/Volumes/Data/usr/local/Caskroom/firefox/129.0/firefox.wrapper.sh"},

--- a/extractor/filesystem/os/rpm/extractor_test.go
+++ b/extractor/filesystem/os/rpm/extractor_test.go
@@ -193,7 +193,7 @@ func TestExtract(t *testing.T) {
 			osrelease:        fedora38,
 			wantResultMetric: stats.FileExtractedResultSuccess,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/Packages.db"},
 					Name:      "aaa_base",
 					Version:   "84.87+git20180409.04c9dae-150300.10.3.1",
@@ -209,7 +209,7 @@ func TestExtract(t *testing.T) {
 						License:      "GPL-2.0+",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/Packages.db"},
 					Name:      "bash",
 					Version:   "4.4-150400.25.22",
@@ -225,7 +225,7 @@ func TestExtract(t *testing.T) {
 						License:      "GPL-3.0-or-later",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/Packages.db"},
 					Name:      "bash-sh",
 					Version:   "4.4-150400.25.22",
@@ -251,7 +251,7 @@ func TestExtract(t *testing.T) {
 			osrelease:        fedora38,
 			wantResultMetric: stats.FileExtractedResultSuccess,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/Packages"},
 					Name:      "acl",
 					Version:   "2.2.51-15.el7",
@@ -267,7 +267,7 @@ func TestExtract(t *testing.T) {
 						License:      "GPLv2+",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/Packages"},
 					Name:      "audit-libs",
 					Version:   "2.8.5-4.el7",
@@ -283,7 +283,7 @@ func TestExtract(t *testing.T) {
 						License:      "LGPLv2+",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/Packages"},
 					Name:      "basesystem",
 					Version:   "10.0-7.el7.centos",
@@ -342,7 +342,7 @@ func TestExtract(t *testing.T) {
 			osrelease:        fedora38,
 			wantResultMetric: stats.FileExtractedResultSuccess,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/rpmdb.sqlite"},
 					Name:      "alternatives",
 					Version:   "1.20-2.el9",
@@ -358,7 +358,7 @@ func TestExtract(t *testing.T) {
 						License:      "GPLv2",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/rpmdb.sqlite"},
 					Name:      "audit-libs",
 					Version:   "3.0.7-103.el9",
@@ -374,7 +374,7 @@ func TestExtract(t *testing.T) {
 						License:      "LGPLv2+",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/rpmdb.sqlite"},
 					Name:      "basesystem",
 					Version:   "11-13.el9",
@@ -401,7 +401,7 @@ func TestExtract(t *testing.T) {
 			BUILD_ID=asdf`,
 			wantResultMetric: stats.FileExtractedResultSuccess,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/rpmdb.sqlite"},
 					Name:      "alternatives",
 					Version:   "1.20-2.el9",
@@ -416,7 +416,7 @@ func TestExtract(t *testing.T) {
 						License:      "GPLv2",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/rpmdb.sqlite"},
 					Name:      "audit-libs",
 					Version:   "3.0.7-103.el9",
@@ -431,7 +431,7 @@ func TestExtract(t *testing.T) {
 						License:      "LGPLv2+",
 					},
 				},
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/rpmdb.sqlite"},
 					Name:      "basesystem",
 					Version:   "11-13.el9",
@@ -463,7 +463,7 @@ func TestExtract(t *testing.T) {
 			CPE_NAME="cpe:/o:fedoraproject:fedora:32"`,
 			wantResultMetric: stats.FileExtractedResultSuccess,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Locations: []string{"testdata/Packages"},
 					Name:      "hello",
 					Version:   "0.0.1-rls",

--- a/extractor/filesystem/os/snap/extractor_test.go
+++ b/extractor/filesystem/os/snap/extractor_test.go
@@ -167,7 +167,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/single-arch.yaml",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "core",
 					Version:   "16-2.61.4-20240607",
 					Locations: []string{"testdata/single-arch.yaml"},
@@ -190,7 +190,7 @@ func TestExtract(t *testing.T) {
 			path:      "testdata/multi-arch.yaml",
 			osrelease: DebianBookworm,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "core",
 					Version:   "16-2.61.4-20240607",
 					Locations: []string{"testdata/multi-arch.yaml"},

--- a/extractor/filesystem/osv/osv_test.go
+++ b/extractor/filesystem/osv/osv_test.go
@@ -173,25 +173,25 @@ func TestExtract(t *testing.T) {
 			extractor: MockExtractor{},
 			purlType:  purl.TypeDebian,
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "reader content",
 					Version:   "1.0",
 					Metadata:  &osv.Metadata{PURLType: purl.TypeDebian},
 					Locations: []string{"targetfile"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "yolo content",
 					Version:   "2.0",
 					Metadata:  &osv.Metadata{PURLType: purl.TypeDebian},
 					Locations: []string{"targetfile"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "foobar content",
 					Version:   "3.0",
 					Metadata:  &osv.Metadata{PURLType: purl.TypeDebian},
 					Locations: []string{"targetfile"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "targetfile",
 					Version:   "4.0",
 					Metadata:  &osv.Metadata{PURLType: purl.TypeDebian},

--- a/extractor/standalone/containers/containerd/containerd_test.go
+++ b/extractor/standalone/containers/containerd/containerd_test.go
@@ -47,7 +47,7 @@ func TestExtract(t *testing.T) {
 		{
 			name:          "valid with no tasks",
 			onGoos:        []string{"linux"},
-			nssTaskIds:    map[string][]string{"default": []string{}, "k8s.io": []string{}},
+			nssTaskIds:    map[string][]string{"default": {}, "k8s.io": {}},
 			tsks:          []*task.Process{},
 			ctrs:          []containerd.Container{},
 			wantInventory: []*extractor.Inventory{},
@@ -55,11 +55,11 @@ func TestExtract(t *testing.T) {
 		{
 			name:       "valid with tasks and rootfs",
 			onGoos:     []string{"linux"},
-			nssTaskIds: map[string][]string{"default": []string{"123456789"}, "k8s.io": []string{"567890123"}},
-			tsks:       []*task.Process{&task.Process{ID: "123456789", ContainerID: "", Pid: 12345}, &task.Process{ID: "567890123", ContainerID: "", Pid: 5678}},
+			nssTaskIds: map[string][]string{"default": {"123456789"}, "k8s.io": {"567890123"}},
+			tsks:       []*task.Process{{ID: "123456789", ContainerID: "", Pid: 12345}, {ID: "567890123", ContainerID: "", Pid: 5678}},
 			ctrs:       []containerd.Container{fakeclient.NewFakeContainer("123456789", "image1", "digest1", "/run/containerd/io.containerd.runtime.v2.task/default/123456789/rootfs"), fakeclient.NewFakeContainer("567890123", "image2", "digest2", "/run/containerd/io.containerd.runtime.v2.task/k8s.io/567890123/rootfs")},
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "image1",
 					Version:   "digest1",
 					Locations: []string{"/run/containerd/io.containerd.runtime.v2.task/default/123456789/rootfs"},
@@ -92,11 +92,11 @@ func TestExtract(t *testing.T) {
 		{
 			name:       "valid with tasks and no rootfs",
 			onGoos:     []string{"linux"},
-			nssTaskIds: map[string][]string{"default": []string{"123456789"}, "k8s.io": []string{"567890123"}},
-			tsks:       []*task.Process{&task.Process{ID: "123456789", ContainerID: "", Pid: 12345}, &task.Process{ID: "567890123", ContainerID: "", Pid: 5678}},
+			nssTaskIds: map[string][]string{"default": {"123456789"}, "k8s.io": {"567890123"}},
+			tsks:       []*task.Process{{ID: "123456789", ContainerID: "", Pid: 12345}, {ID: "567890123", ContainerID: "", Pid: 5678}},
 			ctrs:       []containerd.Container{fakeclient.NewFakeContainer("123456789", "image1", "digest1", ""), fakeclient.NewFakeContainer("567890123", "image2", "digest2", "")},
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "image1",
 					Version:   "digest1",
 					Locations: []string{"/run/containerd/io.containerd.runtime.v2.task/default/123456789/rootfs"},
@@ -129,11 +129,11 @@ func TestExtract(t *testing.T) {
 		{
 			name:       "valid with tasks and relative-path-only rootfs",
 			onGoos:     []string{"linux"},
-			nssTaskIds: map[string][]string{"default": []string{"123456788"}, "k8s.io": []string{"567890122"}},
-			tsks:       []*task.Process{&task.Process{ID: "123456788", ContainerID: "", Pid: 12346}, &task.Process{ID: "567890122", ContainerID: "", Pid: 5677}},
+			nssTaskIds: map[string][]string{"default": {"123456788"}, "k8s.io": {"567890122"}},
+			tsks:       []*task.Process{{ID: "123456788", ContainerID: "", Pid: 12346}, {ID: "567890122", ContainerID: "", Pid: 5677}},
 			ctrs:       []containerd.Container{fakeclient.NewFakeContainer("123456788", "image1", "digest1", "test/rootfs"), fakeclient.NewFakeContainer("567890122", "image2", "digest2", "test2/rootfs")},
 			wantInventory: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "image1",
 					Version:   "digest1",
 					Locations: []string{"/run/containerd/io.containerd.runtime.v2.task/default/123456788/test/rootfs"},

--- a/extractor/standalone/windows/dismpatch/dismparser/dism_parser_test.go
+++ b/extractor/standalone/windows/dismpatch/dismparser/dism_parser_test.go
@@ -37,42 +37,42 @@ func TestParse(t *testing.T) {
 	}
 
 	want := []DismPkg{
-		DismPkg{
+		{
 			PackageIdentity: "Microsoft-Windows-FodMetadata-Package~31bf3856ad364e35~amd64~~10.0.17763.1",
 			PackageVersion:  "10.0.17763.1",
 			State:           "Installed",
 			ReleaseType:     "Feature Pack",
 			InstallTime:     "9/15/2018 9:08 AM",
 		},
-		DismPkg{
+		{
 			PackageIdentity: "Package_for_KB4470788~31bf3856ad364e35~amd64~~17763.164.1.1",
 			PackageVersion:  "17763.164.1.1",
 			State:           "Installed",
 			ReleaseType:     "Security Update",
 			InstallTime:     "3/12/2019 6:27 AM",
 		},
-		DismPkg{
+		{
 			PackageIdentity: "Package_for_RollupFix~31bf3856ad364e35~amd64~~17763.3406.1.5",
 			PackageVersion:  "17763.3406.1.5",
 			State:           "Installed",
 			ReleaseType:     "Security Update",
 			InstallTime:     "9/13/2022 11:06 PM",
 		},
-		DismPkg{
+		{
 			PackageIdentity: "Package_for_RollupFix~31bf3856ad364e35~amd64~~17763.379.1.11",
 			PackageVersion:  "17763.379.1.11",
 			State:           "Superseded",
 			ReleaseType:     "Security Update",
 			InstallTime:     "3/12/2019 6:31 AM",
 		},
-		DismPkg{
+		{
 			PackageIdentity: "Package_for_ServicingStack_3232~31bf3856ad364e35~amd64~~17763.3232.1.1",
 			PackageVersion:  "17763.3232.1.1",
 			State:           "Installed",
 			ReleaseType:     "Update",
 			InstallTime:     "9/13/2022 10:46 PM",
 		},
-		DismPkg{
+		{
 			PackageIdentity: "Microsoft-Windows-WordPad-FoD-Package~31bf3856ad364e35~wow64~en-US~10.0.19041.1",
 			PackageVersion:  "10.0.19041.1",
 			State:           "Installed",

--- a/extractor/standalone/windows/dismpatch/extractor.go
+++ b/extractor/standalone/windows/dismpatch/extractor.go
@@ -32,7 +32,7 @@ func inventoryFromOutput(flavor, output string) ([]*extractor.Inventory, error) 
 	imgVersion = strings.TrimSpace(imgVersion)
 	windowsProduct := winproducts.WindowsProductFromVersion(flavor, imgVersion)
 	inventory := []*extractor.Inventory{
-		&extractor.Inventory{
+		{
 			Name:      windowsProduct,
 			Version:   imgVersion,
 			Locations: []string{"cmd-dism-osver"},

--- a/extractor/standalone/windows/dismpatch/extractor_test.go
+++ b/extractor/standalone/windows/dismpatch/extractor_test.go
@@ -42,37 +42,37 @@ func TestInventoryFromOutput(t *testing.T) {
 			flavor: "server",
 			output: string(dismTestData),
 			want: []*extractor.Inventory{
-				&extractor.Inventory{
+				{
 					Name:      "windows_server_2019",
 					Version:   "10.0.17763.3406",
 					Locations: []string{"cmd-dism-osver"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Microsoft-Windows-FodMetadata-Package~31bf3856ad364e35~amd64~~10.0.17763.1",
 					Version:   "10.0.17763.1",
 					Locations: []string{"cmd-dism"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Package_for_KB4470788~31bf3856ad364e35~amd64~~17763.164.1.1",
 					Version:   "17763.164.1.1",
 					Locations: []string{"cmd-dism"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Package_for_RollupFix~31bf3856ad364e35~amd64~~17763.3406.1.5",
 					Version:   "17763.3406.1.5",
 					Locations: []string{"cmd-dism"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Package_for_RollupFix~31bf3856ad364e35~amd64~~17763.379.1.11",
 					Version:   "17763.379.1.11",
 					Locations: []string{"cmd-dism"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Package_for_ServicingStack_3232~31bf3856ad364e35~amd64~~17763.3232.1.1",
 					Version:   "17763.3232.1.1",
 					Locations: []string{"cmd-dism"},
 				},
-				&extractor.Inventory{
+				{
 					Name:      "Microsoft-Windows-WordPad-FoD-Package~31bf3856ad364e35~wow64~en-US~10.0.19041.1",
 					Version:   "10.0.19041.1",
 					Locations: []string{"cmd-dism"},

--- a/extractor/standalone/windows/regosversion/extractor_windows.go
+++ b/extractor/standalone/windows/regosversion/extractor_windows.go
@@ -79,7 +79,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 	fullVersion := fmt.Sprintf("%s.%s.%d", currentVersion, buildNumber, revision)
 	winproduct := winproducts.WindowsProductFromVersion(flavor, fullVersion)
 	return []*extractor.Inventory{
-		&extractor.Inventory{
+		{
 			Name:      winproduct,
 			Version:   fullVersion,
 			Locations: []string{"registry"},

--- a/inventoryindex/inventory_index_test.go
+++ b/inventoryindex/inventory_index_test.go
@@ -37,9 +37,9 @@ func TestGetAll(t *testing.T) {
 	npmEx := packagejson.New(packagejson.DefaultConfig())
 	pipEx := wheelegg.New(wheelegg.DefaultConfig())
 	inv := []*extractor.Inventory{
-		&extractor.Inventory{Name: "software1", Extractor: npmEx},
-		&extractor.Inventory{Name: "software2", Extractor: pipEx},
-		&extractor.Inventory{Name: "software3", Extractor: pipEx},
+		{Name: "software1", Extractor: npmEx},
+		{Name: "software2", Extractor: pipEx},
+		{Name: "software3", Extractor: pipEx},
 	}
 	want := inv
 
@@ -58,13 +58,13 @@ func TestGetAllOfType(t *testing.T) {
 	npmEx := packagejson.New(packagejson.DefaultConfig())
 	pipEx := wheelegg.New(wheelegg.DefaultConfig())
 	inv := []*extractor.Inventory{
-		&extractor.Inventory{Name: "software1", Extractor: npmEx},
-		&extractor.Inventory{Name: "software2", Extractor: pipEx},
-		&extractor.Inventory{Name: "software3", Extractor: pipEx},
+		{Name: "software1", Extractor: npmEx},
+		{Name: "software2", Extractor: pipEx},
+		{Name: "software3", Extractor: pipEx},
 	}
 	want := []*extractor.Inventory{
-		&extractor.Inventory{Name: "software2", Extractor: pipEx},
-		&extractor.Inventory{Name: "software3", Extractor: pipEx},
+		{Name: "software2", Extractor: pipEx},
+		{Name: "software3", Extractor: pipEx},
 	}
 
 	ix, err := inventoryindex.New(inv)

--- a/scalibr_test.go
+++ b/scalibr_test.go
@@ -50,7 +50,7 @@ func TestScan(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	tmpRoot := []*scalibrfs.ScanRoot{&scalibrfs.ScanRoot{FS: scalibrfs.DirFS(tmp), Path: tmp}}
+	tmpRoot := []*scalibrfs.ScanRoot{{FS: scalibrfs.DirFS(tmp), Path: tmp}}
 	os.WriteFile(filepath.Join(tmp, "file.txt"), []byte("Content"), 0644)
 
 	invName := "software"
@@ -82,8 +82,8 @@ func TestScan(t *testing.T) {
 			want: &scalibr.ScanResult{
 				Status: success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{Name: "detector", Version: 2, Status: success},
-					&plugin.Status{Name: "python/wheelegg", Version: 1, Status: success},
+					{Name: "detector", Version: 2, Status: success},
+					{Name: "python/wheelegg", Version: 1, Status: success},
 				},
 				Inventories: []*extractor.Inventory{inventory},
 				Findings:    []*detector.Finding{withDetectorName(finding, "detector")},
@@ -107,8 +107,8 @@ func TestScan(t *testing.T) {
 					FailureReason: "multiple non-identical advisories with ID &{ CVE-1234}",
 				},
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{Name: "detector", Version: 2, Status: success},
-					&plugin.Status{Name: "detector", Version: 3, Status: success},
+					{Name: "detector", Version: 2, Status: success},
+					{Name: "detector", Version: 3, Status: success},
 				},
 				Inventories: []*extractor.Inventory{},
 				Findings:    []*detector.Finding{},
@@ -126,8 +126,8 @@ func TestScan(t *testing.T) {
 			want: &scalibr.ScanResult{
 				Status: success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{Name: "detector", Version: 2, Status: success},
-					&plugin.Status{Name: "python/wheelegg", Version: 1, Status: extFailure},
+					{Name: "detector", Version: 2, Status: success},
+					{Name: "python/wheelegg", Version: 1, Status: extFailure},
 				},
 				Inventories: nil,
 				Findings:    []*detector.Finding{withDetectorName(finding, "detector")},
@@ -145,8 +145,8 @@ func TestScan(t *testing.T) {
 			want: &scalibr.ScanResult{
 				Status: success,
 				PluginStatus: []*plugin.Status{
-					&plugin.Status{Name: "detector", Version: 2, Status: detFailure},
-					&plugin.Status{Name: "python/wheelegg", Version: 1, Status: success},
+					{Name: "detector", Version: 2, Status: detFailure},
+					{Name: "python/wheelegg", Version: 1, Status: success},
 				},
 				Inventories: []*extractor.Inventory{inventory},
 				Findings:    []*detector.Finding{},

--- a/testing/fakeextractor/fake_extractor_test.go
+++ b/testing/fakeextractor/fake_extractor_test.go
@@ -132,10 +132,10 @@ func TestFileRequired(t *testing.T) {
 func TestExtract(t *testing.T) {
 	name1 := "package"
 	name2 := "another package"
-	multipleInventories := []*extractor.Inventory{&extractor.Inventory{
+	multipleInventories := []*extractor.Inventory{{
 		Name:      name1,
 		Locations: []string{"some path"},
-	}, &extractor.Inventory{
+	}, {
 		Name:      name2,
 		Locations: []string{"some path"},
 	}}
@@ -154,7 +154,7 @@ func TestExtract(t *testing.T) {
 		{
 			name: "no results",
 			extractor: fakeextractor.New("", 1, nil, map[string]fakeextractor.NamesErr{
-				"some path": fakeextractor.NamesErr{nil, nil},
+				"some path": {nil, nil},
 			}),
 			args: args{context.Background(), &filesystem.ScanInput{Path: "some path"}},
 			want: []*extractor.Inventory{},
@@ -162,7 +162,7 @@ func TestExtract(t *testing.T) {
 		{
 			name: "multiple results",
 			extractor: fakeextractor.New("extractor name", 1, nil, map[string]fakeextractor.NamesErr{
-				"some path": fakeextractor.NamesErr{[]string{name1, name2}, nil},
+				"some path": {[]string{name1, name2}, nil},
 			}),
 			args: args{context.Background(), &filesystem.ScanInput{Path: "some path"}},
 			want: multipleInventories,
@@ -170,7 +170,7 @@ func TestExtract(t *testing.T) {
 		{
 			name: "unrecognized path throws an error",
 			extractor: fakeextractor.New("", 1, nil, map[string]fakeextractor.NamesErr{
-				"some path": fakeextractor.NamesErr{nil, nil},
+				"some path": {nil, nil},
 			}),
 			args:    args{context.Background(), &filesystem.ScanInput{Path: "another path"}},
 			wantErr: cmpopts.AnyError,


### PR DESCRIPTION
This is the result of manually running `gofmt -s -w .` in preparation for setting up `golangci-lint` to actually enforce this

Relates to #158