### PR TITLE
chore: enable `gochecknoinits` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,7 +31,7 @@ linters:
 #    - forbidigo
     - ginkgolinter
     - gocheckcompilerdirectives
-#    - gochecknoinits
+    - gochecknoinits
     - gochecksumtype
 #    - gocritic
 #    - gofmt

--- a/binary/cdx/cdx_test.go
+++ b/binary/cdx/cdx_test.go
@@ -28,6 +28,7 @@ import (
 
 var doc *cyclonedx.BOM
 
+//nolint:gochecknoinits
 func init() {
 	doc = cyclonedx.NewBOM()
 	doc.Metadata = &cyclonedx.Metadata{

--- a/detector/list/list.go
+++ b/detector/list/list.go
@@ -68,6 +68,7 @@ var detectorNames = map[string][]detector.Detector{
 	"all":         All,
 }
 
+//nolint:gochecknoinits
 func init() {
 	for _, d := range All {
 		register(d)

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -178,6 +178,7 @@ var (
 
 // LINT.ThenChange(/docs/supported_inventory_types.md)
 
+//nolint:gochecknoinits
 func init() {
 	for _, e := range All {
 		register(e)

--- a/extractor/standalone/list/list.go
+++ b/extractor/standalone/list/list.go
@@ -66,6 +66,7 @@ var (
 	}
 )
 
+//nolint:gochecknoinits
 func init() {
 	for _, e := range All {
 		register(e)


### PR DESCRIPTION
This enables the `gochecknoinits` linter to strong discourage the usage of `init` functions as while they do sometimes have their usages (and are even necessary), overuse tends to lead to very brittle code.

Relates to #274