### PR TITLE
fix: Stop error logging during traceback.

### DIFF
--- a/artifact/image/layerscanning/trace/trace.go
+++ b/artifact/image/layerscanning/trace/trace.go
@@ -124,7 +124,10 @@ func PopulateLayerDetails(ctx context.Context, inventory []*extractor.Inventory,
 					oldInventory = []*extractor.Inventory{}
 				} else {
 					// Update the extractor config to use the files from the current layer.
-					updateExtractorConfig(inv.Locations, invExtractor, oldChainLayer.FS())
+					// We only take extract the first location because other locations are derived from the initial
+					// extraction location. If other locations can no longer be determined from the first location
+					// they should not be included here, and the trace for those packages stops here.
+					updateExtractorConfig([]string{inv.Locations[0]}, invExtractor, oldChainLayer.FS())
 
 					var err error
 					oldInventory, _, err = filesystem.Run(ctx, config)

--- a/artifact/image/layerscanning/trace/trace.go
+++ b/artifact/image/layerscanning/trace/trace.go
@@ -120,17 +120,17 @@ func PopulateLayerDetails(ctx context.Context, inventory []*extractor.Inventory,
 			} else {
 				// Check if file still exist in this layer, if not skip extraction.
 				// This is both an optimization, and avoids polluting the log output with false file not found errors.
-				if _, err := oldChainLayer.FS().Stat(inv.Name); errors.Is(err, fs.ErrNotExist) {
-					break
-				}
+				if _, err := oldChainLayer.FS().Stat(inv.Locations[0]); errors.Is(err, fs.ErrNotExist) {
+					oldInventory = []*extractor.Inventory{}
+				} else {
+					// Update the extractor config to use the files from the current layer.
+					updateExtractorConfig(inv.Locations, invExtractor, oldChainLayer.FS())
 
-				// Update the extractor config to use the files from the current layer.
-				updateExtractorConfig(inv.Locations, invExtractor, oldChainLayer.FS())
-
-				var err error
-				oldInventory, _, err = filesystem.Run(ctx, config)
-				if err != nil {
-					break
+					var err error
+					oldInventory, _, err = filesystem.Run(ctx, config)
+					if err != nil {
+						break
+					}
 				}
 
 				// Cache the inventory for future use.


### PR DESCRIPTION
@mleyvajr100 FYI this will change the log output quite a bit.

I also updated slightly how traceback works with inventories that contain multiple locations. From what I understand for filesystem extraction only the first Location is the location that the initial walk extracts, and the following locations are just additional information that is obtained from that initial first file. 

Therefore we should only extract the first file during traceback.