### PR TITLE
ci: increase timeout for golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.61.0
+          args: --timeout=5m
   tests:
     strategy:
       matrix:


### PR DESCRIPTION
Due to the size of this codebase, `golangci-lint` requires more time to compile everything and run the linters - hopefully 5 minutes will be enough