### PR TITLE
chore: disable `paralleltest` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -62,7 +62,6 @@ linters:
 #    - noctx
     - nolintlint
 #    - nosprintfhostport
-#    - paralleltest
 #    - perfsprint
 #    - prealloc
     - predeclared
@@ -90,7 +89,8 @@ linters:
     - zerologlint
   disable-all: true
 #  disable:
-#    - tparallel # Parallel tests mixes up log lines of multiple tests in the internal test runner
+#    - paralleltest # Parallel tests mixes up log lines of multiple tests in the internal test runner
+#    - tparallel    # Parallel tests mixes up log lines of multiple tests in the internal test runner
 
 linters-settings:
   forbidigo:


### PR DESCRIPTION
I didn't realise there's actually two linters that are keen for us to use `t.Parallel` 😅 

Relates to #274