### PR TITLE
chore: enable `errname` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,7 +24,7 @@ linters:
     - durationcheck
 #    - errcheck
 #    - errchkjson
-#    - errname
+    - errname
 #    - errorlint
 #    - exhaustive
 #    - fatcontext

--- a/testing/extracttest/errors.go
+++ b/testing/extracttest/errors.go
@@ -21,6 +21,8 @@ import (
 
 // ContainsErrStr is an error that matches other errors that contains
 // `str` in their error string.
+//
+//nolint:errname
 type ContainsErrStr struct {
 	Str string
 }


### PR DESCRIPTION
This enforces errors end with "Error" as per Go convention - the only violation we have of this is with `extracttest.ContainsErrStr` which we could rename, but (if my understanding is correct) it's not really an error in the traditional sense so I think it makes sense to skip that one.

In future if we find ourselves adding more "test errors", we can configure golangci to skip this whole file

Relates to #274