### PR TITLE
chore: make `nolint` in its own line

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,7 +60,7 @@ linters:
 #    - nilnil
 #    - nlreturn
 #    - noctx
-#    - nolintlint
+    - nolintlint
 #    - nosprintfhostport
 #    - perfsprint
 #    - prealloc

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,7 +60,7 @@ linters:
 #    - nilnil
 #    - nlreturn
 #    - noctx
-    - nolintlint
+#    - nolintlint
 #    - nosprintfhostport
 #    - perfsprint
 #    - prealloc

--- a/artifact/image/whiteout/whiteout.go
+++ b/artifact/image/whiteout/whiteout.go
@@ -40,7 +40,8 @@ func Files(scalibrfs scalibrfs.FS) (map[string]struct{}, error) {
 
 	err := fs.WalkDir(scalibrfs, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			// nolint:nilerr // Continue walking if there is an error.
+			// Continue walking if there is an error.
+			//nolint:nilerr
 			return nil
 		}
 

--- a/artifact/image/whiteout/whiteout.go
+++ b/artifact/image/whiteout/whiteout.go
@@ -40,7 +40,6 @@ func Files(scalibrfs scalibrfs.FS) (map[string]struct{}, error) {
 
 	err := fs.WalkDir(scalibrfs, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			// nolint:nilerr // Continue walking if there is an error.
 			return nil
 		}
 

--- a/artifact/image/whiteout/whiteout.go
+++ b/artifact/image/whiteout/whiteout.go
@@ -40,6 +40,7 @@ func Files(scalibrfs scalibrfs.FS) (map[string]struct{}, error) {
 
 	err := fs.WalkDir(scalibrfs, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			// nolint:nilerr // Continue walking if there is an error.
 			return nil
 		}
 


### PR DESCRIPTION
Tweak the comments a bit to make it pass both the public and internal linters.