### PR TITLE
chore: enable `containedctx` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,7 @@ linters:
     - bidichk
     - bodyclose
     - canonicalheader
-#    - containedctx
+    - containedctx
 #    - contextcheck
     - copyloopvar
     - decorder

--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -237,6 +237,7 @@ func RunFS(ctx context.Context, config *Config, wc *walkContext) ([]*extractor.I
 }
 
 type walkContext struct {
+	//nolint:containedctx
 	ctx               context.Context
 	stats             stats.Collector
 	extractors        []Extractor

--- a/testing/fakeextractor/fake_extractor_test.go
+++ b/testing/fakeextractor/fake_extractor_test.go
@@ -142,6 +142,7 @@ func TestExtract(t *testing.T) {
 	}}
 
 	type args struct {
+		//nolint:containedctx
 		ctx   context.Context
 		input *filesystem.ScanInput
 	}


### PR DESCRIPTION
This linter discourages the usage of `context.Context` fields on structs which is generally considered [bad practice](https://go.dev/blog/context-and-structs).

Relates to #274