### PR TITLE
refactor: sort imports

### DIFF
--- a/artifact/image/layerscanning/image/image.go
+++ b/artifact/image/layerscanning/image/image.go
@@ -17,6 +17,7 @@
 package image
 
 import (
+	"archive/tar"
 	"errors"
 	"fmt"
 	"io"
@@ -25,8 +26,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-
-	"archive/tar"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"

--- a/artifact/image/layerscanning/image/image_test.go
+++ b/artifact/image/layerscanning/image/image_test.go
@@ -15,6 +15,7 @@
 package image
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"errors"
@@ -25,7 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	"archive/tar"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "github.com/google/go-containerregistry/pkg/v1"

--- a/artifact/image/unpack/unpack.go
+++ b/artifact/image/unpack/unpack.go
@@ -16,6 +16,7 @@
 package unpack
 
 import (
+	"archive/tar"
 	"bytes"
 	"errors"
 	"fmt"
@@ -25,8 +26,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-
-	"archive/tar"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/osv-scalibr/artifact/image/require"


### PR DESCRIPTION
This makes the linter happy - technically only the change to `artifact/image/layerscanning/image/image_test.go` is needed for that, but I don't see any reason why `archive/tar` should be in its own dedicated group so I've checked the rest of the codebase too