### PR TITLE
refactor: enable `ineffassign` and `wastedassign` linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,7 +47,7 @@ linters:
     - grouper
     - importas
 #    - inamedparam
-#    - ineffassign
+    - ineffassign
     - interfacebloat
 #    - intrange
     - loggercheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -86,7 +86,7 @@ linters:
 #    - unparam
 #    - unused
 #    - usestdlibvars
-#    - wastedassign
+    - wastedassign
     - whitespace
     - zerologlint
   disable-all: true

--- a/binary/proto/proto.go
+++ b/binary/proto/proto.go
@@ -78,7 +78,7 @@ func typeForPath(filePath string) (*fileType, error) {
 		}
 	}
 
-	isBinProto := false
+	var isBinProto bool
 	switch ext {
 	case ".binproto":
 		isBinProto = true

--- a/extractor/filesystem/os/rpm/rpm_test.go
+++ b/extractor/filesystem/os/rpm/rpm_test.go
@@ -146,8 +146,8 @@ func TestFileRequired(t *testing.T) {
 				wantResultMetric = stats.FileRequiredResultOK
 			}
 			gotResultMetric := collector.FileRequiredResult(tt.path)
-			if tt.wantResultMetric != "" && gotResultMetric != tt.wantResultMetric {
-				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			if wantResultMetric != "" && gotResultMetric != wantResultMetric {
+				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, wantResultMetric)
 			}
 		})
 	}

--- a/extractor/standalone/containers/containerd/containerd_linux.go
+++ b/extractor/standalone/containers/containerd/containerd_linux.go
@@ -135,7 +135,6 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 		// and reset it in the extractor.
 		cli, err := containerd.New(e.socketAddr)
 		if err != nil {
-			cli = nil
 			log.Errorf("Failed to connect to containerd socket %v, error: %v", e.socketAddr, err)
 			return inventory, err
 		}


### PR DESCRIPTION
This enables linters for ensuring that the result of assignments are actually used - I'm not actually sure of the difference between the two, but they both seem to be enabled by default and very quick, so I don't think it's a huge issue to have both

Relates to #274