### PR TITLE
ci: don't cancel other test jobs if one fails

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,6 +42,7 @@ jobs:
           args: --timeout=5m
   tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
In my experience this tends to be a better experience as cancelling the other jobs means you can't easily confirm if the failure is OS-specific