### PR TITLE
fix: ensure extractors return a `nil` slice when erroring

### DIFF
--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
@@ -33,7 +33,7 @@ func TestExtractor_Extract_v1(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-json.txt",
 			},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
 		},
 		{

--- a/extractor/filesystem/language/cpp/conanlock/conanlock.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock.go
@@ -214,7 +214,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 
 	err := json.NewDecoder(input.Reader).Decode(&parsedLockfile)
 	if err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 
 	inv := parseConanLock(*parsedLockfile)

--- a/extractor/filesystem/language/golang/gobinary/gobinary.go
+++ b/extractor/filesystem/language/golang/gobinary/gobinary.go
@@ -136,7 +136,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		buf := bytes.NewBuffer([]byte{})
 		_, err := io.Copy(buf, input.Reader)
 		if err != nil {
-			return []*extractor.Inventory{}, err
+			return nil, err
 		}
 		readerAt = bytes.NewReader(buf.Bytes())
 	}

--- a/extractor/filesystem/language/java/gradlelockfile/gradlelockfile.go
+++ b/extractor/filesystem/language/java/gradlelockfile/gradlelockfile.go
@@ -107,7 +107,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	}
 
 	if err := scanner.Err(); err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("failed to read: %w", err)
+		return nil, fmt.Errorf("failed to read: %w", err)
 	}
 
 	return pkgs, nil

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml.go
@@ -64,7 +64,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	err := xml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 
 	pkgs := make([]*extractor.Inventory, 0, len(parsedLockfile.Components))

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
@@ -107,7 +107,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-xml.txt",
 			},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
 		},
 		{

--- a/extractor/filesystem/language/java/pomxml/pomxml.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml.go
@@ -153,7 +153,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	err := xml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 
 	details := map[string]*extractor.Inventory{}

--- a/extractor/filesystem/language/java/pomxml/pomxml_test.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml_test.go
@@ -75,7 +75,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-pom.txt",
 			},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
 		},
 		{
@@ -83,7 +83,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/invalid-syntax.xml",
 			},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
 		},
 		{

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
@@ -241,7 +241,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	err := yaml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil && !errors.Is(err, io.EOF) {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 
 	// this will happen if the file is empty

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
@@ -83,7 +83,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-yaml.txt",
 			},
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 		},
 		{
 			Name: "invalid dep path",

--- a/extractor/filesystem/language/php/composerlock/composerlock.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock.go
@@ -67,7 +67,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	err := json.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 
 	packages := make(

--- a/extractor/filesystem/language/php/composerlock/composerlock_test.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock_test.go
@@ -82,7 +82,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-json.txt",
 			},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
 		},
 		{

--- a/extractor/filesystem/language/python/pdmlock/pdmlock.go
+++ b/extractor/filesystem/language/python/pdmlock/pdmlock.go
@@ -66,7 +66,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 
 	_, err := toml.NewDecoder(input.Reader).Decode(&parsedLockFile)
 	if err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 	packages := make([]*extractor.Inventory, 0, len(parsedLockFile.Packages))
 

--- a/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
+++ b/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
@@ -89,7 +89,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-toml.txt",
 			},
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/python/pipfilelock/pipfilelock.go
+++ b/extractor/filesystem/language/python/pipfilelock/pipfilelock.go
@@ -67,7 +67,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	err := json.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 
 	details := make(map[string]*extractor.Inventory)

--- a/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
+++ b/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
@@ -83,7 +83,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-json.txt",
 			},
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/python/poetrylock/poetrylock.go
+++ b/extractor/filesystem/language/python/poetrylock/poetrylock.go
@@ -72,7 +72,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	_, err := toml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 
 	packages := make([]*extractor.Inventory, 0, len(parsedLockfile.Packages))

--- a/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
+++ b/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
@@ -83,7 +83,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-toml.txt",
 			},
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/r/renvlock/renvlock.go
+++ b/extractor/filesystem/language/r/renvlock/renvlock.go
@@ -63,7 +63,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	err := json.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 
 	packages := make([]*extractor.Inventory, 0, len(parsedLockfile.Packages))

--- a/extractor/filesystem/language/r/renvlock/renvlock_test.go
+++ b/extractor/filesystem/language/r/renvlock/renvlock_test.go
@@ -32,7 +32,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-json.txt",
 			},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
 		},
 		{

--- a/extractor/filesystem/language/rust/cargolock/cargolock.go
+++ b/extractor/filesystem/language/rust/cargolock/cargolock.go
@@ -64,7 +64,7 @@ func (e Extractor) Extract(_ context.Context, input *filesystem.ScanInput) ([]*e
 	_, err := toml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return []*extractor.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract from %s: %w", input.Path, err)
 	}
 
 	packages := make([]*extractor.Inventory, 0, len(parsedLockfile.Packages))

--- a/extractor/filesystem/language/rust/cargolock/cargolock_test.go
+++ b/extractor/filesystem/language/rust/cargolock/cargolock_test.go
@@ -83,7 +83,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-toml.txt",
 			},
-			WantInventory: []*extractor.Inventory{},
+			WantInventory: nil,
 			WantErr:       extracttest.ContainsErrStr{Str: "could not extract from"},
 		},
 		{


### PR DESCRIPTION
This ensures we're more consistent, and is the result of discussions on [#379](https://github.com/google/osv-scalibr/pull/379#discussion_r1916805117)