### PR TITLE
fix(yarnlock): ignore `yarn.lock` files in `node_modules`

### DIFF
--- a/extractor/filesystem/language/javascript/yarnlock/yarnlock_test.go
+++ b/extractor/filesystem/language/javascript/yarnlock/yarnlock_test.go
@@ -51,6 +51,10 @@ func TestExtractor_FileRequired(t *testing.T) {
 			inputPath: "path.to.my.yarn.lock",
 			want:      false,
 		},
+		{
+			inputPath: "foo/node_modules/bar/yarn.lock",
+			want:      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.inputPath, func(t *testing.T) {


### PR DESCRIPTION
This mirrors the behaviour of `packagelockjson`, so I think it should be applied here too as I don't know of any tool which respects lockfiles in `node_modules`.

This _might_ fix https://github.com/google/osv-scalibr/issues/400