### PR TITLE
refactor: enable `predeclared` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,7 +65,7 @@ linters:
 #    - paralleltest
 #    - perfsprint
 #    - prealloc
-#    - predeclared
+    - predeclared
     - promlinter
 #    - protogetter
     - reassign

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -169,7 +169,7 @@ func TestRun(t *testing.T) {
 }
 
 func withDetectorName(f *detector.Finding, det string) *detector.Finding {
-	copy := *f
-	copy.Detectors = []string{det}
-	return &copy
+	c := *f
+	c.Detectors = []string{det}
+	return &c
 }

--- a/scalibr_test.go
+++ b/scalibr_test.go
@@ -185,9 +185,9 @@ func TestScan(t *testing.T) {
 }
 
 func withDetectorName(f *detector.Finding, det string) *detector.Finding {
-	copy := *f
-	copy.Detectors = []string{det}
-	return &copy
+	c := *f
+	c.Detectors = []string{det}
+	return &c
 }
 
 func TestEnableRequiredExtractors(t *testing.T) {

--- a/testing/fakedetector/fake_detector.go
+++ b/testing/fakedetector/fake_detector.go
@@ -38,15 +38,15 @@ type fakeDetector struct {
 //
 // The detector returns the specified Finding or error.
 func New(name string, version int, finding *detector.Finding, err error) detector.Detector {
-	var copy *detector.Finding
+	var c *detector.Finding
 	if finding != nil {
-		copy = &detector.Finding{}
-		*copy = *finding
+		c = &detector.Finding{}
+		*c = *finding
 	}
 	return &fakeDetector{
 		DetName:    name,
 		DetVersion: version,
-		Finding:    copy,
+		Finding:    c,
 		Err:        err,
 	}
 }


### PR DESCRIPTION
This enables the `predeclared` linter which catches variables whose names clash with predeclared identifiers, as that can be confusing.

Currently the only violation was a few variables being named `copy` which I've renamed to `c` since they have a very short local lifespan

Relates to #152
Relates to #274