### PR TITLE
refactor: name parameters in `Cracker` interface

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,7 +46,7 @@ linters:
 #    - govet
     - grouper
     - importas
-#    - inamedparam
+    - inamedparam
     - ineffassign
     - interfacebloat
 #    - intrange

--- a/detector/weakcredentials/etcshadow/cracker.go
+++ b/detector/weakcredentials/etcshadow/cracker.go
@@ -29,7 +29,7 @@ var ErrNotCracked = errors.New("not cracked")
 // Cracker interface is implemented by types which know how to crack hashes.
 type Cracker interface {
 	// Crack returns (password,nil) on success and ("", ErrNotCracked) on failure.
-	Crack(context.Context, string) (string, error)
+	Crack(ctx context.Context, hash string) (string, error)
 }
 
 type passwordCracker struct {


### PR DESCRIPTION
This enables the `inamedparam` linter which ensures all interface methods name their parameters, to help make it clear what they're intended for

Relates to #274