### PR TITLE
refactor: reuse existing context where possible

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,7 +14,7 @@ linters:
     - bodyclose
     - canonicalheader
 #    - containedctx
-#    - contextcheck
+    - contextcheck
     - copyloopvar
     - decorder
 #    - depguard

--- a/extractor/filesystem/os/rpm/rpm_linux.go
+++ b/extractor/filesystem/os/rpm/rpm_linux.go
@@ -174,7 +174,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 			}
 		}()
 	}
-	rpmPkgs, err := e.parseRPMDB(absPath)
+	rpmPkgs, err := e.parseRPMDB(ctx, absPath)
 	if err != nil {
 		return nil, fmt.Errorf("ParseRPMDB(%s): %w", absPath, err)
 	}
@@ -213,7 +213,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 }
 
 // parseRPMDB returns a slice of OS packages parsed from a RPM DB.
-func (e Extractor) parseRPMDB(path string) ([]rpmPackageInfo, error) {
+func (e Extractor) parseRPMDB(ctx context.Context, path string) ([]rpmPackageInfo, error) {
 	db, err := rpmdb.Open(path)
 	if err != nil {
 		return nil, err
@@ -227,7 +227,7 @@ func (e Extractor) parseRPMDB(path string) ([]rpmPackageInfo, error) {
 			return nil, err
 		}
 	} else {
-		ctx, cancelFunc := context.WithTimeout(context.Background(), e.Timeout)
+		ctx, cancelFunc := context.WithTimeout(ctx, e.Timeout)
 		defer cancelFunc()
 
 		// The timeout is only for corrupt bdb databases

--- a/extractor/standalone/containers/containerd/containerd_linux.go
+++ b/extractor/standalone/containers/containerd/containerd_linux.go
@@ -192,7 +192,7 @@ func containersFromAPI(ctx context.Context, client CtrdClient) ([]Metadata, erro
 
 func namespacesFromAPI(ctx context.Context, client CtrdClient) ([]string, error) {
 	nsService := client.NamespaceService()
-	nss, err := nsService.List(context.Background())
+	nss, err := nsService.List(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This enables the `contextcheck` linter which ensures we're properly inheriting our contexts when appropriate - for the existing violations, I've refactored the code to reuse contexts that are nearby which feels like the right thing to do, but I'm not super experienced with managing contexts so maybe it's the wrong thing to do 😅

Relates to #274