### PR TITLE
feat: Add ReadAt function for fileNode to allow gobinary extractor to successfully extract.

### DIFF
--- a/artifact/image/layerscanning/image/file_node.go
+++ b/artifact/image/layerscanning/image/file_node.go
@@ -67,6 +67,20 @@ func (f *fileNode) Read(b []byte) (n int, err error) {
 	return f.file.Read(b)
 }
 
+// ReadAt reads the real file referred to by the fileNode at a specific offset.
+func (f *fileNode) ReadAt(b []byte, off int64) (n int, err error) {
+	if f.isWhiteout {
+		return 0, fs.ErrNotExist
+	}
+	if f.file == nil {
+		f.file, err = os.Open(f.RealFilePath())
+	}
+	if err != nil {
+		return 0, err
+	}
+	return f.file.ReadAt(b, off)
+}
+
 // Close closes the real file referred to by the fileNode and resets the file field.
 func (f *fileNode) Close() error {
 	if f.file != nil {

--- a/artifact/image/layerscanning/image/file_node_test.go
+++ b/artifact/image/layerscanning/image/file_node_test.go
@@ -15,10 +15,14 @@
 package image
 
 import (
+	"io"
 	"io/fs"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 var (
@@ -167,9 +171,147 @@ func TestRead(t *testing.T) {
 	}
 }
 
-func TestClose(t *testing.T) {
+func TestReadAt(t *testing.T) {
 	const bufferSize = 20
 
+	tempDir := t.TempDir()
+	os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
+
+	os.WriteFile(path.Join(tempDir, "baz"), []byte("baz"), 0600)
+	openedRootFile, err := os.OpenFile(path.Join(tempDir, "baz"), os.O_RDONLY, filePermission)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	// Close the file after the test. The file should be closed via the fileNode.Close method,
+	// however, this test explicitly closes the file since the fileNode.Close method is tested in a
+	// separate test.
+	defer openedRootFile.Close()
+
+	os.MkdirAll(path.Join(tempDir, "dir1"), 0700)
+	os.WriteFile(path.Join(tempDir, "dir1/foo"), []byte("foo"), 0600)
+
+	fileNodeWithUnopenedFile := &fileNode{
+		extractDir:    tempDir,
+		originLayerID: "",
+		virtualPath:   "/bar",
+		isWhiteout:    false,
+		mode:          filePermission,
+	}
+	fileNodeWithOpenedFile := &fileNode{
+		extractDir:    tempDir,
+		originLayerID: "",
+		virtualPath:   "/baz",
+		isWhiteout:    false,
+		mode:          filePermission,
+		file:          openedRootFile,
+	}
+	fileNodeNonRootFile := &fileNode{
+		extractDir:    tempDir,
+		originLayerID: "",
+		virtualPath:   "/dir1/foo",
+		isWhiteout:    false,
+		mode:          filePermission,
+	}
+	fileNodeNonExistentFile := &fileNode{
+		extractDir:    tempDir,
+		originLayerID: "",
+		virtualPath:   "/dir1/xyz",
+		isWhiteout:    false,
+		mode:          filePermission,
+	}
+	fileNodeWhiteoutFile := &fileNode{
+		extractDir:    tempDir,
+		originLayerID: "",
+		virtualPath:   "/dir1/abc",
+		isWhiteout:    true,
+		mode:          filePermission,
+	}
+	tests := []struct {
+		name    string
+		node    *fileNode
+		offset  int64
+		want    string
+		wantErr error
+	}{
+		{
+			name: "unopened root file",
+			node: fileNodeWithUnopenedFile,
+			want: "bar",
+			// All successful reads should return EOF
+			wantErr: io.EOF,
+		},
+		{
+			name:    "opened root file",
+			node:    fileNodeWithOpenedFile,
+			want:    "baz",
+			wantErr: io.EOF,
+		},
+		{
+			name:    "opened root file at offset",
+			node:    fileNodeWithUnopenedFile,
+			offset:  2,
+			want:    "r",
+			wantErr: io.EOF,
+		},
+		{
+			name:    "opened root file at offset at the end of file",
+			node:    fileNodeWithUnopenedFile,
+			offset:  3,
+			want:    "",
+			wantErr: io.EOF,
+		},
+		{
+			name:    "opened root file at offset beyond the end of file",
+			node:    fileNodeWithUnopenedFile,
+			offset:  4,
+			want:    "",
+			wantErr: io.EOF,
+		},
+		{
+			name:    "non-root file",
+			node:    fileNodeNonRootFile,
+			want:    "foo",
+			wantErr: io.EOF,
+		},
+		{
+			name:    "non-root file at offset",
+			node:    fileNodeNonRootFile,
+			offset:  1,
+			want:    "oo",
+			wantErr: io.EOF,
+		},
+		{
+			name:    "non-existent file",
+			node:    fileNodeNonExistentFile,
+			wantErr: os.ErrNotExist,
+		},
+		{
+			name:    "whiteout file",
+			node:    fileNodeWhiteoutFile,
+			wantErr: os.ErrNotExist,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBytes := make([]byte, bufferSize)
+			gotNumBytesRead, gotErr := tc.node.ReadAt(gotBytes, tc.offset)
+			// Close the file. The Close method is tested in a separate test.
+			defer tc.node.Close()
+
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("ReadAt(%v) returned unexpected error (-want +got): %v", tc.node, diff)
+				return
+			}
+
+			gotContent := string(gotBytes[:gotNumBytesRead])
+			if gotContent != tc.want {
+				t.Errorf("ReadAt(%v) = %v, want: %v", tc.node, gotContent, tc.want)
+			}
+		})
+	}
+}
+
+func TestClose(t *testing.T) {
 	tempDir := t.TempDir()
 	os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
 


### PR DESCRIPTION
The gobinary extractor expects a ReaderAt, but fileNode does not implement it. The underlying file does though, so this just exposes it. 