### PR TITLE
fix: FileRequired for SBOM extractors to correctly identify names based on spec

### DIFF
--- a/extractor/filesystem/sbom/cdx/cdx.go
+++ b/extractor/filesystem/sbom/cdx/cdx.go
@@ -47,9 +47,12 @@ type extractFunc = func(io.Reader) (cyclonedx.BOM, error)
 // https://cyclonedx.org/specification/overview/#recognized-file-patterns
 var cdxExtensions = map[string]cyclonedx.BOMFileFormat{
 	".cdx.json": cyclonedx.BOMFileFormatJSON,
-	".bom.json": cyclonedx.BOMFileFormatJSON,
 	".cdx.xml":  cyclonedx.BOMFileFormatXML,
-	".bom.xml":  cyclonedx.BOMFileFormatXML,
+}
+
+var cdxNames = map[string]cyclonedx.BOMFileFormat{
+	"bom.json": cyclonedx.BOMFileFormatJSON,
+	"bom.xml":  cyclonedx.BOMFileFormatXML,
 }
 
 // FileRequired returns true if the specified file is a supported cdx file.
@@ -79,6 +82,15 @@ func findExtractor(path string) extractFunc {
 
 	for ext, format := range cdxExtensions {
 		if hasFileExtension(path, ext) {
+			return func(rdr io.Reader) (cyclonedx.BOM, error) {
+				var cdxBOM cyclonedx.BOM
+				return cdxBOM, cyclonedx.NewBOMDecoder(rdr, format).Decode(&cdxBOM)
+			}
+		}
+	}
+
+	for name, format := range cdxNames {
+		if strings.ToLower(filepath.Base(path)) == name {
 			return func(rdr io.Reader) (cyclonedx.BOM, error) {
 				var cdxBOM cyclonedx.BOM
 				return cdxBOM, cyclonedx.NewBOMDecoder(rdr, format).Decode(&cdxBOM)

--- a/extractor/filesystem/sbom/cdx/cdx_test.go
+++ b/extractor/filesystem/sbom/cdx/cdx_test.go
@@ -55,11 +55,21 @@ func TestFileRequired(t *testing.T) {
 		{
 			name:           "sbom.bom.json",
 			path:           "testdata/sbom.bom.json",
-			wantIsRequired: true,
+			wantIsRequired: false,
 		},
 		{
 			name:           "sbom.bom.xml",
 			path:           "testdata/sbom.bom.xml",
+			wantIsRequired: false,
+		},
+		{
+			name:           "bom.json",
+			path:           "testdata/bom.json",
+			wantIsRequired: true,
+		},
+		{
+			name:           "bom.xml",
+			path:           "testdata/bom.xml",
 			wantIsRequired: true,
 		},
 		{

--- a/extractor/filesystem/sbom/spdx/spdx.go
+++ b/extractor/filesystem/sbom/spdx/spdx.go
@@ -50,10 +50,11 @@ type extractFunc = func(io.Reader) (*spdx.Document, error)
 
 // Format support based on https://spdx.dev/resources/use/#documents
 var extensionHandlers = map[string]extractFunc{
-	".spdx.json": json.Read,
-	".spdx":      tagvalue.Read,
-	".spdx.yml":  yaml.Read,
-	".spdx.rdf":  rdf.Read,
+	".spdx.json":    json.Read,
+	".spdx":         tagvalue.Read,
+	".spdx.yml":     yaml.Read,
+	".spdx.rdf":     rdf.Read,
+	".spdx.rdf.xml": rdf.Read,
 	// No support for .xsl files because those are too ambiguous and could be many other things.
 }
 

--- a/extractor/filesystem/sbom/spdx/spdx_test.go
+++ b/extractor/filesystem/sbom/spdx/spdx_test.go
@@ -68,6 +68,11 @@ func TestFileRequired(t *testing.T) {
 			wantIsRequired: true,
 		},
 		{
+			name:           "sbom.spdx.rdf.xml",
+			path:           "testdata/sbom.spdx.rdf.xml",
+			wantIsRequired: true,
+		},
+		{
 			name:           "random_file.ext",
 			path:           "testdata/random_file.ext",
 			wantIsRequired: false,


### PR DESCRIPTION
This fixes the current implementation to correctly identify SBOM files that fit the spec, and discard non spec filenames.

Removes support for:
```
*.bom.json
*.bom.spdx
```

Adds support for:
```
bom.json
bom.spdx
spdx.rdf.xml (Official example is a file with .xml extension)
```

https://cyclonedx.org/specification/overview/#recognized-file-patterns
https://spdx.dev/learn/overview/#documents

Related: https://github.com/google/osv-scanner/discussions/1529#discussioncomment-12017733 