### PR TITLE
test: forbid using `t.Parallel`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -81,7 +81,6 @@ linters:
     - testableexamples
     - testifylint
     - thelper
-#    - tparallel
     - unconvert
 #    - unparam
 #    - unused
@@ -90,6 +89,8 @@ linters:
     - whitespace
     - zerologlint
   disable-all: true
+#  disable:
+#    - tparallel # Parallel tests mixes up log lines of multiple tests in the internal test runner
 
 linters-settings:
   forbidigo:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,7 +28,7 @@ linters:
 #    - errorlint
 #    - exhaustive
 #    - fatcontext
-#    - forbidigo
+    - forbidigo
     - ginkgolinter
     - gocheckcompilerdirectives
     - gochecknoinits
@@ -90,3 +90,11 @@ linters:
     - whitespace
     - zerologlint
   disable-all: true
+
+linters-settings:
+  forbidigo:
+    forbid:
+      # Parallel tests mixes up log lines of multiple tests in the internal test runner
+      - p: ^testing.T.Parallel$
+        pkg: ^testing$
+    analyze-types: true

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v1-revisions_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v1-revisions_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestExtractor_Extract_v1_revisions(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "no packages",
@@ -161,7 +159,6 @@ func TestExtractor_Extract_v1_revisions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := conanlock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestExtractor_Extract_v1(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid json",
@@ -233,7 +231,6 @@ func TestExtractor_Extract_v1(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := conanlock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v2_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v2_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestExtractor_Extract_v2(t *testing.T) {
-	t.Parallel()
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "no packages",
@@ -160,7 +159,6 @@ func TestExtractor_Extract_v2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := conanlock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/cpp/conanlock/conanlock_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name      string
 		inputPath string
@@ -57,7 +55,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			e := conanlock.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {

--- a/extractor/filesystem/language/golang/gomod/gomod_test.go
+++ b/extractor/filesystem/language/golang/gomod/gomod_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name      string
 		inputPath string
@@ -61,7 +59,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.inputPath, func(t *testing.T) {
-			t.Parallel()
 			e := gomod.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -72,8 +69,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid",
@@ -265,7 +260,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := gomod.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/java/gradlelockfile/gradlelockfile_test.go
+++ b/extractor/filesystem/language/java/gradlelockfile/gradlelockfile_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		inputPath string
 		want      bool
@@ -81,7 +79,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.inputPath, func(t *testing.T) {
-			t.Parallel()
 			e := gradlelockfile.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -92,7 +89,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "only comments",
@@ -208,7 +204,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := gradlelockfile.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name      string
 		inputPath string
@@ -93,7 +91,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			e := gradleverificationmetadataxml.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -104,7 +101,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid xml",
@@ -454,7 +450,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := gradleverificationmetadataxml.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/java/pomxml/pomxml_test.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		inputPath string
 		want      bool
@@ -61,7 +59,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.inputPath, func(t *testing.T) {
-			t.Parallel()
 			e := pomxml.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -72,8 +69,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid",
@@ -252,7 +247,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := pomxml.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestNPMLockExtractor_Extract_V1(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid json",
@@ -839,8 +837,6 @@ func TestNPMLockExtractor_Extract_V1(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
-
 			collector := testcollector.New()
 			extr := packagelockjson.New(packagelockjson.Config{
 				Stats: collector,

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v2_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v2_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestNPMLockExtractor_Extract_V2(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid json",
@@ -555,8 +553,6 @@ func TestNPMLockExtractor_Extract_V2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
-
 			collector := testcollector.New()
 			extr := packagelockjson.New(packagelockjson.Config{
 				Stats: collector,

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson_test.go
@@ -188,8 +188,6 @@ func TestMetricCollector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			collector := testcollector.New()
 			extr := packagelockjson.New(packagelockjson.Config{
 				Stats: collector,

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock-v9_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock-v9_test.go
@@ -341,7 +341,6 @@ func TestExtractor_Extract_v9(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := pnpmlock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
@@ -66,7 +66,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			e := pnpmlock.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -685,7 +684,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := pnpmlock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/javascript/yarnlock/yarnlock-v2_test.go
+++ b/extractor/filesystem/language/javascript/yarnlock/yarnlock-v2_test.go
@@ -350,7 +350,6 @@ func TestExtractor_Extract_v2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := yarnlock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/php/composerlock/composerlock_test.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name      string
 		inputPath string
@@ -68,7 +66,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			e := composerlock.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -79,8 +76,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid json",
@@ -199,7 +194,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := composerlock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
+++ b/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestPdmExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name      string
 		inputPath string
@@ -74,7 +72,6 @@ func TestPdmExtractor_FileRequired(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			e := pdmlock.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -85,8 +82,6 @@ func TestPdmExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid toml",
@@ -230,7 +225,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := pdmlock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
+++ b/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name      string
 		inputPath string
@@ -68,7 +66,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			e := pipfilelock.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -79,8 +76,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid json",
@@ -228,7 +223,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := pipfilelock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
+++ b/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name      string
 		inputPath string
@@ -68,7 +66,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			e := poetrylock.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -79,7 +76,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid toml",
@@ -207,7 +203,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := poetrylock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/r/renvlock/renvlock_test.go
+++ b/extractor/filesystem/language/r/renvlock/renvlock_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "invalid json",
@@ -112,7 +110,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := renvlock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/ruby/gemfilelock/gemfilelock_test.go
+++ b/extractor/filesystem/language/ruby/gemfilelock/gemfilelock_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		inputPath string
 		want      bool
@@ -60,7 +58,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.inputPath, func(t *testing.T) {
-			t.Parallel()
 			e := gemfilelock.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -71,8 +68,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "no spec section",
@@ -686,7 +681,6 @@ func TestExtractor_Extract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := gemfilelock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/extractor/filesystem/language/rust/cargolock/cargolock_test.go
+++ b/extractor/filesystem/language/rust/cargolock/cargolock_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestExtractor_FileRequired(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name      string
 		inputPath string
@@ -69,7 +67,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			e := cargolock.Extractor{}
 			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
 			if got != tt.want {
@@ -80,8 +77,6 @@ func TestExtractor_FileRequired(t *testing.T) {
 }
 
 func TestExtractor_Extract(t *testing.T) {
-	t.Parallel()
-
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "Invalid toml",
@@ -163,7 +158,6 @@ func TestExtractor_Extract(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
 			extr := cargolock.Extractor{}
 
 			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)

--- a/scalibr_test.go
+++ b/scalibr_test.go
@@ -241,7 +241,6 @@ func TestEnableRequiredExtractors(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			if err := tc.cfg.EnableRequiredExtractors(); !cmp.Equal(tc.wantErr, err, cmpopts.EquateErrors()) {
 				t.Fatalf("EnableRequiredExtractors() error: %v, want %v", tc.wantErr, err)
 			}
@@ -353,7 +352,6 @@ func TestValidatePluginRequirements(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
 			if err := tc.cfg.ValidatePluginRequirements(); !cmp.Equal(tc.wantErr, err, cmpopts.EquateErrors()) {
 				t.Fatalf("ValidatePluginRequirements() error: %v, want %v", tc.wantErr, err)
 			}

--- a/testing/extracttest/compare_test.go
+++ b/testing/extracttest/compare_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 func TestInventoryCmpLess(t *testing.T) {
-	t.Parallel()
-
 	type args struct {
 		a *extractor.Inventory
 		b *extractor.Inventory


### PR DESCRIPTION
The internal test runner used by Google gets confused by testing using `t.Parallel` due to the log lines getting mixed, so this removes all usage of it and configures the `forbidigo` linter to enforce it's not-use.

Since this by extension means we never want the `tparallel` linter enabled, I've updated the linting config to remove it from the `enable` list and added it to the commented out `disable` list in preparation for when we're able to switch to having all linters enabled by default (as you're not allowed to use both `disable-all` and `disable` at the same time)