### PR TITLE
fix(pnpmlock): ignore `pnpm-lock.yaml` files in `node_modules`

### DIFF
--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -231,7 +232,19 @@ func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabili
 
 // FileRequired returns true if the specified file matches pnpm-lock.yaml files.
 func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
-	return filepath.Base(api.Path()) == "pnpm-lock.yaml"
+	path := api.Path()
+	if filepath.Base(path) != "pnpm-lock.yaml" {
+		return false
+	}
+	// Skip lockfiles inside node_modules directories since the packages they list aren't
+	// necessarily installed by the root project. We instead use the more specific top-level
+	// lockfile for the root project dependencies.
+	dir := filepath.ToSlash(filepath.Dir(path))
+	if slices.Contains(strings.Split(dir, "/"), "node_modules") {
+		return false
+	}
+
+	return true
 }
 
 // Extract extracts packages from a pnpm-lock.yaml file passed through the scan input.

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
@@ -63,6 +63,11 @@ func TestExtractor_FileRequired(t *testing.T) {
 			inputPath: "path.to.my.pnpm-lock.yaml",
 			want:      false,
 		},
+		{
+			name:      "",
+			inputPath: "foo/node_modules/bar/pnpn-lock.yaml",
+			want:      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This mirrors the behaviour of `packagelockjson`, so I think it should be applied here too as I don't know of any tool which respects lockfiles in `node_modules`.