### PR TITLE
test: ensure that `t.Helper` is used

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -80,7 +80,7 @@ linters:
     - tenv
     - testableexamples
     - testifylint
-#    - thelper
+    - thelper
 #    - tparallel
 #    - unconvert
 #    - unparam

--- a/artifact/image/tar/tar_test.go
+++ b/artifact/image/tar/tar_test.go
@@ -80,6 +80,8 @@ func filesMatch(t *testing.T, path1, path2 string) bool {
 }
 
 func mustHashFile(t *testing.T, path string) string {
+	t.Helper()
+
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("os.Open(%q) error: %v", path, err)

--- a/artifact/image/unpack/unpack_test.go
+++ b/artifact/image/unpack/unpack_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"archive/tar"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/pkg/v1"
@@ -584,6 +585,8 @@ func mustReadSubDirs(t *testing.T, dir string) []digestAndContent {
 // This image may not contain parent directories because it is constructed from an intermediate tarball.
 // This is useful for testing the parent directory creation logic of unpack.
 func mustNewSquashedImage(t *testing.T, pathsToContent map[string]contentAndMode) v1.Image {
+	t.Helper()
+
 	// Squash layers into a single layer.
 	files := make(map[string]contentAndMode)
 	for path, contentAndMode := range pathsToContent {

--- a/extractor/filesystem/containers/containerd/containerd_test.go
+++ b/extractor/filesystem/containers/containerd/containerd_test.go
@@ -259,6 +259,8 @@ func createFileFromTestData(t *testing.T, root string, subPath string, fileName 
 }
 
 func createScanInput(t *testing.T, root string, path string) *filesystem.ScanInput {
+	t.Helper()
+
 	finalPath := filepath.Join(root, path)
 	reader, err := os.Open(finalPath)
 	defer func() {

--- a/extractor/filesystem/os/rpm/rpm_test.go
+++ b/extractor/filesystem/os/rpm/rpm_test.go
@@ -970,6 +970,8 @@ func TestEcosystem(t *testing.T) {
 
 // CopyFileToTempDir copies the passed in file to a temporary directory, then returns the new file path.
 func CopyFileToTempDir(t *testing.T, filepath, root string) (string, error) {
+	t.Helper()
+
 	filename := path.Base(filepath)
 	newfile := path.Join(root, filename)
 

--- a/extractor/filesystem/sbom/cdx/cdx_test.go
+++ b/extractor/filesystem/sbom/cdx/cdx_test.go
@@ -207,6 +207,8 @@ func invLess(i1, i2 *extractor.Inventory) bool {
 }
 
 func purlFromString(t *testing.T, purlStr string) *purl.PackageURL {
+	t.Helper()
+
 	res, err := purl.FromString(purlStr)
 	if err != nil {
 		t.Fatalf("purlFromString(%s): %v", purlStr, err)


### PR DESCRIPTION
This enables the `thelper` linter which ensures helper functions actually call `t.Helper` so that test failures report the test itself as the failure rather than the helper, making it easier to track down what actually failed.

Relates to #274