### PR TITLE
refactor: enable `copyloopvar` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,7 @@ linters:
     - canonicalheader
 #    - containedctx
 #    - contextcheck
-#    - copyloopvar
+    - copyloopvar
     - decorder
 #    - depguard
     - dogsled

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v1-revisions_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v1-revisions_test.go
@@ -160,7 +160,6 @@ func TestExtractor_Extract_v1_revisions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := conanlock.Extractor{}

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
@@ -232,7 +232,6 @@ func TestExtractor_Extract_v1(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := conanlock.Extractor{}

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v2_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v2_test.go
@@ -159,7 +159,6 @@ func TestExtractor_Extract_v2(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := conanlock.Extractor{}

--- a/extractor/filesystem/language/cpp/conanlock/conanlock_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock_test.go
@@ -56,7 +56,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := conanlock.Extractor{}

--- a/extractor/filesystem/language/erlang/mixlock/mixlock_test.go
+++ b/extractor/filesystem/language/erlang/mixlock/mixlock_test.go
@@ -327,7 +327,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			extr := mixlock.Extractor{}
 

--- a/extractor/filesystem/language/java/gradlelockfile/gradlelockfile_test.go
+++ b/extractor/filesystem/language/java/gradlelockfile/gradlelockfile_test.go
@@ -207,7 +207,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := gradlelockfile.Extractor{}

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
@@ -453,7 +453,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := gradleverificationmetadataxml.Extractor{}

--- a/extractor/filesystem/language/java/pomxml/pomxml_test.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml_test.go
@@ -251,7 +251,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := pomxml.Extractor{}

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock-v9_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock-v9_test.go
@@ -340,7 +340,6 @@ func TestExtractor_Extract_v9(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := pnpmlock.Extractor{}

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
@@ -65,7 +65,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := pnpmlock.Extractor{}
@@ -685,7 +684,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := pnpmlock.Extractor{}

--- a/extractor/filesystem/language/php/composerlock/composerlock_test.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock_test.go
@@ -67,7 +67,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := composerlock.Extractor{}
@@ -199,7 +198,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := composerlock.Extractor{}

--- a/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
+++ b/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
@@ -73,7 +73,6 @@ func TestPdmExtractor_FileRequired(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := pdmlock.Extractor{}
@@ -230,7 +229,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := pdmlock.Extractor{}

--- a/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
+++ b/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
@@ -67,7 +67,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := pipfilelock.Extractor{}
@@ -228,7 +227,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := pipfilelock.Extractor{}

--- a/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
+++ b/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
@@ -67,7 +67,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := poetrylock.Extractor{}
@@ -225,7 +224,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := poetrylock.Extractor{}

--- a/extractor/filesystem/language/r/renvlock/renvlock_test.go
+++ b/extractor/filesystem/language/r/renvlock/renvlock_test.go
@@ -111,7 +111,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			extr := renvlock.Extractor{}


### PR DESCRIPTION
This enables the `copyloopvar` to ensure that variables are not needless copied in relation to loops which was a common practice before Go 1.22 as variables prior to that version were created once and updated by each iteration, whereas now they're (re)created on each iteration.

This most commonly presented in testing tables so unsurprisingly that's where all of our violations are