### PR TITLE
[extractor/golang] Generate valid golang purls

### DIFF
--- a/extractor/filesystem/language/golang/gobinary/gobinary.go
+++ b/extractor/filesystem/language/golang/gobinary/gobinary.go
@@ -221,10 +221,12 @@ func parseDependency(d *debug.Module) (string, string) {
 
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	nameParts := strings.Split(i.Name, "/")
 	return &purl.PackageURL{
-		Type:    purl.TypeGolang,
-		Name:    i.Name,
-		Version: i.Version,
+		Type:      purl.TypeGolang,
+		Name:      nameParts[len(nameParts)-1],
+		Namespace: strings.Join(nameParts[:len(nameParts)-1], "/"),
+		Version:   i.Version,
 	}
 }
 

--- a/extractor/filesystem/language/golang/gobinary/gobinary_test.go
+++ b/extractor/filesystem/language/golang/gobinary/gobinary_test.go
@@ -283,14 +283,15 @@ func TestExtract(t *testing.T) {
 func TestToPURL(t *testing.T) {
 	e := gobinary.Extractor{}
 	i := &extractor.Inventory{
-		Name:      "name",
+		Name:      "github.com/google/osv-scalibr",
 		Version:   "1.2.3",
 		Locations: []string{"location"},
 	}
 	want := &purl.PackageURL{
-		Type:    purl.TypeGolang,
-		Name:    "name",
-		Version: "1.2.3",
+		Type:      purl.TypeGolang,
+		Name:      "osv-scalibr",
+		Namespace: "github.com/google",
+		Version:   "1.2.3",
 	}
 	got := e.ToPURL(i)
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/extractor/filesystem/language/golang/gomod/gomod.go
+++ b/extractor/filesystem/language/golang/gomod/gomod.go
@@ -140,10 +140,12 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	nameParts := strings.Split(i.Name, "/")
 	return &purl.PackageURL{
-		Type:    purl.TypeGolang,
-		Name:    i.Name,
-		Version: i.Version,
+		Type:      purl.TypeGolang,
+		Name:      nameParts[len(nameParts)-1],
+		Namespace: strings.Join(nameParts[:len(nameParts)-1], "/"),
+		Version:   i.Version,
 	}
 }
 

--- a/extractor/filesystem/language/golang/gomod/gomod_test.go
+++ b/extractor/filesystem/language/golang/gomod/gomod_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
 	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/purl"
 	"github.com/google/osv-scalibr/testing/extracttest"
 )
 
@@ -276,5 +277,23 @@ func TestExtractor_Extract(t *testing.T) {
 				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
 			}
 		})
+	}
+}
+
+func TestExtractor_ToPURL(t *testing.T) {
+	e := gomod.Extractor{}
+	i := &extractor.Inventory{
+		Name:    "github.com/google/osv-scalibr",
+		Version: "1.2.3",
+	}
+	want := &purl.PackageURL{
+		Type:      purl.TypeGolang,
+		Name:      "osv-scalibr",
+		Namespace: "github.com/google",
+		Version:   "1.2.3",
+	}
+	got := e.ToPURL(i)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ToPURL(%v) (-want +got):\n%s", i, diff)
 	}
 }


### PR DESCRIPTION
According to the purl spec, the golang type is using both name and namespace.

Scalibr is only populating the name, resulting in a single percent-encoded string instead of a namespace with multiple segments and a name: Example:
 - Purl-spec: pkg:golang/github.com/google/osv-scalibr
 - Scalibr:   pkg:golang/github.com%2Fgoogle%2Fosv-scalibr

See: https://github.com/package-url/purl-spec/blob/main/PURL-TYPES.rst#golang