### PR TITLE
refactor: remove unused error returns from internal functions

### DIFF
--- a/binary/cli/cli.go
+++ b/binary/cli/cli.go
@@ -462,10 +462,7 @@ func multiStringToList(arg []string) []string {
 
 func (f *Flags) scanRoots() ([]*scalibrfs.ScanRoot, error) {
 	if f.RemoteImage != "" {
-		imageOptions, err := f.scanRemoteImageOptions()
-		if err != nil {
-			return nil, err
-		}
+		imageOptions := f.scanRemoteImageOptions()
 		fs, err := scalibrimage.NewFromRemoteName(f.RemoteImage, *imageOptions...)
 		if err != nil {
 			return nil, err
@@ -491,7 +488,7 @@ func (f *Flags) scanRoots() ([]*scalibrfs.ScanRoot, error) {
 	return scanRoots, nil
 }
 
-func (f *Flags) scanRemoteImageOptions() (*[]remote.Option, error) {
+func (f *Flags) scanRemoteImageOptions() *[]remote.Option {
 	imageOptions := []remote.Option{
 		remote.WithAuthFromKeychain(authn.DefaultKeychain),
 	}
@@ -504,7 +501,7 @@ func (f *Flags) scanRemoteImageOptions() (*[]remote.Option, error) {
 			},
 		))
 	}
-	return &imageOptions, nil
+	return &imageOptions
 }
 
 // All capabilities are enabled when running SCALIBR as a binary.

--- a/binary/proto/proto.go
+++ b/binary/proto/proto.go
@@ -166,10 +166,7 @@ func ScanResultToProto(r *scalibr.ScanResult) (*spb.ScanResult, error) {
 
 	inventories := make([]*spb.Inventory, 0, len(r.Inventories))
 	for _, i := range r.Inventories {
-		p, err := inventoryToProto(i)
-		if err != nil {
-			return nil, err
-		}
+		p := inventoryToProto(i)
 		inventories = append(inventories, p)
 	}
 
@@ -216,9 +213,9 @@ func pluginStatusToProto(s *plugin.Status) *spb.PluginStatus {
 	}
 }
 
-func inventoryToProto(i *extractor.Inventory) (*spb.Inventory, error) {
+func inventoryToProto(i *extractor.Inventory) *spb.Inventory {
 	if i == nil {
-		return nil, nil
+		return nil
 	}
 	p := converter.ToPURL(i)
 	inventoryProto := &spb.Inventory{
@@ -233,7 +230,7 @@ func inventoryToProto(i *extractor.Inventory) (*spb.Inventory, error) {
 		LayerDetails: layerDetailsToProto(i.LayerDetails),
 	}
 	setProtoMetadata(i.Metadata, inventoryProto)
-	return inventoryProto, nil
+	return inventoryProto
 }
 
 func setProtoMetadata(meta any, i *spb.Inventory) {
@@ -614,10 +611,7 @@ func findingToProto(f *detector.Finding) (*spb.Finding, error) {
 	}
 	var target *spb.TargetDetails
 	if f.Target != nil {
-		i, err := inventoryToProto(f.Target.Inventory)
-		if err != nil {
-			return nil, err
-		}
+		i := inventoryToProto(f.Target.Inventory)
 		target = &spb.TargetDetails{
 			Location:  f.Target.Location,
 			Inventory: i,

--- a/extractor/filesystem/language/golang/gobinary/gobinary.go
+++ b/extractor/filesystem/language/golang/gobinary/gobinary.go
@@ -139,9 +139,9 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		return []*extractor.Inventory{}, nil
 	}
 
-	inventory, err := e.extractPackagesFromBuildInfo(binfo, input.Path)
-	e.reportFileExtracted(input.Path, input.Info, err)
-	return inventory, err
+	inventory := e.extractPackagesFromBuildInfo(binfo, input.Path)
+	e.reportFileExtracted(input.Path, input.Info, nil)
+	return inventory, nil
 }
 
 func (e Extractor) reportFileExtracted(path string, fileinfo fs.FileInfo, err error) {
@@ -159,7 +159,7 @@ func (e Extractor) reportFileExtracted(path string, fileinfo fs.FileInfo, err er
 	})
 }
 
-func (e *Extractor) extractPackagesFromBuildInfo(binfo *buildinfo.BuildInfo, filename string) ([]*extractor.Inventory, error) {
+func (e *Extractor) extractPackagesFromBuildInfo(binfo *buildinfo.BuildInfo, filename string) []*extractor.Inventory {
 	res := []*extractor.Inventory{}
 
 	validatedGoVers, err := validateGoVersion(binfo.GoVersion)
@@ -190,7 +190,7 @@ func (e *Extractor) extractPackagesFromBuildInfo(binfo *buildinfo.BuildInfo, fil
 		res = append(res, pkg)
 	}
 
-	return res, nil
+	return res
 }
 
 func validateGoVersion(vers string) (string, error) {

--- a/extractor/standalone/containers/containerd/containerd_linux.go
+++ b/extractor/standalone/containers/containerd/containerd_linux.go
@@ -184,11 +184,7 @@ func containersFromAPI(ctx context.Context, client CtrdClient) ([]Metadata, erro
 	for _, ns := range nss {
 		// For each namespace returned by the API, get the containers metadata.
 		ctx := namespaces.WithNamespace(ctx, ns)
-		ctrs, err := containersMetadata(ctx, client, ns, defaultContainerdRootfsPrefix)
-		if err != nil {
-			log.Errorf("Could not get a list of containers from the containerd: %v", err)
-			return nil, err
-		}
+		ctrs := containersMetadata(ctx, client, ns, defaultContainerdRootfsPrefix)
 		// Merge all containers metadata items for all namespaces into a single list.
 		metadata = append(metadata, ctrs...)
 	}
@@ -205,7 +201,7 @@ func namespacesFromAPI(ctx context.Context, client CtrdClient) ([]string, error)
 	return nss, nil
 }
 
-func containersMetadata(ctx context.Context, client CtrdClient, namespace string, defaultAbsoluteToBundlePath string) ([]Metadata, error) {
+func containersMetadata(ctx context.Context, client CtrdClient, namespace string, defaultAbsoluteToBundlePath string) []Metadata {
 	var containersMetadata []Metadata
 
 	taskService := client.TaskService()
@@ -226,7 +222,7 @@ func containersMetadata(ctx context.Context, client CtrdClient, namespace string
 
 		containersMetadata = append(containersMetadata, md)
 	}
-	return containersMetadata, nil
+	return containersMetadata
 }
 
 func taskMetadata(ctx context.Context, client CtrdClient, task *task.Process, namespace string, defaultAbsoluteToBundlePath string) (Metadata, error) {

--- a/semantic/parse.go
+++ b/semantic/parse.go
@@ -46,33 +46,33 @@ func Parse(str string, ecosystem string) (Version, error) {
 	case "Alpine":
 		return parseAlpineVersion(str)
 	case "ConanCenter":
-		return parseSemverVersion(str)
+		return parseSemverVersion(str), nil
 	case "CRAN":
-		return parseCRANVersion(str)
+		return parseCRANVersion(str), nil
 	case "crates.io":
-		return parseSemverVersion(str)
+		return parseSemverVersion(str), nil
 	case "Debian":
 		return parseDebianVersion(str)
 	case "Go":
-		return parseSemverVersion(str)
+		return parseSemverVersion(str), nil
 	case "Hex":
-		return parseSemverVersion(str)
+		return parseSemverVersion(str), nil
 	case "Maven":
-		return parseMavenVersion(str)
+		return parseMavenVersion(str), nil
 	case "npm":
-		return parseSemverVersion(str)
+		return parseSemverVersion(str), nil
 	case "NuGet":
-		return parseNuGetVersion(str)
+		return parseNuGetVersion(str), nil
 	case "Packagist":
-		return parsePackagistVersion(str)
+		return parsePackagistVersion(str), nil
 	case "Pub":
-		return parseSemverVersion(str)
+		return parseSemverVersion(str), nil
 	case "PyPI":
 		return parsePyPIVersion(str)
 	case "Red Hat":
-		return parseRedHatVersion(str)
+		return parseRedHatVersion(str), nil
 	case "RubyGems":
-		return parseRubyGemsVersion(str)
+		return parseRubyGemsVersion(str), nil
 	case "Ubuntu":
 		return parseDebianVersion(str)
 	}

--- a/semantic/version-cran.go
+++ b/semantic/version-cran.go
@@ -49,16 +49,10 @@ func (v cranVersion) compare(w cranVersion) int {
 }
 
 func (v cranVersion) CompareStr(str string) (int, error) {
-	w, err := parseCRANVersion(str)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return v.compare(w), nil
+	return v.compare(parseCRANVersion(str)), nil
 }
 
-func parseCRANVersion(str string) (cranVersion, error) {
+func parseCRANVersion(str string) cranVersion {
 	// dashes and periods have the same weight, so we can just normalize to periods
 	parts := strings.Split(strings.ReplaceAll(str, "-", "."), ".")
 
@@ -70,5 +64,5 @@ func parseCRANVersion(str string) (cranVersion, error) {
 		comps = append(comps, v)
 	}
 
-	return cranVersion{comps}, nil
+	return cranVersion{comps}
 }

--- a/semantic/version-maven.go
+++ b/semantic/version-maven.go
@@ -359,15 +359,9 @@ func (mv mavenVersion) compare(w mavenVersion) (int, error) {
 }
 
 func (mv mavenVersion) CompareStr(str string) (int, error) {
-	mw, err := parseMavenVersion(str)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return mv.compare(mw)
+	return mv.compare(parseMavenVersion(str))
 }
 
-func parseMavenVersion(str string) (mavenVersion, error) {
-	return newMavenVersion(str), nil
+func parseMavenVersion(str string) mavenVersion {
+	return newMavenVersion(str)
 }

--- a/semantic/version-nuget.go
+++ b/semantic/version-nuget.go
@@ -29,15 +29,9 @@ func (v nuGetVersion) compare(w nuGetVersion) int {
 }
 
 func (v nuGetVersion) CompareStr(str string) (int, error) {
-	w, err := parseNuGetVersion(str)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return v.compare(w), nil
+	return v.compare(parseNuGetVersion(str)), nil
 }
 
-func parseNuGetVersion(str string) (nuGetVersion, error) {
-	return nuGetVersion{parseSemverLikeVersion(str, 4)}, nil
+func parseNuGetVersion(str string) nuGetVersion {
+	return nuGetVersion{parseSemverLikeVersion(str, 4)}
 }

--- a/semantic/version-packagist.go
+++ b/semantic/version-packagist.go
@@ -128,11 +128,11 @@ type packagistVersion struct {
 	Components []string
 }
 
-func parsePackagistVersion(str string) (packagistVersion, error) {
+func parsePackagistVersion(str string) packagistVersion {
 	return packagistVersion{
 		str,
 		strings.Split(canonicalizePackagistVersion(str), "."),
-	}, nil
+	}
 }
 
 func (v packagistVersion) compare(w packagistVersion) int {
@@ -140,11 +140,5 @@ func (v packagistVersion) compare(w packagistVersion) int {
 }
 
 func (v packagistVersion) CompareStr(str string) (int, error) {
-	w, err := parsePackagistVersion(str)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return v.compare(w), nil
+	return v.compare(parsePackagistVersion(str)), nil
 }

--- a/semantic/version-redhat.go
+++ b/semantic/version-redhat.go
@@ -203,13 +203,7 @@ func (v redHatVersion) compare(w redHatVersion) int {
 }
 
 func (v redHatVersion) CompareStr(str string) (int, error) {
-	w, err := parseRedHatVersion(str)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return v.compare(w), nil
+	return v.compare(parseRedHatVersion(str)), nil
 }
 
 // parseRedHatVersion parses a Red Hat version into a redHatVersion struct.
@@ -223,7 +217,7 @@ func (v redHatVersion) CompareStr(str string) (int, error) {
 //
 // When all components are present, the version is represented as "n-e:v-r.a",
 // though only the version is actually required.
-func parseRedHatVersion(str string) (redHatVersion, error) {
+func parseRedHatVersion(str string) redHatVersion {
 	bf, af, hasColon := strings.Cut(str, ":")
 
 	if !hasColon {
@@ -247,5 +241,5 @@ func parseRedHatVersion(str string) (redHatVersion, error) {
 		epoch = "0"
 	}
 
-	return redHatVersion{epoch, version, release}, nil
+	return redHatVersion{epoch, version, release}
 }

--- a/semantic/version-rubygems.go
+++ b/semantic/version-rubygems.go
@@ -119,11 +119,11 @@ type rubyGemsVersion struct {
 	Segments []string
 }
 
-func parseRubyGemsVersion(str string) (rubyGemsVersion, error) {
+func parseRubyGemsVersion(str string) rubyGemsVersion {
 	return rubyGemsVersion{
 		str,
 		canonicalSegments(strings.Split(canonicalizeRubyGemVersion(str), ".")),
-	}, nil
+	}
 }
 
 func (v rubyGemsVersion) compare(w rubyGemsVersion) int {
@@ -131,11 +131,5 @@ func (v rubyGemsVersion) compare(w rubyGemsVersion) int {
 }
 
 func (v rubyGemsVersion) CompareStr(str string) (int, error) {
-	w, err := parseRubyGemsVersion(str)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return v.compare(w), nil
+	return v.compare(parseRubyGemsVersion(str)), nil
 }

--- a/semantic/version-semver.go
+++ b/semantic/version-semver.go
@@ -100,8 +100,8 @@ type semverVersion struct {
 	semverLikeVersion
 }
 
-func parseSemverVersion(str string) (semverVersion, error) {
-	return semverVersion{parseSemverLikeVersion(str, 3)}, nil
+func parseSemverVersion(str string) semverVersion {
+	return semverVersion{parseSemverLikeVersion(str, 3)}
 }
 
 func (v semverVersion) compare(w semverVersion) int {
@@ -113,11 +113,5 @@ func (v semverVersion) compare(w semverVersion) int {
 }
 
 func (v semverVersion) CompareStr(str string) (int, error) {
-	w, err := parseSemverVersion(str)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return v.compare(w), nil
+	return v.compare(parseSemverVersion(str)), nil
 }


### PR DESCRIPTION
Since none of these functions actually return an error value, we can remove that return entirely and in doing so remove a few error checks that would never be hit.

In the long run the `unparam` linter will help catch this for us.

Relates to #274