### PR TITLE
refactor: explicitly ignore errors that we don't need to handle

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,7 +22,7 @@ linters:
     - dupl
     - dupword
     - durationcheck
-#    - errcheck
+    - errcheck
     - errchkjson
     - errname
 #    - errorlint

--- a/artifact/image/layerscanning/image/file_node_test.go
+++ b/artifact/image/layerscanning/image/file_node_test.go
@@ -154,9 +154,9 @@ func TestRead(t *testing.T) {
 	const bufferSize = 20
 
 	tempDir := t.TempDir()
-	os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
+	_ = os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
 
-	os.WriteFile(path.Join(tempDir, "baz"), []byte("baz"), 0600)
+	_ = os.WriteFile(path.Join(tempDir, "baz"), []byte("baz"), 0600)
 	openedRootFile, err := os.OpenFile(path.Join(tempDir, "baz"), os.O_RDONLY, filePermission)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -166,8 +166,8 @@ func TestRead(t *testing.T) {
 	// separate test.
 	defer openedRootFile.Close()
 
-	os.MkdirAll(path.Join(tempDir, "dir1"), 0700)
-	os.WriteFile(path.Join(tempDir, "dir1/foo"), []byte("foo"), 0600)
+	_ = os.MkdirAll(path.Join(tempDir, "dir1"), 0700)
+	_ = os.WriteFile(path.Join(tempDir, "dir1/foo"), []byte("foo"), 0600)
 
 	fileNodeWithUnopenedFile := &fileNode{
 		extractDir:    tempDir,
@@ -255,7 +255,7 @@ func TestRead(t *testing.T) {
 			}
 
 			// Close the file. The Close method is tested in a separate test.
-			tc.node.Close()
+			_ = tc.node.Close()
 		})
 	}
 }
