### PR TITLE
refactor: enable `whitespace` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -87,6 +87,6 @@ linters:
 #    - unused
 #    - usestdlibvars
 #    - wastedassign
-#    - whitespace
+    - whitespace
     - zerologlint
   disable-all: true

--- a/artifact/image/layerscanning/image_test.go
+++ b/artifact/image/layerscanning/image_test.go
@@ -328,7 +328,6 @@ func TestLoadFrom(t *testing.T) {
 
 				compareChainLayerEntries(t, chainLayer, wantChainLayerEntries)
 			}
-
 		})
 	}
 }

--- a/artifact/image/layerscanning/layer_test.go
+++ b/artifact/image/layerscanning/layer_test.go
@@ -72,7 +72,6 @@ func (fakeV1Layer *fakeV1Layer) MediaType() (types.MediaType, error) {
 }
 
 func TestConvertV1Layer(t *testing.T) {
-
 	reader := io.NopCloser(nil)
 	tests := []struct {
 		name      string
@@ -306,7 +305,6 @@ func TestChainFSOpen(t *testing.T) {
 			if diff := cmp.Diff(gotFile, tc.wantNode, cmp.AllowUnexported(fileNode{})); tc.wantNode != nil && diff != "" {
 				t.Errorf("Open(%v) returned file: %v, want file: %v", tc.path, gotFile, tc.wantNode)
 			}
-
 		})
 	}
 }

