### PR TITLE
chore: ignore `nilerr` violations relating to linux process extractor

### DIFF
--- a/common/linux/proc/process_linux.go
+++ b/common/linux/proc/process_linux.go
@@ -94,6 +94,7 @@ func readFileDescriptors(ctx context.Context, d fs.DirEntry, inodesToPID map[int
 	// only read PID directories
 	pid, err := strconv.ParseInt(d.Name(), 10, 64)
 	if err != nil {
+		//nolint:nilerr // only read PID directories
 		return nil
 	}
 
@@ -107,6 +108,8 @@ func readFileDescriptors(ctx context.Context, d fs.DirEntry, inodesToPID map[int
 			return err
 		}
 
+		// an inode of 0 means that the file descriptor is not a socket or
+		// there was an error extracting the inode, so we just ignore it
 		if inode != 0 {
 			inodesToPID[inode] = pid
 		}
@@ -137,6 +140,7 @@ func extractSocketInode(ctx context.Context, absFdDir string, d fs.DirEntry) (in
 
 	var inode int64
 	if _, err := fmt.Sscanf(link, "socket:[%d]", &inode); err != nil {
+		//nolint:nilerr // don't surface the error
 		return 0, nil
 	}
 


### PR DESCRIPTION
I think my understanding here is correct enough, though I feel like ideally `extractSocketInode` should be returning a sentinel error rather than 0 (which I assume is being used as it is the sentinel value used by Linux to indicate there isn't an inode); in addition to that requiring a bit more code, I figure it might be possible for the function to end up with 0 anyway meaning we couldn't just get rid of the `inode != 0` ...

Ultimately, I'm just looking to get CI green again so happy to go in whatever direction(s) others would prefer (including what's written in the comments)