### PR TITLE
refactor: remove unnecessary type conversions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -82,7 +82,7 @@ linters:
     - testifylint
 #    - thelper
 #    - tparallel
-#    - unconvert
+    - unconvert
 #    - unparam
 #    - unused
 #    - usestdlibvars

--- a/extractor/filesystem/containers/containerd/containerd_linux.go
+++ b/extractor/filesystem/containers/containerd/containerd_linux.go
@@ -445,7 +445,7 @@ func runcInitPid(scanRoot string, runtimeName string, id string) int {
 		return -1
 	}
 	var grpcContainerStatus map[string]*json.RawMessage
-	if err := json.Unmarshal([]byte(statusContent), &grpcContainerStatus); err != nil {
+	if err := json.Unmarshal(statusContent, &grpcContainerStatus); err != nil {
 		log.Errorf("Can't unmarshal status for container %v , error: %v", id, err)
 		return -1
 	}

--- a/extractor/filesystem/containers/containerd/containerd_test.go
+++ b/extractor/filesystem/containers/containerd/containerd_test.go
@@ -252,7 +252,7 @@ func createFileFromTestData(t *testing.T, root string, subPath string, fileName 
 	if err != nil {
 		t.Fatalf("read from %s: %v\n", testDataFilePath, err)
 	}
-	err = os.WriteFile(filepath.Join(root, subPath, fileName), []byte(testData), 0644)
+	err = os.WriteFile(filepath.Join(root, subPath, fileName), testData, 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, subPath, fileName), err)
 	}

--- a/extractor/standalone/windows/dismpatch/dismpatch.go
+++ b/extractor/standalone/windows/dismpatch/dismpatch.go
@@ -26,7 +26,7 @@ import (
 
 // inventoryFromOutput parses the output of DISM and produces inventory entries from it.
 func inventoryFromOutput(flavor, output string) ([]*extractor.Inventory, error) {
-	packages, imgVersion, err := dismparser.Parse(string(output))
+	packages, imgVersion, err := dismparser.Parse(output)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This enables the `unconvert` linter which ensures conversions are actually necessary, which helps to keep things readable by reducing the amount of code and potentially even being slightly more performant

Relates to #274