### PR TITLE
feat: use Maven Central mirror as the registry for pomxmlnet extractor

### DIFF
--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -36,6 +36,10 @@ import (
 // MavenCentral holds the URL of Maven Central Repository.
 const MavenCentral = "https://repo.maven.apache.org/maven2"
 
+// MavenCentralMirror holds the URL of Maven Central mirror hosted on Google Cloud Storage.
+// https://storage-download.googleapis.com/maven-central/index.html
+const MavenCentralMirror = "https://maven-central.storage-download.googleapis.com/maven2/"
+
 var errAPIFailed = errors.New("API query failed")
 
 // MavenRegistryAPIClient defines a client to fetch metadata from a Maven registry.

--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
@@ -48,18 +48,23 @@ type Config struct {
 	*datasource.MavenRegistryAPIClient
 }
 
-// DefaultConfig returns the default configuration for the pomxmlnet extractor.
-func DefaultConfig() Config {
+// NewConfig returns the configuration given the URL of the Maven registry to fetch metadata.
+func NewConfig(registry string) Config {
 	// No need to check errors since we are using the default Maven Central URL.
-	depClient, _ := resolution.NewMavenRegistryClient(datasource.MavenCentral)
+	depClient, _ := resolution.NewMavenRegistryClient(registry)
 	mavenClient, _ := datasource.NewMavenRegistryAPIClient(datasource.MavenRegistry{
-		URL:             datasource.MavenCentral,
+		URL:             registry,
 		ReleasesEnabled: true,
 	})
 	return Config{
 		DependencyClient:       depClient,
 		MavenRegistryAPIClient: mavenClient,
 	}
+}
+
+// DefaultConfig returns the default configuration for the pomxmlnet extractor.
+func DefaultConfig() Config {
+	return NewConfig(datasource.MavenCentral)
 }
 
 // New makes a new pom.xml transitive extractor with the given config.

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -24,6 +24,7 @@ import (
 	// OSV extractors.
 
 	// SCALIBR internal extractors.
+	"github.com/google/osv-scalibr/clients/datasource"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/bunlock"
 
@@ -102,7 +103,7 @@ var (
 		gradlelockfile.Extractor{},
 		gradleverificationmetadataxml.Extractor{},
 		javaarchive.New(javaarchive.DefaultConfig()),
-		pomxmlnet.New(pomxmlnet.DefaultConfig()),
+		pomxmlnet.New(pomxmlnet.NewConfig(datasource.MavenCentralMirror)),
 	}
 	// Javascript extractors.
 	Javascript []filesystem.Extractor = []filesystem.Extractor{


### PR DESCRIPTION
Maven Central has quite strict rate limit, we probably want switch to [Maven Central mirror](https://storage-download.googleapis.com/maven-central/index.html) considering the internal use case.