### PR TITLE
ci: explore running linting on just new changes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,22 @@ jobs:
         with:
           version: v1.61.0
           args: --timeout=5m
+  # TODO(#346): we're exploring if only-new-issues will help reduce friction in PRs
+  lint-just-new:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.61.0
+          only-new-issues: true
+          args: --timeout=5m
   tests:
     strategy:
       matrix:


### PR DESCRIPTION
This adds a new temporary job that runs `golangci-lint` with `only-new-issues` enabled in the hopes that it'll reduce friction for contributions being made via GitHub by avoiding failing CI due to linting violations introduced through internal patches.

As I've not had a lot of experience with this option and an incorrect setup with linters can often look the same as linting being happy unless someone actually takes the time to review the logs of every run, I've opted to start by introducing this as a second job with the idea being we'll get the see what the linter would give us with and without that option.

I expect after a bunch of pull requests, we'll have seen enough to decide if this option would actually be helpful, and either way remove one of the two jobs

Relates to #346