### PR TITLE
fix(bunlock): import package that actually exists

### DIFF
--- a/extractor/filesystem/language/javascript/bunlock/bunlock.go
+++ b/extractor/filesystem/language/javascript/bunlock/bunlock.go
@@ -29,7 +29,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/osv"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/purl"
-	"github.com/tidwall/jsonc/pkg/jsonc"
+	"github.com/tidwall/jsonc"
 )
 
 type bunLockfile struct {


### PR DESCRIPTION
This was introduced in the commit that landed #379 - I'm pretty sure this change wasn't actually meant to be included in the commit