### PR TITLE
test(pnpmlock): cover partial extraction and multiple error cases

### DIFF
--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
@@ -90,8 +90,54 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/invalid-path.yaml",
 			},
-			WantErr:       extracttest.ContainsErrStr{Str: "invalid dependency path"},
-			WantInventory: []*extractor.Inventory{},
+			WantErr: extracttest.ContainsErrStr{Str: "invalid dependency path"},
+			WantInventory: []*extractor.Inventory{
+				{
+					Name:       "acorn",
+					Version:    "8.7.0",
+					Locations:  []string{"testdata/invalid-path.yaml"},
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+			},
+		},
+		{
+			Name: "invalid dep paths (first error)",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid-paths.yaml",
+			},
+			WantErr: extracttest.ContainsErrStr{Str: "invalid dependency path: invalidpath1"},
+			WantInventory: []*extractor.Inventory{
+				{
+					Name:       "acorn",
+					Version:    "8.7.0",
+					Locations:  []string{"testdata/invalid-paths.yaml"},
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+			},
+		},
+		{
+			Name: "invalid dep paths (second error)",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid-paths.yaml",
+			},
+			WantErr: extracttest.ContainsErrStr{Str: "invalid dependency path: invalidpath2"},
+			WantInventory: []*extractor.Inventory{
+				{
+					Name:       "acorn",
+					Version:    "8.7.0",
+					Locations:  []string{"testdata/invalid-paths.yaml"},
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+			},
 		},
 		{
 			Name: "empty",

--- a/extractor/filesystem/language/javascript/pnpmlock/testdata/invalid-paths.yaml
+++ b/extractor/filesystem/language/javascript/pnpmlock/testdata/invalid-paths.yaml
@@ -8,13 +8,19 @@ dependencies:
 
 packages:
 
+  invalidpath1:
+    resolution: {integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
+
   /acorn/8.7.0:
     resolution: {integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: false
 
-  invalidpath:
+  invalidpath2:
     resolution: {integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true


### PR DESCRIPTION
This ensures that the extractor will return everything it's managed to extract successfully in the event of a recoverable error extracting a specific package, and that it also includes all the errors in its output