@@ -264,9 +264,9 @@ func TestReadAt(t *testing.T) {
 	const bufferSize = 20
 
 	tempDir := t.TempDir()
-	os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
+	_ = os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
 
-	os.WriteFile(path.Join(tempDir, "baz"), []byte("baz"), 0600)
+	_ = os.WriteFile(path.Join(tempDir, "baz"), []byte("baz"), 0600)
 	openedRootFile, err := os.OpenFile(path.Join(tempDir, "baz"), os.O_RDONLY, filePermission)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -276,8 +276,8 @@ func TestReadAt(t *testing.T) {
 	// separate test.
 	defer openedRootFile.Close()
 
-	os.MkdirAll(path.Join(tempDir, "dir1"), 0700)
-	os.WriteFile(path.Join(tempDir, "dir1/foo"), []byte("foo"), 0600)
+	_ = os.MkdirAll(path.Join(tempDir, "dir1"), 0700)
+	_ = os.WriteFile(path.Join(tempDir, "dir1/foo"), []byte("foo"), 0600)
 
 	fileNodeWithUnopenedFile := &fileNode{
 		extractDir:    tempDir,
@@ -403,7 +403,7 @@ func TestReadAt(t *testing.T) {
 // Test for the Seek method
 func TestSeek(t *testing.T) {
 	tempDir := t.TempDir()
-	os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
+	_ = os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
 
 	// Test seeking to different positions
 	tests := []struct {
@@ -461,7 +461,7 @@ func TestSeek(t *testing.T) {
 				mode:          filePermission,
 			}
 			gotPos, err := fileNode.Seek(tc.offset, tc.whence)
-			fileNode.Close()
+			_ = fileNode.Close()
 			if err != nil {
 				t.Fatalf("Seek failed: %v", err)
 			}
@@ -474,7 +474,7 @@ func TestSeek(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	tempDir := t.TempDir()
-	os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
+	_ = os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
 
 	fileNodeWithUnopenedFile := &fileNode{
 		extractDir:    tempDir,
@@ -520,8 +520,8 @@ func TestReadingAfterClose(t *testing.T) {
 	const readAndCloseEvents = 2
 
 	tempDir := t.TempDir()
-	os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
-	os.WriteFile(path.Join(tempDir, "baz"), []byte("baz"), 0600)
+	_ = os.WriteFile(path.Join(tempDir, "bar"), []byte("bar"), 0600)
+	_ = os.WriteFile(path.Join(tempDir, "baz"), []byte("baz"), 0600)
 	openedRootFile, err := os.OpenFile(path.Join(tempDir, "baz"), os.O_RDONLY, filePermission)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)

--- a/artifact/image/layerscanning/image/image.go
+++ b/artifact/image/layerscanning/image/image.go
@@ -486,7 +486,7 @@ func fillChainLayersWithFilesFromTar(img *Image, tarReader *tar.Reader, originLa
 
 		// Add the fileNode to the node tree of the underlying layer.
 		layer := currentChainLayer.latestLayer.(*Layer)
-		layer.fileNodeTree.Insert(virtualPath, newNode)
+		_ = layer.fileNodeTree.Insert(virtualPath, newNode)
 	}
 	return requiredTargets, nil
 }
@@ -627,7 +627,7 @@ func fillChainLayersWithFileNode(chainLayersToFill []*chainLayer, newNode *fileN
 
 		// Add the file to the chain layer. If there is an error, then we fail open.
 		// TODO: b/379154069 - Add logging for fail open errors.
-		chainLayer.fileNodeTree.Insert(virtualPath, newNode)
+		_ = chainLayer.fileNodeTree.Insert(virtualPath, newNode)
 	}
 }
 

--- a/artifact/image/layerscanning/image/image_test.go
+++ b/artifact/image/layerscanning/image/image_test.go
@@ -581,6 +581,7 @@ func TestFromTarball(t *testing.T) {
 				t.Fatalf("FromTarball(%v) returned unexpected error: %v", tc.tarPath, gotErr)
 			}
 			// Only defer call to CleanUp if the image was created successfully.
+			//nolint:errcheck
 			defer gotImage.CleanUp()
 
 			// Make sure the expected files are in the chain layers.
@@ -669,7 +670,7 @@ func TestFromV1Image(t *testing.T) {
 			gotImage, gotErr := FromV1Image(tc.v1Image, DefaultConfig())
 			defer func() {
 				if gotImage != nil {
-					gotImage.CleanUp()
+					_ = gotImage.CleanUp()
 				}
 			}()
 

--- a/artifact/image/layerscanning/image/layer_test.go
+++ b/artifact/image/layerscanning/image/layer_test.go
@@ -88,7 +88,7 @@ func TestConvertV1Layer(t *testing.T) {
 func TestChainLayerFS(t *testing.T) {
 	testDir := func() string {
 		dir := t.TempDir()
-		os.WriteFile(path.Join(dir, "file1"), []byte("file1"), 0600)
+		_ = os.WriteFile(path.Join(dir, "file1"), []byte("file1"), 0600)
 		return dir
 	}()
 
@@ -109,13 +109,13 @@ func TestChainLayerFS(t *testing.T) {
 
 	emptyTree := func() *pathtree.Node[fileNode] {
 		tree := pathtree.NewNode[fileNode]()
-		tree.Insert("/", root)
+		_ = tree.Insert("/", root)
 		return tree
 	}()
 	nonEmptyTree := func() *pathtree.Node[fileNode] {
 		tree := pathtree.NewNode[fileNode]()
-		tree.Insert("/", root)
-		tree.Insert("/file1", file1)
+		_ = tree.Insert("/", root)
+		_ = tree.Insert("/file1", file1)
 		return tree
 	}()
 
@@ -151,7 +151,7 @@ func TestChainLayerFS(t *testing.T) {
 			chainfs := tc.chainLayer.FS()
 
 			gotPaths := []string{}
-			fs.WalkDir(chainfs, "/", func(path string, d fs.DirEntry, err error) error {
+			_ = fs.WalkDir(chainfs, "/", func(path string, d fs.DirEntry, err error) error {
 				if err != nil {
 					t.Errorf("WalkDir(%v) returned error: %v", path, err)
 				}
@@ -747,15 +747,15 @@ func setUpChainFS(t *testing.T, maxSymlinkDepth int) (FS, string) {
 	}
 
 	for path, node := range vfsMap {
-		chainfs.tree.Insert(path, node)
+		_ = chainfs.tree.Insert(path, node)
 
 		if node.IsDir() {
-			os.MkdirAll(node.RealFilePath(), dirPermission)
+			_ = os.MkdirAll(node.RealFilePath(), dirPermission)
 		} else {
 			if node.mode == fs.ModeSymlink {
 				continue
 			}
-			os.WriteFile(node.RealFilePath(), []byte(path), filePermission)
+			_ = os.WriteFile(node.RealFilePath(), []byte(path), filePermission)
 		}
 	}
 	return chainfs, tempDir

--- a/artifact/image/tar/tar_test.go
+++ b/artifact/image/tar/tar_test.go
@@ -53,7 +53,7 @@ func TestSaveToTarball(t *testing.T) {
 			defer os.RemoveAll(dir)
 			path := filepath.Join(dir, "image.tar")
 			if tc.missingDir {
-				os.RemoveAll(dir)
+				_ = os.RemoveAll(dir)
 			}
 
 			err := tar.SaveToTarball(path, tc.image)

--- a/artifact/image/unpack/unpack.go
+++ b/artifact/image/unpack/unpack.go
@@ -207,7 +207,7 @@ func (u *Unpacker) UnpackSquashedFromTarball(dir string, tarPath string) error {
 		}
 		log.Infof("Unpacking pass %d of %d", pass+1, u.MaxPass)
 		requiredTargets, err = unpack(dir, reader, u.SymlinkResolution, u.SymlinkErrStrategy, u.Requirer, requiredTargets, finalPass, u.MaxSizeBytes)
-		reader.Close()
+		_ = reader.Close()
 		if err != nil {
 			return err
 		}
@@ -257,7 +257,7 @@ func (u *Unpacker) UnpackLayers(dir string, image v1.Image) ([]string, error) {
 		layerDigests = append(layerDigests, digest.String())
 
 		layerPath := filepath.Join(dir, strings.Replace(digest.String(), ":", "-", -1))
-		os.Mkdir(layerPath, fs.ModePerm)
+		_ = os.Mkdir(layerPath, fs.ModePerm)
 
 		// requiredTargets stores targets that symlinks point to.
 		// This is needed because the symlink may be required by u.requirer, but the target may not be.
@@ -441,7 +441,7 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 func (u *Unpacker) addSquashedImageDirectory(root string, image v1.Image) error {
 	squashedImagePath := filepath.Join(root, squashedImageDirectory)
 
-	os.Mkdir(squashedImagePath, fs.ModePerm)
+	_ = os.Mkdir(squashedImagePath, fs.ModePerm)
 
 	if err := u.UnpackSquashed(squashedImagePath, image); err != nil {
 		return fmt.Errorf("failed to unpack all squashed image: %w", err)

--- a/artifact/image/unpack/unpack_test.go
+++ b/artifact/image/unpack/unpack_test.go
@@ -203,7 +203,7 @@ func TestUnpackSquashed(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create temp dir: %v", err)
 			}
-			os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("some secret\n"), 0644)
+			_ = os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("some secret\n"), 0644)
 			return innerDir
 		}(),
 		image: mustImageFromPath(t, filepath.Join("testdata", "symlinks.tar")),
@@ -611,7 +611,7 @@ func mustNewSquashedImage(t *testing.T, pathsToContent map[string]contentAndMode
 			t.Fatalf("couldn't write %s: %v", path, err)
 		}
 	}
-	w.Close()
+	_ = w.Close()
 	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewBuffer(buf.Bytes())), nil
 	})

--- a/clients/datasource/cache_test.go
+++ b/clients/datasource/cache_test.go
@@ -38,7 +38,7 @@ func TestRequestCache(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				t.Helper()
-				requestCache.Get(i, func() (int, error) {
+				_, _ = requestCache.Get(i, func() (int, error) {
 					// Count how many times this function gets called for this key,
 					// then return the key as the value.
 					atomic.AddInt32(&fnCalls[i], 1)

--- a/clients/datasource/http_auth.go
+++ b/clients/datasource/http_auth.go
@@ -214,7 +214,7 @@ func (auth *HTTPAuthentication) addDigest(req *http.Request, challenge string) b
 			return false
 		}
 		var b bytes.Buffer
-		fmt.Fprintf(&b, "%x:%s:%s", ha1, nonce, cnonce)
+		_, _ = fmt.Fprintf(&b, "%x:%s:%s", ha1, nonce, cnonce)
 		//nolint:gosec
 		ha1 = md5.Sum(b.Bytes())
 	case "MD5":
@@ -244,23 +244,23 @@ func (auth *HTTPAuthentication) addDigest(req *http.Request, challenge string) b
 				return false
 			}
 		}
-		fmt.Fprintf(&b, "%x:%s:%s:%s:%s:%x", ha1, nonce, nonceCount, cnonce, "auth", ha2)
+		_, _ = fmt.Fprintf(&b, "%x:%s:%s:%s:%s:%x", ha1, nonce, nonceCount, cnonce, "auth", ha2)
 	} else {
-		fmt.Fprintf(&b, "%x:%s:%x", ha1, nonce, ha2)
+		_, _ = fmt.Fprintf(&b, "%x:%s:%x", ha1, nonce, ha2)
 	}
 	//nolint:gosec
 	response := md5.Sum(b.Bytes())
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Digest username=\"%s\", realm=\"%s\", nonce=\"%s\", uri=\"%s\"",
+	_, _ = fmt.Fprintf(&sb, "Digest username=\"%s\", realm=\"%s\", nonce=\"%s\", uri=\"%s\"",
 		auth.Username, realm, nonce, uri)
 	if _, ok := params["qop"]; ok {
-		fmt.Fprintf(&sb, ", qop=auth, nc=%s, cnonce=\"%s\"", nonceCount, cnonce)
+		_, _ = fmt.Fprintf(&sb, ", qop=auth, nc=%s, cnonce=\"%s\"", nonceCount, cnonce)
 	}
 	if alg, ok := params["algorithm"]; ok {
-		fmt.Fprintf(&sb, ", algorithm=%s", alg)
+		_, _ = fmt.Fprintf(&sb, ", algorithm=%s", alg)
 	}
-	fmt.Fprintf(&sb, ", response=\"%x\", opaque=\"%s\"", response, params["opaque"])
+	_, _ = fmt.Fprintf(&sb, ", response=\"%x\", opaque=\"%s\"", response, params["opaque"])
 
 	req.Header.Add("Authorization", sb.String())
 

--- a/common/windows/registry/offline.go
+++ b/common/windows/registry/offline.go
@@ -47,7 +47,7 @@ func (o *OfflineOpener) Open() (Registry, error) {
 
 	reg, err := regparser.NewRegistry(f)
 	if err != nil {
-		f.Close()
+		_ = f.Close()
 		return nil, err
 	}
 

--- a/detector/weakcredentials/etcshadow/etcshadow.go
+++ b/detector/weakcredentials/etcshadow/etcshadow.go
@@ -104,9 +104,9 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	// Sort users to avoid non-determinism in the processing order from users map.
 	sort.Strings(problemUsers)
 	buf := new(strings.Builder)
-	fmt.Fprintln(buf, "The following users have weak passwords:")
+	_, _ = fmt.Fprintln(buf, "The following users have weak passwords:")
 	for _, u := range problemUsers {
-		fmt.Fprintln(buf, u)
+		_, _ = fmt.Fprintln(buf, u)
 	}
 	problemDescription := buf.String()
 

--- a/extractor/filesystem/containers/containerd/containerd_test.go
+++ b/extractor/filesystem/containers/containerd/containerd_test.go
@@ -247,7 +247,7 @@ func TestExtract(t *testing.T) {
 
 func createFileFromTestData(t *testing.T, root string, subPath string, fileName string, testDataFilePath string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, subPath), 0755)
+	_ = os.MkdirAll(filepath.Join(root, subPath), 0755)
 	testData, err := os.ReadFile(testDataFilePath)
 	if err != nil {
 		t.Fatalf("read from %s: %v\n", testDataFilePath, err)

--- a/extractor/filesystem/internal/walkdir_iterate_test.go
+++ b/extractor/filesystem/internal/walkdir_iterate_test.go
@@ -112,6 +112,7 @@ func TestWalkDir(t *testing.T) {
 	if err = os.Chdir(tmpDir); err != nil {
 		t.Fatal("entering temp dir:", err)
 	}
+	//nolint:errcheck
 	defer os.Chdir(origDir)
 
 	fsys := makeTree()
@@ -147,6 +148,7 @@ func TestIssue51617(t *testing.T) {
 	if err := os.Chmod(bad, 0); err != nil {
 		t.Fatal(err)
 	}
+	//nolint:errcheck
 	defer os.Chmod(bad, 0700) // avoid errors on cleanup
 	var saw []string
 	err := WalkDirUnsorted(scalibrfs.DirFS(dir), ".", func(path string, d fs.DirEntry, err error) error {

--- a/extractor/filesystem/language/java/archive/archive_test.go
+++ b/extractor/filesystem/language/java/archive/archive_test.go
@@ -698,6 +698,7 @@ func mustJar(t *testing.T, path string) *os.File {
 	if err != nil {
 		t.Fatalf("os.CreateTemp(\"temp-*.jar\") unexpected error: %v", err)
 	}
+	//nolint:errcheck
 	defer jarFile.Sync()
 
 	zipWriter := zip.NewWriter(jarFile)

--- a/extractor/filesystem/language/java/archive/manifest.go
+++ b/extractor/filesystem/language/java/archive/manifest.go
@@ -276,11 +276,11 @@ func NewOmitEmptyLinesReader(r io.Reader) io.Reader {
 		for scanner.Scan() {
 			line := scanner.Text()
 			if line != "" {
-				pw.Write([]byte(line + "\n"))
+				_, _ = pw.Write([]byte(line + "\n"))
 			}
 		}
 		if err := scanner.Err(); err != nil {
-			pw.CloseWithError(err)
+			_ = pw.CloseWithError(err)
 		}
 	}()
 

--- a/extractor/filesystem/os/apk/apk_test.go
+++ b/extractor/filesystem/os/apk/apk_test.go
@@ -422,7 +422,7 @@ func getInventory(path, pkgName, origin, version, osID, osVersionID, maintainer,
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/cos/cos_test.go
+++ b/extractor/filesystem/os/cos/cos_test.go
@@ -403,7 +403,7 @@ func TestToPURL(t *testing.T) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/dpkg/dpkg_test.go
+++ b/extractor/filesystem/os/dpkg/dpkg_test.go
@@ -1526,7 +1526,7 @@ func TestEcosystem(t *testing.T) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/flatpak/flatpak_test.go
+++ b/extractor/filesystem/os/flatpak/flatpak_test.go
@@ -366,7 +366,7 @@ func TestToPURL(t *testing.T) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/kernel/module/module_test.go
+++ b/extractor/filesystem/os/kernel/module/module_test.go
@@ -450,7 +450,7 @@ func TestEcosystem(t *testing.T) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/kernel/vmlinuz/vmlinuz_test.go
+++ b/extractor/filesystem/os/kernel/vmlinuz/vmlinuz_test.go
@@ -427,7 +427,7 @@ func TestEcosystem(t *testing.T) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/nix/nix_test.go
+++ b/extractor/filesystem/os/nix/nix_test.go
@@ -311,7 +311,7 @@ func TestToPURL(t *testing.T) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/osrelease/osrelease_test.go
+++ b/extractor/filesystem/os/osrelease/osrelease_test.go
@@ -104,8 +104,8 @@ func TestGetOSRelease(t *testing.T) {
 			}
 
 			d := t.TempDir()
-			os.Mkdir(filepath.Join(d, "etc"), 0744)
-			os.MkdirAll(filepath.Join(d, "usr/lib"), 0744)
+			_ = os.Mkdir(filepath.Join(d, "etc"), 0744)
+			_ = os.MkdirAll(filepath.Join(d, "usr/lib"), 0744)
 			p := filepath.Join(d, tt.path)
 			err := os.WriteFile(p, []byte(tt.content), tt.mode)
 			if err != nil {

--- a/extractor/filesystem/os/pacman/pacman_test.go
+++ b/extractor/filesystem/os/pacman/pacman_test.go
@@ -480,7 +480,7 @@ func TestEcosystem(t *testing.T) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/portage/portage_test.go
+++ b/extractor/filesystem/os/portage/portage_test.go
@@ -392,7 +392,7 @@ func TestEcosystem(t *testing.T) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/rpm/rpm_test.go
+++ b/extractor/filesystem/os/rpm/rpm_test.go
@@ -1002,7 +1002,7 @@ func CopyFileToTempDir(t *testing.T, filepath, root string) (string, error) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/extractor/filesystem/os/snap/snap_test.go
+++ b/extractor/filesystem/os/snap/snap_test.go
@@ -411,7 +411,7 @@ func TestEcosystem(t *testing.T) {
 
 func createOsRelease(t *testing.T, root string, content string) {
 	t.Helper()
-	os.MkdirAll(filepath.Join(root, "etc"), 0755)
+	_ = os.MkdirAll(filepath.Join(root, "etc"), 0755)
 	err := os.WriteFile(filepath.Join(root, "etc/os-release"), []byte(content), 0644)
 	if err != nil {
 		t.Fatalf("write to %s: %v\n", filepath.Join(root, "etc/os-release"), err)

--- a/internal/guidedremediation/resolution/resolve_test.go
+++ b/internal/guidedremediation/resolution/resolve_test.go
@@ -178,7 +178,7 @@ func TestResolveNPM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got.Canon()
+	_ = got.Canon()
 	got.Duration = 0 // Ignore duration for comparison
 
 	want, err := schema.ParseResolve(`
@@ -197,7 +197,7 @@ test 1.0.0
 	if err != nil {
 		t.Fatal(err)
 	}
-	want.Canon()
+	_ = want.Canon()
 	want.Duration = 0
 
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -266,7 +266,7 @@ func TestResolveMaven(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got.Canon()
+	_ = got.Canon()
 	got.Duration = 0
 
 	want, err := schema.ParseResolve(`
@@ -278,7 +278,7 @@ test:test 1.0.0
 	if err != nil {
 		t.Fatal(err)
 	}
-	want.Canon()
+	_ = want.Canon()
 	want.Duration = 0
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/scalibr_test.go
+++ b/scalibr_test.go
@@ -51,7 +51,7 @@ func TestScan(t *testing.T) {
 
 	tmp := t.TempDir()
 	tmpRoot := []*scalibrfs.ScanRoot{{FS: scalibrfs.DirFS(tmp), Path: tmp}}
-	os.WriteFile(filepath.Join(tmp, "file.txt"), []byte("Content"), 0644)
+	_ = os.WriteFile(filepath.Join(tmp, "file.txt"), []byte("Content"), 0644)
 
 	invName := "software"
 	fakeExtractor := fe.New(


### PR DESCRIPTION
This enables the `errcheck` linter which enforces errors be either handled or explicitly ignored to make it clear that the error handling has been thought about rather than mistakenly forgotten.

Relates to #274