### PR TITLE
refactor: remove unused params from internal functions

### DIFF
--- a/artifact/image/layerscanning/image/image.go
+++ b/artifact/image/layerscanning/image/image.go
@@ -455,11 +455,11 @@ func fillChainLayersWithFilesFromTar(img *Image, tarReader *tar.Reader, originLa
 		var newNode *fileNode
 		switch header.Typeflag {
 		case tar.TypeDir:
-			newNode, err = img.handleDir(realFilePath, virtualPath, originLayerID, tarReader, header, isWhiteout)
+			newNode, err = img.handleDir(realFilePath, virtualPath, originLayerID, header, isWhiteout)
 		case tar.TypeReg:
 			newNode, err = img.handleFile(realFilePath, virtualPath, originLayerID, tarReader, header, isWhiteout)
 		case tar.TypeSymlink, tar.TypeLink:
-			newNode, err = img.handleSymlink(virtualPath, originLayerID, tarReader, header, isWhiteout, requiredTargets)
+			newNode, err = img.handleSymlink(virtualPath, originLayerID, header, isWhiteout, requiredTargets)
 		default:
 			log.Warnf("unsupported file type: %v, path: %s", header.Typeflag, header.Name)
 			continue
@@ -519,7 +519,7 @@ func populateEmptyDirectoryNodes(virtualPath, originLayerID, extractDir string, 
 
 // handleSymlink returns the symlink header mode. Symlinks are handled by creating a fileNode with
 // the symlink mode with additional metadata.
-func (img *Image) handleSymlink(virtualPath, originLayerID string, tarReader *tar.Reader, header *tar.Header, isWhiteout bool, requiredTargets map[string]bool) (*fileNode, error) {
+func (img *Image) handleSymlink(virtualPath, originLayerID string, header *tar.Header, isWhiteout bool, requiredTargets map[string]bool) (*fileNode, error) {
 	targetPath := filepath.ToSlash(header.Linkname)
 	if targetPath == "" {
 		return nil, fmt.Errorf("symlink header has no target path")
@@ -548,7 +548,7 @@ func (img *Image) handleSymlink(virtualPath, originLayerID string, tarReader *ta
 }
 
 // handleDir creates the directory specified by path, if it doesn't exist.
-func (img *Image) handleDir(realFilePath, virtualPath, originLayerID string, tarReader *tar.Reader, header *tar.Header, isWhiteout bool) (*fileNode, error) {
+func (img *Image) handleDir(realFilePath, virtualPath, originLayerID string, header *tar.Header, isWhiteout bool) (*fileNode, error) {
 	if _, err := os.Stat(realFilePath); err != nil {
 		if err := os.MkdirAll(realFilePath, dirPermission); err != nil {
 			return nil, fmt.Errorf("failed to create directory with realFilePath %s: %w", realFilePath, err)

--- a/common/linux/proc/process_linux.go
+++ b/common/linux/proc/process_linux.go
@@ -103,7 +103,7 @@ func readFileDescriptors(ctx context.Context, d fs.DirEntry, inodesToPID map[int
 	// for each file descriptor in the process directory, we try to extract the inode number for
 	// sockets.
 	fn := func(d fs.DirEntry) error {
-		inode, err := extractSocketInode(ctx, absFdPath, d)
+		inode, err := extractSocketInode(absFdPath, d)
 		if err != nil {
 			return err
 		}
@@ -124,7 +124,7 @@ func readFileDescriptors(ctx context.Context, d fs.DirEntry, inodesToPID map[int
 	return nil
 }
 
-func extractSocketInode(ctx context.Context, absFdDir string, d fs.DirEntry) (int64, error) {
+func extractSocketInode(absFdDir string, d fs.DirEntry) (int64, error) {
 	if d.Type() != fs.ModeSymlink {
 		return 0, nil
 	}

--- a/extractor/filesystem/containers/containerd/containerd_linux.go
+++ b/extractor/filesystem/containers/containerd/containerd_linux.go
@@ -415,18 +415,18 @@ func snapshotMetadataFromSnapshotsBuckets(tx *bolt.Tx, snapshotsBucketByDigest [
 func containerInitPid(scanRoot string, runtimeName string, namespace string, id string) int {
 	// A typical Linux case.
 	if runtimeName == "io.containerd.runc.v2" {
-		return runcInitPid(scanRoot, runtimeName, id)
+		return runcInitPid(scanRoot, id)
 	}
 
 	// A typical Windows case.
 	if runtimeName == "io.containerd.runhcs.v1" {
-		return runhcsInitPid(scanRoot, runtimeName, namespace, id)
+		return runhcsInitPid(scanRoot, namespace, id)
 	}
 
 	return -1
 }
 
-func runcInitPid(scanRoot string, runtimeName string, id string) int {
+func runcInitPid(scanRoot string, id string) int {
 	// If a container is running by runc, the init pid is stored in the grpc status file.
 	// status file is located at the
 	// <scanRoot>/<criPluginStatusFilePrefix>/<container_id>/state.json path.
@@ -466,7 +466,7 @@ func runcInitPid(scanRoot string, runtimeName string, id string) int {
 	return initPID
 }
 
-func runhcsInitPid(scanRoot string, runtimeName string, namespace string, id string) int {
+func runhcsInitPid(scanRoot string, namespace string, id string) int {
 	// If a container is running by runhcs, the init pid is stored in the runhcs shim.pid file.
 	// shim.pid file is located at the
 	// <scanRoot>/<runhcsStateFilePrefix>/<namespace_name>/<container_id>/shim.pid.

--- a/extractor/filesystem/language/dotnet/depsjson/depsjson.go
+++ b/extractor/filesystem/language/dotnet/depsjson/depsjson.go
@@ -117,7 +117,7 @@ func (e Extractor) reportFileRequired(path string, result stats.FileRequiredResu
 
 // Extract parses the deps.json file to extract .NET package dependencies.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	packages, err := e.extractFromInput(ctx, input)
+	packages, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -146,7 +146,7 @@ type DepsJSON struct {
 	} `json:"libraries"`
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	var deps DepsJSON
 	decoder := json.NewDecoder(input.Reader)
 	if err := decoder.Decode(&deps); err != nil {

--- a/extractor/filesystem/language/dotnet/packagesconfig/packagesconfig.go
+++ b/extractor/filesystem/language/dotnet/packagesconfig/packagesconfig.go
@@ -130,7 +130,7 @@ func (e Extractor) reportFileRequired(path string, result stats.FileRequiredResu
 
 // Extract parses the packages.config file to extract .NET package dependencies.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	packages, err := e.extractFromInput(ctx, input)
+	packages, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -155,7 +155,7 @@ type dotNETPackages struct {
 	Packages []dotNETPackage `xml:"package"`
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	var packages dotNETPackages
 	decoder := xml.NewDecoder(input.Reader)
 	if err := decoder.Decode(&packages); err != nil {

--- a/extractor/filesystem/language/dotnet/packageslockjson/packageslockjson.go
+++ b/extractor/filesystem/language/dotnet/packageslockjson/packageslockjson.go
@@ -131,7 +131,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract returns a list of dependencies in a packages.lock.json file.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	inventory, err := e.extractFromInput(ctx, input)
+	inventory, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -146,7 +146,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return inventory, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	p, err := Parse(input.Reader)
 	if err != nil {
 		return nil, err

--- a/extractor/filesystem/language/elixir/mixlock/mixlock.go
+++ b/extractor/filesystem/language/elixir/mixlock/mixlock.go
@@ -120,7 +120,7 @@ func (e Extractor) reportFileRequired(path string, result stats.FileRequiredResu
 
 // Extract parses the mix.lock file to extract Elixir package dependencies.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	packages, err := e.extractFromInput(ctx, input)
+	packages, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -135,7 +135,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return packages, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	// Parse the Mix.lock file into a list of packages and return Inventory directly
 	return mixlockutils.ParseMixLockFile(input)
 }

--- a/extractor/filesystem/language/python/condameta/condameta.go
+++ b/extractor/filesystem/language/python/condameta/condameta.go
@@ -135,7 +135,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract parses and extracts dependency data from Conda metadata files.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	inventory, err := e.extractFromInput(ctx, input)
+	inventory, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -150,7 +150,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return inventory, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	// Parse the metadata and get a package
 	pkg, err := parse(input.Reader)
 	if err != nil {

--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -142,7 +142,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	// Additional paths to recursive files found during extraction.
 	var extraPaths pathQueue
 	var inv []*extractor.Inventory
-	newRepos, newPaths, err := extractFromPath(input.Reader, input.Path, input.FS)
+	newRepos, newPaths, err := extractFromPath(input.Reader, input.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -195,10 +195,10 @@ func openAndExtractFromFile(path string, fs scalibrfs.FS) ([]*extractor.Inventor
 		return nil, nil, err
 	}
 	defer reader.Close()
-	return extractFromPath(reader, path, fs)
+	return extractFromPath(reader, path)
 }
 
-func extractFromPath(reader io.Reader, path string, fs scalibrfs.FS) ([]*extractor.Inventory, pathQueue, error) {
+func extractFromPath(reader io.Reader, path string) ([]*extractor.Inventory, pathQueue, error) {
 	var inv []*extractor.Inventory
 	var extraPaths pathQueue
 	s := bufio.NewScanner(reader)

--- a/extractor/filesystem/language/swift/packageresolved/packageresolved.go
+++ b/extractor/filesystem/language/swift/packageresolved/packageresolved.go
@@ -118,7 +118,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract parses and extracts dependency data from a Package.resolved file.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	inventory, err := e.extractFromInput(ctx, input)
+	inventory, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -133,7 +133,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return inventory, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	pkgs, err := parse(input.Reader)
 	if err != nil {
 		return nil, err

--- a/extractor/filesystem/language/swift/podfilelock/podfilelock.go
+++ b/extractor/filesystem/language/swift/podfilelock/podfilelock.go
@@ -113,7 +113,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract processes and extracts dependency information from a Podfile.lock file.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	inventory, err := e.extractFromInput(ctx, input)
+	inventory, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -128,7 +128,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return inventory, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	pkgs, err := swiftutils.ParsePodfileLock(input.Reader)
 	if err != nil {
 		return nil, err

--- a/extractor/filesystem/os/cos/cos.go
+++ b/extractor/filesystem/os/cos/cos.go
@@ -130,7 +130,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract extracts packages from cos package info files passed through the scan input.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	inventory, err := e.extractFromInput(ctx, input)
+	inventory, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -145,7 +145,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return inventory, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	m, err := osrelease.GetOSRelease(input.FS)
 	if err != nil {
 		log.Errorf("osrelease.ParseOsRelease(): %v", err)

--- a/extractor/filesystem/os/kernel/module/module.go
+++ b/extractor/filesystem/os/kernel/module/module.go
@@ -131,7 +131,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract extracts packages from .ko files passed through the scan input.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	inventory, err := e.extractFromInput(ctx, input)
+	inventory, err := e.extractFromInput(input)
 
 	if e.stats != nil {
 		var fileSizeBytes int64
@@ -147,7 +147,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return inventory, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	pkgs := []*extractor.Inventory{}
 
 	m, err := osrelease.GetOSRelease(input.FS)

--- a/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
+++ b/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
@@ -134,7 +134,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract extracts information from vmlinuz files passed through the scan input.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	inventory, err := e.extractFromInput(ctx, input)
+	inventory, err := e.extractFromInput(input)
 
 	if e.stats != nil {
 		var fileSizeBytes int64
@@ -150,7 +150,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return inventory, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	pkgs := []*extractor.Inventory{}
 
 	m, err := osrelease.GetOSRelease(input.FS)

--- a/extractor/filesystem/os/macapps/macapps.go
+++ b/extractor/filesystem/os/macapps/macapps.go
@@ -133,7 +133,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract extracts packages from Info.plist files passed through the scan input.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	i, err := e.extractFromInput(ctx, input)
+	i, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -154,7 +154,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return []*extractor.Inventory{i}, nil
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) (*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) (*extractor.Inventory, error) {
 	// Read the first 8 bytes to check for binary plist header
 	header := make([]byte, 8)
 	_, err := io.ReadFull(input.Reader, header)

--- a/extractor/filesystem/os/portage/portage.go
+++ b/extractor/filesystem/os/portage/portage.go
@@ -140,7 +140,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract extracts packages from portage database files passed through the scan input.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	inventory, err := e.extractFromInput(ctx, input)
+	inventory, err := e.extractFromInput(input)
 	if e.stats == nil {
 		return inventory, err
 	}
@@ -156,7 +156,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return inventory, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	osRelease, err := osrelease.GetOSRelease(input.FS)
 	if err != nil {
 		log.Errorf("osrelease.GetOSRelease(): %v", err)

--- a/extractor/filesystem/os/snap/snap.go
+++ b/extractor/filesystem/os/snap/snap.go
@@ -139,7 +139,7 @@ func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result s
 
 // Extract extracts snap info from snap.yaml file passed through the scan input.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
-	inventory, err := e.extractFromInput(ctx, input)
+	inventory, err := e.extractFromInput(input)
 	if e.stats != nil {
 		var fileSizeBytes int64
 		if input.Info != nil {
@@ -154,7 +154,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	return inventory, err
 }
 
-func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	m, err := osrelease.GetOSRelease(input.FS)
 	if err != nil {
 		log.Errorf("osrelease.ParseOsRelease(): %v", err)

--- a/extractor/standalone/os/netports/netports_linux.go
+++ b/extractor/standalone/os/netports/netports_linux.go
@@ -93,13 +93,13 @@ func (e Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([]
 			port := entry.LocalPort
 			pid, ok := inodeToPID[entry.Inode]
 			if !ok {
-				inventories = append(inventories, e.newInventory(ctx, port, proto, []string{"unknown"}))
+				inventories = append(inventories, e.newInventory(port, proto, []string{"unknown"}))
 				continue
 			}
 
 			cmdline, cached := pidCommandLinesCache[pid]
 			if cached {
-				inventories = append(inventories, e.newInventory(ctx, port, proto, cmdline))
+				inventories = append(inventories, e.newInventory(port, proto, cmdline))
 				continue
 			}
 
@@ -109,7 +109,7 @@ func (e Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([]
 			}
 
 			pidCommandLinesCache[pid] = cmdline
-			inventories = append(inventories, e.newInventory(ctx, port, proto, cmdline))
+			inventories = append(inventories, e.newInventory(port, proto, cmdline))
 		}
 	}
 
@@ -150,7 +150,7 @@ func (e Extractor) extractPortsFromFile(ctx context.Context, path string) (*proc
 	return proc.ParseNetTCP(ctx, f)
 }
 
-func (e Extractor) newInventory(ctx context.Context, port uint32, protocol string, cmdline []string) *extractor.Inventory {
+func (e Extractor) newInventory(port uint32, protocol string, cmdline []string) *extractor.Inventory {
 	return &extractor.Inventory{
 		Name: fmt.Sprintf("network-port-%d", port),
 		Metadata: &Metadata{


### PR DESCRIPTION
As none of these parameters are used by their respective functions, they can be safely removed without issue.

In the long run the `unparam` linter will help catch this for us.

Relates to #274