### PR TITLE
refactor: use integer-based `range`s where possible

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,7 +49,7 @@ linters:
 #    - inamedparam
     - ineffassign
     - interfacebloat
-#    - intrange
+    - intrange
     - loggercheck
     - makezero
     - mirror

--- a/artifact/image/layerscanning/file_node_test.go
+++ b/artifact/image/layerscanning/file_node_test.go
@@ -259,7 +259,7 @@ func TestReadingAfterClose(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			for i := 0; i < readAndCloseEvents; i++ {
+			for range readAndCloseEvents {
 				gotBytes := make([]byte, bufferSize)
 				gotNumBytesRead, gotErr := tc.node.Read(gotBytes)
 

--- a/artifact/image/layerscanning/layer_test.go
+++ b/artifact/image/layerscanning/layer_test.go
@@ -474,7 +474,7 @@ func TestChainFSReadDir(t *testing.T) {
 				return strings.Compare(a.Name(), b.Name())
 			})
 
-			for i := range len(wantDirEntries) {
+			for i := range wantDirEntries {
 				gotEntry := gotDirEntries[i]
 				wantEntry := wantDirEntries[i]
 				if gotEntry.Name() != wantEntry.Name() {

--- a/artifact/image/unpack/unpack.go
+++ b/artifact/image/unpack/unpack.go
@@ -194,7 +194,7 @@ func (u *Unpacker) UnpackSquashedFromTarball(dir string, tarPath string) error {
 	// requiredTargets stores targets that symlinks point to.
 	// This is needed because the symlink may be required by u.requirer, but the target may not be.
 	requiredTargets := make(map[string]bool)
-	for pass := 0; pass < u.MaxPass; pass++ {
+	for pass := range u.MaxPass {
 		finalPass := false
 		// Resolve symlinks on the last pass once all potential target files have been unpacked.
 		if pass == u.MaxPass-1 {
@@ -262,7 +262,7 @@ func (u *Unpacker) UnpackLayers(dir string, image v1.Image) ([]string, error) {
 		// requiredTargets stores targets that symlinks point to.
 		// This is needed because the symlink may be required by u.requirer, but the target may not be.
 		requiredTargets := make(map[string]bool)
-		for pass := 0; pass < u.MaxPass; pass++ {
+		for pass := range u.MaxPass {
 			finalPass := false
 			// Resolve symlinks on the last pass once all potential target files have been unpacked.
 			if pass == u.MaxPass-1 {

--- a/detector/cve/cve202338408/semantic/version-packagist.go
+++ b/detector/cve/cve202338408/semantic/version-packagist.go
@@ -79,7 +79,7 @@ func comparePackagistComponents(a, b []string) int {
 
 	var compare int
 
-	for i := 0; i < minLen; i++ {
+	for i := range minLen {
 		ai, aIsNumber := convertToBigInt(a[i])
 		bi, bIsNumber := convertToBigInt(b[i])
 

--- a/detector/cve/cve20236019/cve20236019.go
+++ b/detector/cve/cve20236019/cve20236019.go
@@ -219,7 +219,7 @@ func generateRandomString(length int) string {
 
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	bytes := make([]byte, length)
-	for i := 0; i < length; i++ {
+	for i := range length {
 		bytes[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(bytes)

--- a/detector/weakcredentials/winlocal/samreg/crypto.go
+++ b/detector/weakcredentials/winlocal/samreg/crypto.go
@@ -71,7 +71,7 @@ func transformRID(key []byte) []byte {
 	outputKey = append(outputKey, ((key[5]&0x3F)<<1)|(key[6]>>7))
 	outputKey = append(outputKey, key[6]&0x7F)
 
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		outputKey[i] = (outputKey[i] << 1) & 0xfe
 	}
 

--- a/detector/weakcredentials/winlocal/systemreg/systemreg.go
+++ b/detector/weakcredentials/winlocal/systemreg/systemreg.go
@@ -83,7 +83,7 @@ func (s *SystemRegistry) Syskey() ([]byte, error) {
 	transforms := []int{8, 5, 4, 2, 11, 9, 13, 3, 0, 6, 1, 12, 14, 10, 15, 7}
 	var resultKey []byte
 
-	for i := range len(unhexKey) {
+	for i := range unhexKey {
 		resultKey = append(resultKey, unhexKey[transforms[i]])
 	}
 


### PR DESCRIPTION
This enables the `intrange` linter which enforces the use of integer-based `range`s where possible, as they're generally cleaner

Relates to #274