### PR TITLE
refactor: apply `goimports` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -36,7 +36,7 @@ linters:
 #    - gocritic
 #    - gofmt
     - goheader
-#    - goimports
+    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname

--- a/artifact/image/image.go
+++ b/artifact/image/image.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/osv-scalibr/artifact/image/require"
 	"github.com/google/osv-scalibr/artifact/image/unpack"

--- a/artifact/image/layerscanning/image.go
+++ b/artifact/image/layerscanning/image.go
@@ -27,7 +27,8 @@ import (
 	"strings"
 
 	"archive/tar"
-	"github.com/google/go-containerregistry/pkg/v1"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	scalibrImage "github.com/google/osv-scalibr/artifact/image"

--- a/artifact/image/tar/tar.go
+++ b/artifact/image/tar/tar.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/osv-scalibr/log"
 )

--- a/artifact/image/tar/tar_test.go
+++ b/artifact/image/tar/tar_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/osv-scalibr/artifact/image/tar"
 )

--- a/artifact/image/unpack/unpack.go
+++ b/artifact/image/unpack/unpack.go
@@ -27,7 +27,8 @@ import (
 	"strings"
 
 	"archive/tar"
-	"github.com/google/go-containerregistry/pkg/v1"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/osv-scalibr/artifact/image/require"
 	"github.com/google/osv-scalibr/artifact/image/symlink"
 	scalibrtar "github.com/google/osv-scalibr/artifact/image/tar"

--- a/artifact/image/unpack/unpack_test.go
+++ b/artifact/image/unpack/unpack_test.go
@@ -26,9 +26,10 @@ import (
 	"testing"
 
 	"archive/tar"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"

--- a/detector/weakcredentials/winlocal/samreg/samreg.go
+++ b/detector/weakcredentials/winlocal/samreg/samreg.go
@@ -17,6 +17,7 @@ package samreg
 
 import (
 	"fmt"
+
 	"github.com/google/osv-scalibr/common/windows/registry"
 )
 


### PR DESCRIPTION
This enables the `goimports` linter to ensure our imports are consistently and well formatted, which most already are

Relates to #274