### PR TITLE
fix(bunlock): ignore `bun.lock` files in `node_modules`

### DIFF
--- a/extractor/filesystem/language/javascript/bunlock/bunlock_test.go
+++ b/extractor/filesystem/language/javascript/bunlock/bunlock_test.go
@@ -63,6 +63,11 @@ func TestExtractor_FileRequired(t *testing.T) {
 			inputPath: "path.to.my.bun.lock",
 			want:      false,
 		},
+		{
+			name:      "",
+			inputPath: "foo/node_modules/bar/bun.lock",
+			want:      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This mirrors the behaviour of `packagelockjson`, so I think it should be applied here too as I don't know of any tool which respects lockfiles in `node_modules`.