### PR TITLE
fix: Unify invalid purl logging behavior in SBOM extractors

### DIFF
--- a/extractor/filesystem/sbom/cdx/cdx.go
+++ b/extractor/filesystem/sbom/cdx/cdx.go
@@ -110,7 +110,7 @@ func (e Extractor) convertCdxBomToInventory(cdxBom *cyclonedx.BOM, path string) 
 		if cdxPkg.PackageURL != "" {
 			packageURL, err := purl.FromString(cdxPkg.PackageURL)
 			if err != nil {
-				log.Warnf("Invalid PURL for package: %q", cdxPkg.BOMRef)
+				log.Warnf("Invalid PURL %q for package ref: %q", cdxPkg.PackageURL, cdxPkg.BOMRef)
 			} else {
 				m.PURL = &packageURL
 				if inv.Name == "" {

--- a/extractor/filesystem/sbom/spdx/spdx.go
+++ b/extractor/filesystem/sbom/spdx/spdx.go
@@ -116,7 +116,7 @@ func (e Extractor) convertSpdxDocToInventory(spdxDoc *spdx.Document, path string
 				packageURL, err := purl.FromString(extRef.Locator)
 				inv.Name = packageURL.Name
 				if err != nil {
-					log.Warnf("Invalid PURL for package: %q", extRef.Locator)
+					log.Warnf("Invalid PURL %q for package: %q", extRef.Locator, spdxPkg.PackageName)
 				} else {
 					m.PURL = &packageURL
 				}


### PR DESCRIPTION
Currently cdx does not print out the invalid purl, while spdx does do that, this PR updates this behavior to try and unify their behavior.

This also helps users better debug their sbom files for the problem.