### PR TITLE
feat: add Maven type and classifier to PURL qualifiers

### DIFF
--- a/extractor/filesystem/language/java/javalockfile/metadata.go
+++ b/extractor/filesystem/language/java/javalockfile/metadata.go
@@ -19,6 +19,8 @@ package javalockfile
 type Metadata struct {
 	ArtifactID   string
 	GroupID      string
+	Type         string
+	Classifier   string
 	DepGroupVals []string
 }
 

--- a/extractor/filesystem/language/java/pomxml/pomxml.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml.go
@@ -45,6 +45,8 @@ type mavenLockDependency struct {
 	ArtifactID string   `xml:"artifactId"`
 	Version    string   `xml:"version"`
 	Scope      string   `xml:"scope"`
+	Type       string   `xml:"type"`
+	Classifier string   `xml:"classifier"`
 }
 
 func (mld mavenLockDependency) parseResolvedVersion(version string) string {
@@ -185,6 +187,8 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		metadata := javalockfile.Metadata{
 			ArtifactID:   lockPackage.ArtifactID,
 			GroupID:      lockPackage.GroupID,
+			Type:         lockPackage.Type,
+			Classifier:   lockPackage.Classifier,
 			DepGroupVals: []string{},
 		}
 		pkgDetails := &extractor.Inventory{
@@ -211,6 +215,10 @@ func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 		Namespace: strings.ToLower(m.GroupID),
 		Name:      strings.ToLower(m.ArtifactID),
 		Version:   i.Version,
+		Qualifiers: purl.QualifiersFromMap(map[string]string{
+			purl.Type:       m.Type,
+			purl.Classifier: m.Classifier,
+		}),
 	}
 }
 

--- a/extractor/filesystem/language/java/pomxml/pomxml_test.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml_test.go
@@ -243,6 +243,26 @@ func TestExtractor_Extract(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "with type and classifier",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/with-type-classifier.xml",
+			},
+			WantInventory: []*extractor.Inventory{
+				{
+					Name:      "abc:xyz",
+					Version:   "1.0.0",
+					Locations: []string{"testdata/with-type-classifier.xml"},
+					Metadata: &javalockfile.Metadata{
+						ArtifactID:   "xyz",
+						GroupID:      "abc",
+						Type:         "pom",
+						Classifier:   "sources",
+						DepGroupVals: []string{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/extractor/filesystem/language/java/pomxml/testdata/with-type-classifier.xml
+++ b/extractor/filesystem/language/java/pomxml/testdata/with-type-classifier.xml
@@ -1,0 +1,11 @@
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>abc</groupId>
+      <artifactId>xyz</artifactId>
+      <version>1.0.0</version>
+      <type>pom</type>
+      <classifier>sources</classifier>
+    </dependency>
+  </dependencies>
+</project>

--- a/purl/purl.go
+++ b/purl/purl.go
@@ -218,4 +218,6 @@ const (
 	SourceRPM           = "sourcerpm"
 	BuildNumber         = "buildnumber"
 	PackageDependencies = "packagedependencies"
+	Classifier          = "classifier" // Maven specific qualifier
+	Type                = "type"       // Maven specific qualifier
 )


### PR DESCRIPTION
https://github.com/google/osv-scalibr/issues/426

This PR adds Maven `type` and `classifier` to PURL qualifiers in the basic `pomxml` extractor. 