### PR TITLE
chore: enable `dupword` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,7 +20,7 @@ linters:
 #    - depguard
     - dogsled
 #    - dupl
-#    - dupword
+    - dupword
     - durationcheck
 #    - errcheck
 #    - errchkjson


### PR DESCRIPTION
This enables the `dupword` linter which catches duplicate word usage like "the the" - we actually don't have any violations as I took care of them in #263