### PR TITLE
refactor: ensure that all fields in (un)marshaled structs have tags

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,7 +54,7 @@ linters:
     - makezero
     - mirror
     - misspell
-#    - musttag
+    - musttag
     - nakedret
 #    - nilerr
 #    - nilnil

--- a/detector/govulncheck/binary/message.go
+++ b/detector/govulncheck/binary/message.go
@@ -35,19 +35,19 @@ type govulncheckFrame struct {
 // in https://go.dev/security/vuln/database#schema.
 type osvEntry struct {
 	// ID is a unique identifier for the vulnerability.
-	ID string
+	ID string `json:"id"`
 	// Aliases is a list of IDs for the same vulnerability in other
 	// databases (CVE, GHSA)
-	Aliases []string
+	Aliases []string `json:"aliases"`
 	// Summary gives a one-line, English textual summary of the vulnerability.
 	// It is recommended that this field be kept short, on the order of no more
 	// than 120 characters.
-	Summary string
+	Summary string `json:"summary"`
 	// Details contains additional English textual details about the vulnerability.
-	Details string
+	Details string `json:"details"`
 	// Affected contains information on the modules and versions
 	// affected by the vulnerability.
-	Affected []affected
+	Affected []affected `json:"affects"`
 }
 
 type affected struct {


### PR DESCRIPTION
While tags are technically not required, it's recommended to always include them so that changes to the structure of the struct on the Go side do not immediately change the field being used when (un)marshalling from an external data source.

Relates to #274