### PR TITLE
perf: avoid deeply nested contexts

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,7 +27,7 @@ linters:
     - errname
 #    - errorlint
 #    - exhaustive
-#    - fatcontext
+    - fatcontext
     - forbidigo
     - ginkgolinter
     - gocheckcompilerdirectives

--- a/extractor/filesystem/containers/containerd/containerd_linux.go
+++ b/extractor/filesystem/containers/containerd/containerd_linux.go
@@ -211,7 +211,7 @@ func containersFromMetaDB(ctx context.Context, metaDB *bolt.DB, scanRoot string,
 	imageStore := metadata.NewImageStore(containerdDB)
 	for _, ns := range nss {
 		// For each namespace stored in the metadb, get the container list to handle.
-		ctx = namespaces.WithNamespace(ctx, ns)
+		ctx := namespaces.WithNamespace(ctx, ns)
 		ctrs, err := containerStore.List(ctx)
 		if err != nil {
 			return nil, err

--- a/extractor/standalone/containers/containerd/containerd_linux.go
+++ b/extractor/standalone/containers/containerd/containerd_linux.go
@@ -183,7 +183,7 @@ func containersFromAPI(ctx context.Context, client CtrdClient) ([]Metadata, erro
 
 	for _, ns := range nss {
 		// For each namespace returned by the API, get the containers metadata.
-		ctx = namespaces.WithNamespace(ctx, ns)
+		ctx := namespaces.WithNamespace(ctx, ns)
 		ctrs, err := containersMetadata(ctx, client, ns, defaultContainerdRootfsPrefix)
 		if err != nil {
 			log.Errorf("Could not get a list of containers from the containerd: %v", err)


### PR DESCRIPTION
As `context.WithValue` (which `namespace.WithNamespace` uses under the hood) works by creating a new child context with the value that wraps its parent, [re-using the same context in a loop can result in a deeply nested context that can impact performance.](https://gabnotes.org/fat-contexts/)

If my understanding is correct, the namespaced context is only relevant in a single cycle, meaning we can avoid this by shadowing the `ctx` variable, creating a new context with the original caller's context as the parent, rather than the context of the previous cycle.

To help catch this in future, I've also enabled the `fatcontext` linter.

Relates to #274