### PR TITLE
feat: bump Go to v1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ results := scalibr.New().Scan(context.Background(), cfg)
 log.Info(results)
 ```
 
+## Go toolchain compatibility policy
+
+We aim to keep the osv-scanner library packages compatible with supported
+versions of Go (last 2 Go releases), while always building osv-scanner binaries
+with the latest version of Go.
+
 ## Contributing
 Read how to [contribute to SCALIBR](CONTRIBUTING.md).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv-scalibr
 
-go 1.22
+go 1.23
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
I've also added a note to the readme about the compatibility policy to match what we've got in `osv-scanner`, however this should not be merged until Go 1.24 is actually released which should hopefully be next month 😅 