### PR TITLE
fix: Fix diffids being wrongly generated

### DIFF
--- a/artifact/image/layerscanning/image/layer.go
+++ b/artifact/image/layerscanning/image/layer.go
@@ -95,7 +95,7 @@ func convertV1Layer(v1Layer v1.Layer, command string, isEmpty bool) (*Layer, err
 	}
 
 	return &Layer{
-		diffID:       digest.FromString(diffID.String()),
+		diffID:       digest.Digest(diffID.String()),
 		buildCommand: command,
 		isEmpty:      isEmpty,
 		uncompressed: uncompressed,

--- a/artifact/image/layerscanning/image/layer_test.go
+++ b/artifact/image/layerscanning/image/layer_test.go
@@ -48,8 +48,7 @@ func TestConvertV1Layer(t *testing.T) {
 			command: "ADD file",
 			isEmpty: false,
 			wantLayer: &Layer{
-				// The diffID is the encoded string: digest.FromString("abc123").
-				diffID:       "sha256:27f2fb5c8ba6b6d955cbc3cd78e89a898cac60a0442260129235683f4cc74e90",
+				diffID:       "sha256:abc123",
 				buildCommand: "ADD file",
 				isEmpty:      false,
 				uncompressed: reader,


### PR DESCRIPTION
FromString actually hashes the string, Digest itself is already a wrapper around a string, so to turn a string directly into a digest just cast it.

We need some snapshot-like tests for container scanning to catch these behavioural changes before they get merged.

Oh wait, we had the tests, just missed it in the review.