### PR TITLE
refactor: enable `misspell` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,7 +53,7 @@ linters:
     - loggercheck
     - makezero
     - mirror
-#    - misspell
+    - misspell
 #    - musttag
     - nakedret
 #    - nilerr

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ scalibr -spdx-document-name="Custom name" --spdx-document-namespace="Custom-name
 ## Running built-in plugins
 
 ### With the standalone binary
-The binary runs SCALIBR's "recommended" internal plugins by default. You can enable more plugins with the `--extractors=` and `--detectors=` flags. See the the definition files for a list of all built-in plugins and their CLI flags ([extractors (fs)](/extractor/filesystem/list/list.go#L26), [detectors](/detector/list/list.go#L26)).
+The binary runs SCALIBR's "recommended" internal plugins by default. You can enable more plugins with the `--extractors=` and `--detectors=` flags. See the definition files for a list of all built-in plugins and their CLI flags ([extractors (fs)](/extractor/filesystem/list/list.go#L26), [detectors](/detector/list/list.go#L26)).
 
 ### With the library
 A collection of all built-in plugin modules can be found in the definition files ([extractors](/extractor/filesystem/list/list.go#L26), [detectors](/detector/list/list.go#L26)). To enable them, just import the module and add the appropriate plugins to the scan config, e.g.

--- a/binary/cdx/cdx.go
+++ b/binary/cdx/cdx.go
@@ -22,7 +22,7 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 )
 
-// Write writes an CDX document into a file in the choosen format.
+// Write writes an CDX document into a file in the chosen format.
 func Write(doc *cyclonedx.BOM, path string, format string) error {
 	var cdxFormat cyclonedx.BOMFileFormat
 	switch format {

--- a/binary/cli/cli.go
+++ b/binary/cli/cli.go
@@ -54,7 +54,7 @@ func (i *Array) String() string {
 	return strings.Join(*i, ",")
 }
 
-// Set gets called whenever an a new instance of a flag is read during CLI arg parsing.
+// Set gets called whenever a new instance of a flag is read during CLI arg parsing.
 // For example, in the case of -o foo -o bar the library will call arr.Set("foo") then arr.Set("bar").
 func (i *Array) Set(value string) error {
 	*i = append(*i, strings.TrimSpace(value))
@@ -79,7 +79,7 @@ func NewStringListFlag(defaultValue []string) StringListFlag {
 	return StringListFlag{defaultValue: defaultValue}
 }
 
-// Set gets called whenever an a new instance of a flag is read during CLI arg parsing.
+// Set gets called whenever a new instance of a flag is read during CLI arg parsing.
 // For example, in the case of -o foo -o bar the library will call arr.Set("foo") then arr.Set("bar").
 func (s *StringListFlag) Set(x string) error {
 	s.value = append(s.value, strings.Split(x, ",")...)

--- a/detector/cve/cve202011978/detector.go
+++ b/detector/cve/cve202011978/detector.go
@@ -285,7 +285,7 @@ func CheckForPause(airflowIP string, airflowServerPort int) bool {
 	return resp.StatusCode == 200
 }
 
-// triggerandWaitForDAG achieves command execution via DAG scheduling using the example bash task from above.
+// triggerAndWaitForDAG achieves command execution via DAG scheduling using the example bash task from above.
 func triggerAndWaitForDAG(ctx context.Context, airflowIP string, airflowServerPort int) bool {
 	dagURL := fmt.Sprintf("http://%s:%d/api/experimental/dags/example_trigger_target_dag/dag_runs", airflowIP, airflowServerPort)
 	payload := map[string]any{

--- a/detector/weakcredentials/etcshadow/cracker_test.go
+++ b/detector/weakcredentials/etcshadow/cracker_test.go
@@ -24,7 +24,7 @@ import (
 // All the hashes below are for the string "Password123" and where obtained
 // running: 'mkpasswd -m METHOD PASSWORD'.
 //
-// Note the the obsolete descrypt will limit password to 8 characters and
+// Note the obsolete descrypt will limit password to 8 characters and
 // there will be cracked as the value 'Password'.
 var testHashes = map[string]string{
 	"yescrypt":      "$y$j9T$huXYrFRxr5.EtlA/GqJQg1$R36Nu5MbY5YM0SzRaWbBPyGpM7KMcWtbUmBq5gDZA9B",

--- a/detector/weakcredentials/winlocal/systemreg/systemreg.go
+++ b/detector/weakcredentials/winlocal/systemreg/systemreg.go
@@ -47,7 +47,7 @@ func NewFromFile(path string) (*SystemRegistry, error) {
 // Syskey returns the syskey used to decrypt user hashes.
 // The syskey is stored as UTF16-le encoded hexadecimal in the class name of the 4 registry keys
 // denoted by `syskeyPaths`. Once the hexadecimal is decoded, the result is still obfuscated and
-// the order of the bytes needs to be swapped using the indexes denotated in the `transforms` table.
+// the order of the bytes needs to be swapped using the indexes detonated in the `transforms` table.
 func (s *SystemRegistry) Syskey() ([]byte, error) {
 	currentSet, err := s.currentControlSet()
 	if err != nil {

--- a/extractor/filesystem/language/dart/pubspec/extractor.go
+++ b/extractor/filesystem/language/dart/pubspec/extractor.go
@@ -36,7 +36,7 @@ type pubspecLockDescription struct {
 
 var _ yaml.Unmarshaler = &pubspecLockDescription{}
 
-// UnmarshalYAML is a custom unmarshals function for pubspecLockDescription.
+// UnmarshalYAML is a custom unmarshalling function for pubspecLockDescription.
 // We need this because descriptions can have two different formats.
 func (pld *pubspecLockDescription) UnmarshalYAML(value *yaml.Node) error {
 	// Duplicating the struct to decode nested fields as a

--- a/extractor/filesystem/language/java/archive/manifest.go
+++ b/extractor/filesystem/language/java/archive/manifest.go
@@ -184,7 +184,7 @@ func getVersion(h textproto.MIMEHeader) string {
 		log.Debugf("  %s: %s\n", k, h.Get(k))
 	}
 
-	// Some versions contain extra information like the buld number or date.
+	// Some versions contain extra information like the build number or date.
 	// For example "1.4 1855 April 22 2006"
 	// We only want the first part.
 	version := getFirst(h, keys)

--- a/extractor/filesystem/language/javascript/pnpmlock/extractor.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/extractor.go
@@ -59,7 +59,7 @@ type pnpmLockfileV6 struct {
 	Packages map[string]pnpmLockPackage `yaml:"packages,omitempty"`
 }
 
-// UnmarshalYAML is a custom unmarshaling function for handling v6 lockfiles.
+// UnmarshalYAML is a custom unmarshalling function for handling v6 lockfiles.
 func (l *pnpmLockfile) UnmarshalYAML(unmarshal func(any) error) error {
 	var lockfileV6 pnpmLockfileV6
 


### PR DESCRIPTION
Enabling this linter actually only caught "choosen" but I also ran my IDEs spell/grammer checker which found a few more things

Relates to #152
Relates to #274