### PR TITLE
fix: use Maven Central as registry for pomxmlnet extractor

### DIFF
--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -36,10 +36,6 @@ import (
 // MavenCentral holds the URL of Maven Central Repository.
 const MavenCentral = "https://repo.maven.apache.org/maven2"
 
-// MavenCentralMirror holds the URL of Maven Central mirror hosted on Google Cloud Storage.
-// https://storage-download.googleapis.com/maven-central/index.html
-const MavenCentralMirror = "https://maven-central.storage-download.googleapis.com/maven2/"
-
 var errAPIFailed = errors.New("API query failed")
 
 // MavenRegistryAPIClient defines a client to fetch metadata from a Maven registry.

--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -36,6 +36,10 @@ import (
 // MavenCentral holds the URL of Maven Central Repository.
 const MavenCentral = "https://repo.maven.apache.org/maven2"
 
+// MavenCentralMirror holds the URL of Maven Central mirror hosted on Google Cloud Storage.
+// https://storage-download.googleapis.com/maven-central/index.html
+const MavenCentralMirror = "https://maven-central.storage-download.googleapis.com/maven2/"
+
 var errAPIFailed = errors.New("API query failed")
 
 // MavenRegistryAPIClient defines a client to fetch metadata from a Maven registry.

--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
@@ -69,7 +69,7 @@ func NewConfig(registry string) Config {
 
 // DefaultConfig returns the default configuration for the pomxmlnet extractor.
 func DefaultConfig() Config {
-	return NewConfig(datasource.MavenCentralMirror)
+	return NewConfig(datasource.MavenCentral)
 }
 
 // New makes a new pom.xml transitive extractor with the given config.


### PR DESCRIPTION
The Maven Central mirror is not a actively maintained service so let's still use the Maven Central repository.