--- a/artifact/image/symlink/symlink.go
+++ b/artifact/image/symlink/symlink.go
@@ -198,7 +198,6 @@ func removeLayerPathPrefix(path, layerPath string) string {
 // For example, if a symlink with path `a/symlink.txt“ points to “../../file.text“, then
 // this function would return true because the target file is outside of the root directory.
 func TargetOutsideRoot(path, target string) bool {
-
 	// Create a marker directory as root to check if the target path is outside of the root directory.
 	markerDir := uuid.New().String()
 	if filepath.IsAbs(target) {

--- a/artifact/image/symlink/symlink_test.go
+++ b/artifact/image/symlink/symlink_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestTargetOutsideRoot(t *testing.T) {
-
 	tests := []struct {
 		name   string
 		path   string
@@ -78,5 +77,4 @@ func TestTargetOutsideRoot(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/artifact/image/tar/tar.go
+++ b/artifact/image/tar/tar.go
@@ -28,7 +28,6 @@ import (
 
 // SaveToTarball saves a container image to a tarball.
 func SaveToTarball(path string, image v1.Image) error {
-
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create tar file %q: %w", path, err)

--- a/artifact/image/tar/tar_test.go
+++ b/artifact/image/tar/tar_test.go
@@ -80,7 +80,6 @@ func filesMatch(t *testing.T, path1, path2 string) bool {
 }
 
 func mustHashFile(t *testing.T, path string) string {
-
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("os.Open(%q) error: %v", path, err)

--- a/artifact/image/unpack/unpack.go
+++ b/artifact/image/unpack/unpack.go
@@ -121,7 +121,6 @@ func (cfg *UnpackerConfig) WithRequirer(requirer require.FileRequirer) *Unpacker
 
 // NewUnpacker creates a new Unpacker.
 func NewUnpacker(cfg *UnpackerConfig) (*Unpacker, error) {
-
 	if cfg.SymlinkResolution == "" {
 		return nil, errors.New("cfg.SymlinkResolution was not specified")
 	}
@@ -226,7 +225,6 @@ func (u *Unpacker) UnpackSquashedFromTarball(dir string, tarPath string) error {
 // Each layer is unpacked into a subdirectory of dir where the sub-directory name is the layer digest.
 // The returned list contains the digests of the image layers from in order oldest/base layer first, and most-recent/top layer last.
 func (u *Unpacker) UnpackLayers(dir string, image v1.Image) ([]string, error) {
-
 	if u.SymlinkResolution == SymlinkIgnore {
 		return nil, fmt.Errorf("symlink resolution strategy %q is not supported", u.SymlinkResolution)
 	}
@@ -292,7 +290,6 @@ func (u *Unpacker) UnpackLayers(dir string, image v1.Image) ([]string, error) {
 }
 
 func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, symlinkErrStrategy SymlinkErrStrategy, requirer require.FileRequirer, requiredTargets map[string]bool, finalPass bool, maxSizeBytes int64) (map[string]bool, error) {
-
 	tarReader := tar.NewReader(reader)
 
 	// Defensive copy of requiredTargets to avoid modifying the original.

--- a/artifact/image/unpack/unpack_test.go
+++ b/artifact/image/unpack/unpack_test.go
@@ -293,7 +293,6 @@ func TestUnpackSquashed(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			defer os.RemoveAll(tc.dir)
 			u := mustNewUnpacker(t, tc.cfg)
 			gotErr := u.UnpackSquashed(tc.dir, tc.image)
@@ -438,7 +437,6 @@ func TestUnpackLayers(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			u := mustNewUnpacker(t, test.cfg)
 
 			defer os.RemoveAll(test.dir)
@@ -586,7 +584,6 @@ func mustReadSubDirs(t *testing.T, dir string) []digestAndContent {
 // This image may not contain parent directories because it is constructed from an intermediate tarball.
 // This is useful for testing the parent directory creation logic of unpack.
 func mustNewSquashedImage(t *testing.T, pathsToContent map[string]contentAndMode) v1.Image {
-
 	// Squash layers into a single layer.
 	files := make(map[string]contentAndMode)
 	for path, contentAndMode := range pathsToContent {

--- a/detector/weakcredentials/filebrowser/filebrowser.go
+++ b/detector/weakcredentials/filebrowser/filebrowser.go
@@ -102,7 +102,6 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	}
 
 	return nil, nil
-
 }
 
 func isVulnerable(ctx context.Context, fileBrowserIP string, fileBrowserPort int) bool {
@@ -164,7 +163,6 @@ func checkAccessibility(ctx context.Context, fileBrowserIP string, fileBrowserPo
 
 // checkLogin checks if the login with default credentials is successful.
 func checkLogin(ctx context.Context, fileBrowserIP string, fileBrowserPort int) bool {
-
 	client := &http.Client{Timeout: requestTimeout}
 	targetURL := fmt.Sprintf("http://%s:%d/api/login", fileBrowserIP, fileBrowserPort)
 

--- a/extractor/filesystem/language/java/groupid/groupid_test.go
+++ b/extractor/filesystem/language/java/groupid/groupid_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestFromArtifactID(t *testing.T) {
-
 	tests := []struct {
 		name       string
 		artifactID string

--- a/extractor/filesystem/language/javascript/packagejson/packagejson_test.go
+++ b/extractor/filesystem/language/javascript/packagejson/packagejson_test.go
@@ -313,7 +313,6 @@ func TestExtract(t *testing.T) {
 	for _, tt := range tests {
 		// Note the subtest here
 		t.Run(tt.name, func(t *testing.T) {
-
 			r, err := os.Open(tt.path)
 			defer func() {
 				if err = r.Close(); err != nil {

--- a/extractor/filesystem/os/macapps/macapps_test.go
+++ b/extractor/filesystem/os/macapps/macapps_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestFileRequired(t *testing.T) {
-
 	tests := []struct {
 		name             string
 		path             string
@@ -130,7 +129,6 @@ func TestFileRequired(t *testing.T) {
 }
 
 func TestExtract(t *testing.T) {
-
 	tests := []struct {
 		name             string
 		path             string

--- a/extractor/standalone/containers/containerd/containerd_linux.go
+++ b/extractor/standalone/containers/containerd/containerd_linux.go
@@ -238,7 +238,6 @@ func taskMetadata(ctx context.Context, client CtrdClient, task *task.Process, na
 	if err != nil {
 		log.Errorf("Failed to obtain container info for container %v, error: %v", task.ID, err)
 		return md, err
-
 	}
 
 	image, err := container.Image(ctx)

--- a/extractor/standalone/containers/containerd/fakeclient/fake_containerd_client.go
+++ b/extractor/standalone/containers/containerd/fakeclient/fake_containerd_client.go
@@ -211,7 +211,6 @@ func (c *Container) Info(ctx context.Context, opts ...containerd.InfoOpts) (cont
 
 func (c *Container) Task(context.Context, cio.Attach) (containerd.Task, error) {
 	return NewFakeTask(c.rootfs), nil
-
 }
 
 // Image returns the underlying container Image object with a given digest.

--- a/testing/fakeextractor/fake_extractor.go
+++ b/testing/fakeextractor/fake_extractor.go
@@ -50,7 +50,6 @@ var AllowUnexported = cmp.AllowUnexported(fakeExtractor{})
 // The fakeExtractor returns FileRequired(path) = true for any path in requiredFiles.
 // The fakeExtractor returns the inventory and error from pathToNamesErr given the same path to Extract(...).
 func New(name string, version int, requiredFiles []string, pathToNamesErr map[string]NamesErr) filesystem.Extractor {
-
 	rfs := map[string]bool{}
 	for _, path := range requiredFiles {
 		rfs[path] = true


### PR DESCRIPTION
This enables the `whitespace` linter, which helps to keep code consistent by reporting unnecessary newlines at the start and end of bodies for functions, ifs, fors, etc

Relates to #274