### PR TITLE
Implementation of Swift podfile Extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -52,6 +52,8 @@ SCALIBR supports extracting software package information from a variety of OS an
   * Lockfiles: Gemfile.lock (OSV)
 * Rust
   * Cargo.lock
+* Swift
+  * Podfile.lock
 
 ## Container inventory
 

--- a/extractor/filesystem/language/swift/podfile/podfilelock.go
+++ b/extractor/filesystem/language/swift/podfile/podfilelock.go
@@ -1,0 +1,170 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package podfilelock extracts dependencies from Podfile.lock files.
+package podfilelock
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/swiftutils"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+)
+
+// Name is the unique name of this extractor.
+const Name = "swift/podfilelock"
+
+// Config represents the configuration for the extractor.
+type Config struct {
+	Stats            stats.Collector
+	MaxFileSizeBytes int64
+}
+
+// DefaultConfig returns the default configuration for the extractor.
+func DefaultConfig() Config {
+	return Config{
+		Stats:            nil,
+		MaxFileSizeBytes: 10 * units.MiB,
+	}
+}
+
+// Config returns the configuration of the extractor.
+func (e Extractor) Config() Config {
+	return Config{
+		Stats:            e.stats,
+		MaxFileSizeBytes: e.maxFileSizeBytes,
+	}
+}
+
+// Extractor extracts dependencies from Podfile.lock files.
+type Extractor struct {
+	stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New creates a new instance of the Podfile.lock extractor.
+func New(cfg Config) *Extractor {
+	return &Extractor{
+		stats:            cfg.Stats,
+		maxFileSizeBytes: cfg.MaxFileSizeBytes,
+	}
+}
+
+// Name returns the extractor's name.
+func (e Extractor) Name() string { return Name }
+
+// Version returns the extractor's version.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements defines the extractor's capabilities.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired checks if a file is named Podfile.lock and meets size constraints.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	if filepath.Base(path) != "Podfile.lock" {
+		return false
+	}
+
+	fileInfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+
+	if e.maxFileSizeBytes > 0 && fileInfo.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fileInfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fileInfo.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.stats == nil {
+		return
+	}
+	e.stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract processes and extracts dependency information from a Podfile.lock file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+	inventory, err := e.extractFromInput(ctx, input)
+	if e.stats != nil {
+		var fileSizeBytes int64
+		if input.Info != nil {
+			fileSizeBytes = input.Info.Size()
+		}
+		e.stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+			Path:          input.Path,
+			Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+			FileSizeBytes: fileSizeBytes,
+		})
+	}
+	return inventory, err
+}
+
+func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+	pkgs, err := swiftutils.ParsePodfileLock(input.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	var inventories []*extractor.Inventory
+	for _, pkg := range pkgs {
+		inventories = append(inventories, &extractor.Inventory{
+			Name:      pkg.Name,
+			Version:   pkg.Version,
+			Locations: []string{input.Path},
+		})
+	}
+
+	return inventories, nil
+}
+
+// ToPURL converts an inventory item into a Package URL (PURL).
+func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return &purl.PackageURL{
+		Type:    purl.TypeCocoapods,
+		Name:    i.Name,
+		Version: i.Version,
+	}
+}
+
+// Ecosystem returns the OSV ecosystem name for CocoaPods.
+func (Extractor) Ecosystem(_ *extractor.Inventory) string { return "CocoaPods" }
+
+// Package represents a single CocoaPods package.
+type Package struct {
+	Name    string
+	Version string
+}
+
+// podfileLock represents the structure of a Podfile.lock YAML file.
+type podfileLock struct {
+	Pods            []interface{}     `yaml:"PODS"`
+	SpecChecksums   map[string]string `yaml:"SPEC CHECKSUMS"`
+	PodfileChecksum string            `yaml:"PODFILE CHECKSUM"`
+	Cocopods        string            `yaml:"COCOAPODS"`
+}

