### PR TITLE
chore: enable `nilerr` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,7 +56,7 @@ linters:
     - misspell
 #    - musttag
     - nakedret
-#    - nilerr
+    - nilerr
 #    - nilnil
 #    - nlreturn
 #    - noctx

--- a/artifact/image/whiteout/whiteout.go
+++ b/artifact/image/whiteout/whiteout.go
@@ -39,6 +39,7 @@ func Files(scalibrfs scalibrfs.FS) (map[string]struct{}, error) {
 
 	err := fs.WalkDir(scalibrfs, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			//nolint:nilerr // continue walking if there is an error
 			return nil
 		}
 


### PR DESCRIPTION
This linter aims to catch mix ups in returns for errors on branches that have asserted an error wasn't `nil`, as usually you want to be returning an error even if it's not the original one or otherwise you'd not have the function return an error in the first place.

Of course, our one violation of this linter happens to be an exception to the rule: `fs.WalkDir` takes `nil` to mean "thanks for letting us know, now continue with the rest of the walk" for cases where it can't walk a particular path.

Relates to #274