### PR TITLE
ci: report all linting errors at once

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -90,3 +90,7 @@ linters:
     - whitespace
     - zerologlint
   disable-all: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ scalibr:
 	CGO_ENABLED=1 go build binary/scalibr/scalibr.go
 
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 run ./... --max-same-issues 0
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 run ./...
 
 test:
 	CGO_ENABLED=1 go test ./...


### PR DESCRIPTION
By default `golangci-lint` only reports the first 50 issues per linter and the first 3 issues that have the same text which is noble but in my experience tends to make it more tedious to deal with long-term as you'll think you've addressed all the linting errors only to find new ones being reported that weren't previously and it also can result in easy-to-address errors being hidden if they come after more complicated ones.