--- a/extractor/filesystem/language/swift/podfile/podfilelock_test.go
+++ b/extractor/filesystem/language/swift/podfile/podfilelock_test.go
@@ -1,0 +1,258 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podfilelock_test
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	podfilelock "github.com/google/osv-scalibr/extractor/filesystem/language/swift/podfile"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	scalibrfs "github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/testing/fakefs"
+	"github.com/google/osv-scalibr/testing/testcollector"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     podfilelock.Config
+		wantCfg podfilelock.Config
+	}{
+		{
+			name: "default",
+			cfg:  podfilelock.DefaultConfig(),
+			wantCfg: podfilelock.Config{
+				MaxFileSizeBytes: 10 * units.MiB,
+			},
+		},
+		{
+			name: "custom",
+			cfg: podfilelock.Config{
+				MaxFileSizeBytes: 10,
+			},
+			wantCfg: podfilelock.Config{
+				MaxFileSizeBytes: 10,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podfilelock.New(tt.cfg)
+			if !reflect.DeepEqual(got.Config(), tt.wantCfg) {
+				t.Errorf("New(%+v).Config(): got %+v, want %+v", tt.cfg, got.Config(), tt.wantCfg)
+			}
+		})
+	}
+}
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+		wantResultMetric stats.FileRequiredResult
+	}{
+		{
+			name:             "Podfile.lock file",
+			path:             "Podfile.lock",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "path Podfile.lock file",
+			path:             "path/to/my/Podfile.lock",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:         "file not required",
+			path:         "test.lock",
+			wantRequired: false,
+		},
+		{
+			name:             "Podfile.lock file required if file size < max file size",
+			path:             "Podfile.lock",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "Podfile.lock file required if file size == max file size",
+			path:             "Podfile.lock",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "Podfile.lock file not required if file size > max file size",
+			path:             "Podfile.lock",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 100 * units.KiB,
+			wantRequired:     false,
+			wantResultMetric: stats.FileRequiredResultSizeLimitExceeded,
+		},
+		{
+			name:             "Podfile.lock file required if max file size set to 0",
+			path:             "Podfile.lock",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 0,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			var e filesystem.Extractor = podfilelock.New(podfilelock.Config{
+				Stats:            collector,
+				MaxFileSizeBytes: tt.maxFileSizeBytes,
+			})
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1000
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+
+			gotResultMetric := collector.FileRequiredResult(tt.path)
+			if tt.wantResultMetric != "" && gotResultMetric != tt.wantResultMetric {
+				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		osrelease        string
+		cfg              podfilelock.Config
+		wantInventory    []*extractor.Inventory
+		wantErr          error
+		wantResultMetric stats.FileExtractedResult
+	}{
+		{
+			name: "valid Podfile.lock file",
+			path: "testdata/valid",
+			wantInventory: []*extractor.Inventory{
+				{
+					Name:      "GlossButtonNode",
+					Version:   "3.1.2",
+					Locations: []string{"testdata/valid"},
+				},
+				{
+					Name:      "PINCache",
+					Version:   "3.0.3",
+					Locations: []string{"testdata/valid"},
+				},
+			},
+			wantResultMetric: stats.FileExtractedResultSuccess,
+		},
+		{
+			name:             "Podfile.lock file not valid",
+			path:             "testdata/invalid",
+			wantErr:          cmpopts.AnyError,
+			wantResultMetric: stats.FileExtractedResultErrorUnknown,
+		},
+		{
+			name:             "Podfile.lock file empty",
+			path:             "testdata/empty",
+			wantErr:          cmpopts.AnyError,
+			wantResultMetric: stats.FileExtractedResultErrorUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			var e filesystem.Extractor = podfilelock.New(podfilelock.Config{
+				Stats:            collector,
+				MaxFileSizeBytes: 100,
+			})
+
+			d := t.TempDir()
+
+			// Opening and Reading the Test File
+			r, err := os.Open(tt.path)
+			defer func() {
+				if err = r.Close(); err != nil {
+					t.Errorf("Close(): %v", err)
+				}
+			}()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			info, err := os.Stat(tt.path)
+			if err != nil {
+				t.Fatalf("Failed to stat test file: %v", err)
+			}
+
+			input := &filesystem.ScanInput{
+				FS: scalibrfs.DirFS(d), Path: tt.path, Reader: r, Root: d, Info: info,
+			}
+
+			got, err := e.Extract(context.Background(), input)
+
+			if diff := cmp.Diff(tt.wantInventory, got); diff != "" {
+				t.Errorf("Inventory mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+func TestToPURL(t *testing.T) {
+	e := podfilelock.Extractor{}
+	i := &extractor.Inventory{
+		Name:      "Name",
+		Version:   "1.2.3",
+		Locations: []string{"location"},
+	}
+	want := &purl.PackageURL{
+		Type:    purl.TypeCocoapods,
+		Name:    "Name",
+		Version: "1.2.3",
+	}
+	got := e.ToPURL(i)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
+	}
+}

--- a/extractor/filesystem/language/swift/podfile/testdata/invalid
+++ b/extractor/filesystem/language/swift/podfile/testdata/invalid
@@ -1,0 +1,3 @@
+invalid
+2FLayoutSpecBuilder
+file 

--- a/extractor/filesystem/language/swift/podfile/testdata/valid
+++ b/extractor/filesystem/language/swift/podfile/testdata/valid
@@ -1,0 +1,42 @@
+PODS:
+  - GlossButtonNode (3.1.2):
+    - Texture/Core (~> 3)
+    - TextureSwiftSupport (>= 3.10.0)
+  - PINCache (3.0.3):
+    - PINCache/Arc-exception-safe (= 3.0.3)
+    - PINCache/Core (= 3.0.3)
+
+DEPENDENCIES:
+  - GlossButtonNode
+  - Reveal-SDK
+  - SwiftGen
+  - Texture
+  - TextureSwiftSupport
+  - TinyConstraints
+
+SPEC REPOS:
+  trunk:
+    - GlossButtonNode
+    - PINCache
+    - PINOperation
+    - PINRemoteImage
+    - Reveal-SDK
+    - SwiftGen
+    - Texture
+    - TextureSwiftSupport
+    - TinyConstraints
+
+SPEC CHECKSUMS:
+  GlossButtonNode: 4ea1197a744f2fb5fb875fe31caf17ded4762e8f
+  PINCache: 7a8fc1a691173d21dbddbf86cd515de6efa55086
+  PINOperation: 00c935935f1e8cf0d1e2d6b542e75b88fc3e5e20
+  PINRemoteImage: f1295b29f8c5e640e25335a1b2bd9d805171bd01
+  Reveal-SDK: effba1c940b8337195563c425a6b5862ec875caa
+  SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
+  Texture: 2e8ab2519452515f7f5a520f5a8f7e0a413abfa3
+  TextureSwiftSupport: c515c7927fab92d0d9485f49b885b8c5de34fbfb
+  TinyConstraints: 7b7ccc0c485bb3bb47082138ff28bc33cd49897f
+
+PODFILE CHECKSUM: 07aa55f54421f6e6d3a920c11716a89fc9243d1b
+
+COCOAPODS: 1.11.2

--- a/extractor/filesystem/language/swift/swiftutils/podfilelock.go
+++ b/extractor/filesystem/language/swift/swiftutils/podfilelock.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swiftutils
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PodfileLock represents the structure of a Podfile.lock file.
+type PodfileLock struct {
+	Pods            []interface{}     `yaml:"PODS"`
+	SpecChecksums   map[string]string `yaml:"SPEC CHECKSUMS"`
+	PodfileChecksum string            `yaml:"PODFILE CHECKSUM"`
+	Cocopods        string            `yaml:"COCOAPODS"`
+}
+
+// Package represents a single package parsed from Podfile.lock.
+type Package struct {
+	Name    string
+	Version string
+}
+
+// ParsePodfileLock parses the contents of a Podfile.lock and returns a list of packages.
+func ParsePodfileLock(reader io.Reader) ([]Package, error) {
+	bytes, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read file: %w", err)
+	}
+
+	var podfile PodfileLock
+	if err = yaml.Unmarshal(bytes, &podfile); err != nil {
+		return nil, fmt.Errorf("unable to parse YAML: %w", err)
+	}
+
+	var pkgs []Package
+	for _, podInterface := range podfile.Pods {
+		var podBlob string
+		switch v := podInterface.(type) {
+		case map[string]interface{}:
+			for k := range v {
+				podBlob = k
+			}
+		case string:
+			podBlob = v
+		default:
+			return nil, fmt.Errorf("malformed Podfile.lock")
+		}
+
+		splits := strings.Split(podBlob, " ")
+		if len(splits) < 2 {
+			return nil, fmt.Errorf("unexpected format in Pods: %s", podBlob)
+		}
+		podName := splits[0]
+		podVersion := strings.TrimSuffix(strings.TrimPrefix(splits[1], "("), ")")
+		pkgs = append(pkgs, Package{
+			Name:    podName,
+			Version: podVersion,
+		})
+	}
+
+	return pkgs, nil
+}

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -51,6 +51,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ruby/gemfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ruby/gemspec"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargolock"
+	podfilelock "github.com/google/osv-scalibr/extractor/filesystem/language/swift/podfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/apk"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/cos"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/dpkg"
@@ -115,6 +116,8 @@ var (
 	Dotnet []filesystem.Extractor = []filesystem.Extractor{packageslockjson.New(packageslockjson.DefaultConfig())}
 	// PHP extractors.
 	PHP []filesystem.Extractor = []filesystem.Extractor{&composerlock.Extractor{}}
+	// Swift extractors.
+	Swift []filesystem.Extractor = []filesystem.Extractor{podfilelock.Extractor{}}
 	// Containers extractors.
 	Containers []filesystem.Extractor = []filesystem.Extractor{containerd.New(containerd.DefaultConfig())}
 
@@ -149,6 +152,7 @@ var (
 		Rust,
 		Dotnet,
 		SBOM,
+		Swift,
 		OS,
 		Containers,
 	)
@@ -167,6 +171,7 @@ var (
 		"dotnet":     Dotnet,
 		"php":        PHP,
 		"rust":       Rust,
+		"swift":      Swift,
 
 		"sbom":       SBOM,
 		"os":         OS,


### PR DESCRIPTION
Pull request for the `Swift Podfile.lock` extractor.
Implemented:

- Extractor implementation;
- Unit test implementation:
- Integration of the extractor in the main tool;

We also chose to create a `ParsePodfileLock` function in a shared library such as `/extractor/filesystem/language/swift/swiftutils/` so that both `Swift` `Podfile` and `ObjectiveC` extractors can call it since they process the same podfile format.