### PR TITLE
refactor: ensure there is a newline before returns and branch statements

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,7 +58,7 @@ linters:
     - nakedret
     - nilerr
 #    - nilnil
-#    - nlreturn
+    - nlreturn
 #    - noctx
     - nolintlint
 #    - nosprintfhostport

--- a/artifact/image/image.go
+++ b/artifact/image/image.go
@@ -105,6 +105,7 @@ func V1ImageFromRemoteName(imageName string, imageOptions ...remote.Option) (v1.
 			return nil, fmt.Errorf("couldn’t pull remote image %s: %v", tag, err)
 		}
 	}
+
 	return image, nil
 }
 
@@ -115,6 +116,7 @@ func NewFromRemoteName(imageName string, imageOptions ...remote.Option) (scalibr
 	if err != nil {
 		return nil, fmt.Errorf("failed to load image from remote name %q: %w", imageName, err)
 	}
+
 	return NewFromImage(image)
 }
 
@@ -140,5 +142,6 @@ func NewFromImage(image v1.Image) (scalibrfs.FS, error) {
 	if err = unpacker.UnpackSquashed(outDir, image); err != nil {
 		return nil, fmt.Errorf("failed to unpack image into directory %q: %w", outDir, err)
 	}
+
 	return scalibrfs.DirFS(outDir), nil
 }

--- a/artifact/image/layerscanning/image/file_node.go
+++ b/artifact/image/layerscanning/image/file_node.go
@@ -63,6 +63,7 @@ func (f *fileNode) Stat() (fs.FileInfo, error) {
 	if f.isWhiteout {
 		return nil, fs.ErrNotExist
 	}
+
 	return f, nil
 }
 
@@ -77,6 +78,7 @@ func (f *fileNode) Read(b []byte) (n int, err error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return f.file.Read(b)
 }
 
@@ -91,6 +93,7 @@ func (f *fileNode) ReadAt(b []byte, off int64) (n int, err error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return f.file.ReadAt(b, off)
 }
 
@@ -104,6 +107,7 @@ func (f *fileNode) Seek(offset int64, whence int) (n int64, err error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return f.file.Seek(offset, whence)
 }
 
@@ -112,8 +116,10 @@ func (f *fileNode) Close() error {
 	if f.file != nil {
 		err := f.file.Close()
 		f.file = nil
+
 		return err
 	}
+
 	return nil
 }
 
@@ -130,6 +136,7 @@ func (f *fileNode) RealFilePath() string {
 // Name returns the name of the fileNode. Name is also used to implement the fs.FileInfo interface.
 func (f *fileNode) Name() string {
 	_, filename := path.Split(f.virtualPath)
+
 	return filename
 }
 

--- a/artifact/image/layerscanning/image/file_node_test.go
+++ b/artifact/image/layerscanning/image/file_node_test.go
@@ -134,6 +134,7 @@ func TestStat(t *testing.T) {
 				if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
 					t.Errorf("Stat(%v) returned unexpected error (-want +got): %v", tc.node, diff)
 				}
+
 				return
 			}
 
@@ -389,6 +390,7 @@ func TestReadAt(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("ReadAt(%v) returned unexpected error (-want +got): %v", tc.node, diff)
+
 				return
 			}
 

--- a/artifact/image/layerscanning/image/find_base_image.go
+++ b/artifact/image/layerscanning/image/find_base_image.go
@@ -114,5 +114,6 @@ func findBaseImageIndex(histories []v1.History) (int, error) {
 			}
 		}
 	}
+
 	return 0, ErrBaseImageNotFound
 }

--- a/artifact/image/layerscanning/image/find_base_image_test.go
+++ b/artifact/image/layerscanning/image/find_base_image_test.go
@@ -197,6 +197,7 @@ func TestFindBaseImageIndex(t *testing.T) {
 			gotIndex, gotErr := findBaseImageIndex(test.histories)
 			if test.wantError != gotErr {
 				t.Errorf("findBaseImageIndex(%v) returned error: %v, want error: %v", test.histories, gotErr, test.wantError)
+
 				return
 			}
 

--- a/artifact/image/layerscanning/image/image.go
+++ b/artifact/image/layerscanning/image/image.go
@@ -93,6 +93,7 @@ func validateConfig(config *Config) error {
 	if config.MaxSymlinkDepth < 0 {
 		return fmt.Errorf("%w: max symlink depth must be non-negative: %d", ErrInvalidConfig, config.MaxSymlinkDepth)
 	}
+
 	return nil
 }
 
@@ -111,6 +112,7 @@ func (img *Image) ChainLayers() ([]scalibrImage.ChainLayer, error) {
 	for _, chainLayer := range img.chainLayers {
 		scalibrChainLayers = append(scalibrChainLayers, chainLayer)
 	}
+
 	return scalibrChainLayers, nil
 }
 
@@ -125,6 +127,7 @@ func FromRemoteName(imageName string, config *Config, imageOptions ...remote.Opt
 	if err != nil {
 		return nil, fmt.Errorf("failed to load image from remote name %q: %w", imageName, err)
 	}
+
 	return FromV1Image(v1Image, config)
 }
 
@@ -135,6 +138,7 @@ func FromTarball(tarPath string, config *Config) (*Image, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load image from tarball with path %q: %w", tarPath, err)
 	}
+
 	return FromV1Image(v1Image, config)
 }
 
@@ -246,6 +250,7 @@ func FromV1Image(v1Image v1.Image, config *Config) (*Image, error) {
 				if err != nil {
 					return fmt.Errorf("failed to fill chain layer with v1 layer tar: %w", err)
 				}
+
 				return nil
 			}()
 
@@ -263,6 +268,7 @@ func FromV1Image(v1Image v1.Image, config *Config) (*Image, error) {
 		for _, isRequired := range requiredTargets {
 			if isRequired {
 				stillHaveRequiredTargets = true
+
 				break
 			}
 		}
@@ -271,6 +277,7 @@ func FromV1Image(v1Image v1.Image, config *Config) (*Image, error) {
 			break
 		}
 	}
+
 	return &outputImage, nil
 }
 
@@ -308,6 +315,7 @@ func initializeChainLayers(v1Layers []v1.Layer, configFile *v1.ConfigFile, maxSy
 				maxSymlinkDepth: maxSymlinkDepth,
 			})
 			historyIndex++
+
 			continue
 		}
 
@@ -436,6 +444,7 @@ func fillChainLayersWithFilesFromTar(img *Image, tarReader *tar.Reader, originLa
 		for _, p := range []string{realFilePath, cleanedFilePath, virtualPath} {
 			if requirer.FileRequired(p, header.FileInfo()) {
 				required = true
+
 				break
 			}
 			if _, ok := requiredTargets[p]; ok {
@@ -443,6 +452,7 @@ func fillChainLayersWithFilesFromTar(img *Image, tarReader *tar.Reader, originLa
 
 				// The required target has been checked, so it can be marked as not required.
 				requiredTargets[p] = false
+
 				break
 			}
 		}
@@ -462,14 +472,17 @@ func fillChainLayersWithFilesFromTar(img *Image, tarReader *tar.Reader, originLa
 			newNode, err = img.handleSymlink(virtualPath, originLayerID, tarReader, header, isWhiteout, requiredTargets)
 		default:
 			log.Warnf("unsupported file type: %v, path: %s", header.Typeflag, header.Name)
+
 			continue
 		}
 
 		if err != nil {
 			if errors.Is(err, ErrFileReadLimitExceeded) {
 				log.Warnf("failed to handle tar entry with path %s: %w", virtualPath, err)
+
 				continue
 			}
+
 			return nil, fmt.Errorf("failed to handle tar entry with path %s: %w", virtualPath, err)
 		}
 
@@ -486,6 +499,7 @@ func fillChainLayersWithFilesFromTar(img *Image, tarReader *tar.Reader, originLa
 		layer := currentChainLayer.latestLayer.(*Layer)
 		layer.fileNodeTree.Insert(virtualPath, newNode)
 	}
+
 	return requiredTargets, nil
 }
 
@@ -527,6 +541,7 @@ func (img *Image) handleSymlink(virtualPath, originLayerID string, tarReader *ta
 
 	if symlink.TargetOutsideRoot(virtualPath, targetPath) {
 		log.Warnf("Found symlink that points outside the root, skipping: %q -> %q", virtualPath, targetPath)
+
 		return nil, fmt.Errorf("%w: %q -> %q", ErrSymlinkPointsOutsideRoot, virtualPath, targetPath)
 	}
 
@@ -651,5 +666,6 @@ func inWhiteoutDir(layer *chainLayer, filePath string) bool {
 
 		filePath = dirname
 	}
+
 	return false
 }

--- a/artifact/image/layerscanning/image/image_test.go
+++ b/artifact/image/layerscanning/image/image_test.go
@@ -74,6 +74,7 @@ func (fakeV1Image *fakeV1Image) Layers() ([]v1.Layer, error) {
 	if fakeV1Image.errorOnLayers {
 		return nil, fmt.Errorf("error on layers")
 	}
+
 	return fakeV1Image.layers, nil
 }
 
@@ -81,6 +82,7 @@ func (fakeV1Image *fakeV1Image) ConfigFile() (*v1.ConfigFile, error) {
 	if fakeV1Image.errorOnConfigFile {
 		return nil, fmt.Errorf("error on config file")
 	}
+
 	return fakeV1Image.config, nil
 }
 
@@ -1036,5 +1038,6 @@ func constructImage(ctx context.Context, version, fakePackageName string) (*v1.I
 		return nil, fmt.Errorf("unable to create layer: %v", err)
 	}
 	image, err := mutate.AppendLayers(empty.Image, layer)
+
 	return &image, err
 }

--- a/artifact/image/layerscanning/image/layer.go
+++ b/artifact/image/layerscanning/image/layer.go
@@ -83,6 +83,7 @@ func (layer *Layer) Uncompressed() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrUncompressedReaderMissingFromLayer, err)
 	}
+
 	return uncompressed, nil
 }
 
@@ -200,6 +201,7 @@ func (chainfs FS) Open(name string) (fs.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve symlink for file node %s: %w", fileNode.virtualPath, err)
 	}
+
 	return resolvedNode, nil
 }
 
@@ -214,6 +216,7 @@ func (chainfs *FS) Stat(name string) (fs.FileInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve symlink for file node %s: %w", node.virtualPath, err)
 	}
+
 	return resolvedNode.Stat()
 }
 
@@ -246,6 +249,7 @@ func (chainfs *FS) ReadDir(name string) ([]fs.DirEntry, error) {
 	slices.SortFunc(dirEntries, func(a, b fs.DirEntry) int {
 		return strings.Compare(a.Name(), b.Name())
 	})
+
 	return dirEntries, nil
 }
 
@@ -260,6 +264,7 @@ func (chainfs *FS) getFileNode(path string) (*fileNode, error) {
 	if node == nil {
 		return nil, fs.ErrNotExist
 	}
+
 	return node, nil
 }
 
@@ -272,6 +277,7 @@ func (chainfs *FS) getFileNodeChildren(path string) ([]*fileNode, error) {
 	if children == nil {
 		return nil, fs.ErrNotExist
 	}
+
 	return children, nil
 }
 
@@ -288,5 +294,6 @@ func normalizePath(path string) string {
 	if path[0] != '/' {
 		path = "/" + path
 	}
+
 	return path
 }

--- a/artifact/image/layerscanning/image/layer_test.go
+++ b/artifact/image/layerscanning/image/layer_test.go
@@ -89,6 +89,7 @@ func TestChainLayerFS(t *testing.T) {
 	testDir := func() string {
 		dir := t.TempDir()
 		os.WriteFile(path.Join(dir, "file1"), []byte("file1"), 0600)
+
 		return dir
 	}()
 
@@ -110,12 +111,14 @@ func TestChainLayerFS(t *testing.T) {
 	emptyTree := func() *pathtree.Node[fileNode] {
 		tree := pathtree.NewNode[fileNode]()
 		tree.Insert("/", root)
+
 		return tree
 	}()
 	nonEmptyTree := func() *pathtree.Node[fileNode] {
 		tree := pathtree.NewNode[fileNode]()
 		tree.Insert("/", root)
 		tree.Insert("/file1", file1)
+
 		return tree
 	}()
 
@@ -156,6 +159,7 @@ func TestChainLayerFS(t *testing.T) {
 					t.Errorf("WalkDir(%v) returned error: %v", path, err)
 				}
 				gotPaths = append(gotPaths, path)
+
 				return nil
 			})
 
@@ -292,11 +296,13 @@ func TestChainFSOpen(t *testing.T) {
 				if !errors.Is(gotErr, tc.wantErr) {
 					t.Fatalf("Open(%v) returned error: %v, want error: %v", tc.path, gotErr, tc.wantErr)
 				}
+
 				return
 			}
 
 			if gotErr != nil {
 				t.Fatalf("Open(%v) returned error: %v", tc.path, gotErr)
+
 				return
 			}
 
@@ -347,6 +353,7 @@ func TestChainFSStat(t *testing.T) {
 				if !errors.Is(gotErr, tc.wantErr) {
 					t.Fatalf("Stat(%v) returned error: %v, want error: %v", tc.path, gotErr, tc.wantErr)
 				}
+
 				return
 			}
 
@@ -539,11 +546,13 @@ func TestChainFSReadDir(t *testing.T) {
 				if !errors.Is(gotErr, tc.wantErr) {
 					t.Fatalf("ReadDir(%v) returned error: %v, want error: %v", tc.path, gotErr, tc.wantErr)
 				}
+
 				return
 			}
 
 			if gotErr != nil {
 				t.Fatalf("ReadDir(%v) returned error: %v", tc.path, gotErr)
+
 				return
 			}
 
@@ -591,11 +600,13 @@ func checkError(t *testing.T, funcName string, gotErr error, wantErr error) {
 		if !errors.Is(gotErr, wantErr) {
 			t.Fatalf("%s returned error: %v, want error: %v", funcName, gotErr, wantErr)
 		}
+
 		return
 	}
 
 	if gotErr != nil {
 		t.Fatalf("%s returned error: %v", funcName, gotErr)
+
 		return
 	}
 }
@@ -758,5 +769,6 @@ func setUpChainFS(t *testing.T, maxSymlinkDepth int) (FS, string) {
 			os.WriteFile(node.RealFilePath(), []byte(path), filePermission)
 		}
 	}
+
 	return chainfs, tempDir
 }

--- a/artifact/image/layerscanning/testing/fakechainlayer/fake_chain_layer.go
+++ b/artifact/image/layerscanning/testing/fakechainlayer/fake_chain_layer.go
@@ -53,6 +53,7 @@ func New(testDir string, index int, diffID digest.Digest, command string, layer 
 			}
 		}
 	}
+
 	return &FakeChainLayer{
 		index:   index,
 		diffID:  diffID,
@@ -91,8 +92,10 @@ func (fakeChainLayer *FakeChainLayer) FS() scalibrfs.FS {
 func (fakeChainLayer *FakeChainLayer) Open(name string) (fs.File, error) {
 	if _, ok := fakeChainLayer.files[name]; ok {
 		filename := filepath.Join(fakeChainLayer.testDir, name)
+
 		return os.Open(filename)
 	}
+
 	return nil, os.ErrNotExist
 }
 
@@ -101,6 +104,7 @@ func (fakeChainLayer *FakeChainLayer) Stat(name string) (fs.FileInfo, error) {
 	if _, ok := fakeChainLayer.files[name]; ok {
 		return os.Stat(path.Join(fakeChainLayer.testDir, name))
 	}
+
 	return nil, os.ErrNotExist
 }
 

--- a/artifact/image/layerscanning/testing/fakelayer/fake_layer.go
+++ b/artifact/image/layerscanning/testing/fakelayer/fake_layer.go
@@ -50,6 +50,7 @@ func New(testDir string, diffID digest.Digest, buildCommand string, files map[st
 			}
 		}
 	}
+
 	return &FakeLayer{
 		testDir:      testDir,
 		diffID:       diffID,
@@ -91,8 +92,10 @@ func (fakeLayer *FakeLayer) Uncompressed() (io.ReadCloser, error) {
 func (fakeLayer *FakeLayer) Open(name string) (fs.File, error) {
 	if _, ok := fakeLayer.files[name]; ok {
 		filename := filepath.Join(fakeLayer.testDir, name)
+
 		return os.Open(filename)
 	}
+
 	return nil, os.ErrNotExist
 }
 
@@ -101,6 +104,7 @@ func (fakeLayer *FakeLayer) Stat(name string) (fs.FileInfo, error) {
 	if _, ok := fakeLayer.files[name]; ok {
 		return os.Stat(path.Join(fakeLayer.testDir, name))
 	}
+
 	return nil, os.ErrNotExist
 }
 

--- a/artifact/image/layerscanning/testing/fakev1layer/fake_v1_layer.go
+++ b/artifact/image/layerscanning/testing/fakev1layer/fake_v1_layer.go
@@ -47,6 +47,7 @@ func (fakeV1Layer *FakeV1Layer) DiffID() (v1.Hash, error) {
 	if fakeV1Layer.diffID == "" {
 		return v1.Hash{}, fmt.Errorf("diffID is empty")
 	}
+
 	return v1.Hash{
 		Algorithm: "sha256",
 		Hex:       fakeV1Layer.diffID,

--- a/artifact/image/layerscanning/trace/trace.go
+++ b/artifact/image/layerscanning/trace/trace.go
@@ -150,6 +150,7 @@ func PopulateLayerDetails(ctx context.Context, inventory []*extractor.Inventory,
 			for _, oldInv := range oldInventory {
 				if areInventoriesEqual(inv, oldInv) {
 					foundPackage = true
+
 					break
 				}
 			}
@@ -158,6 +159,7 @@ func PopulateLayerDetails(ctx context.Context, inventory []*extractor.Inventory,
 			if !foundPackage {
 				layerDetails = chainLayerDetailsList[i+1]
 				foundOrigin = true
+
 				break
 			}
 		}
@@ -196,6 +198,7 @@ func areInventoriesEqual(inv1 *extractor.Inventory, inv2 *extractor.Inventory) b
 	if !slices.Equal(locations1, locations2) {
 		return false
 	}
+
 	return true
 }
 
@@ -228,5 +231,6 @@ func filesExistInLayer(chainLayer scalibrImage.ChainLayer, fileLocations []strin
 			return true
 		}
 	}
+
 	return false
 }

--- a/artifact/image/layerscanning/trace/trace_test.go
+++ b/artifact/image/layerscanning/trace/trace_test.go
@@ -42,6 +42,7 @@ func setupFakeChainLayer(t *testing.T, testDir string, index int, diffID digest.
 	if err != nil {
 		t.Fatalf("fakechainlayer.New(%d, %q, %q, %v, %v) failed: %v", index, diffID, command, layer, chainLayerContents, err)
 	}
+
 	return chainLayer
 }
 

--- a/artifact/image/pathtree/pathtree.go
+++ b/artifact/image/pathtree/pathtree.go
@@ -57,6 +57,7 @@ func (node *Node[V]) Insert(path string, value *V) error {
 	// the path.
 	if path == "" {
 		node.value = value
+
 		return nil
 	}
 
@@ -100,6 +101,7 @@ func (node *Node[V]) getNode(path string) *Node[V] {
 		}
 		cursor = next
 	}
+
 	return cursor
 }
 
@@ -110,6 +112,7 @@ func (node *Node[V]) Get(path string) *V {
 	if pathNode == nil {
 		return nil
 	}
+
 	return pathNode.value
 }
 

--- a/artifact/image/pathtree/pathtree_test.go
+++ b/artifact/image/pathtree/pathtree_test.go
@@ -268,6 +268,7 @@ func TestNode_Walk(t *testing.T) {
 			got := []keyValue{}
 			err := tt.tree.Walk(func(path string, node *testVal) error {
 				got = append(got, keyValue{key: path, val: node.string})
+
 				return nil
 			})
 			if err != nil {
@@ -277,6 +278,7 @@ func TestNode_Walk(t *testing.T) {
 				if a.key == b.key {
 					return a.val < b.val
 				}
+
 				return a.key < b.key
 			})); diff != "" {
 				t.Errorf("Node.Walk() (-want +got): %v", diff)

--- a/artifact/image/require/require.go
+++ b/artifact/image/require/require.go
@@ -52,6 +52,7 @@ func NewFileRequirerPaths(required []string) *FileRequirerPaths {
 	for _, r := range required {
 		fr.required[r] = true
 	}
+
 	return fr
 }
 

--- a/artifact/image/symlink/symlink.go
+++ b/artifact/image/symlink/symlink.go
@@ -49,6 +49,7 @@ func RemoveObsoleteSymlinks(root string) error {
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			log.Warnf("Failed to walk directory %q: %v", path, err)
+
 			return fmt.Errorf("failed to walk directory %q: %w", path, err)
 		}
 
@@ -60,6 +61,7 @@ func RemoveObsoleteSymlinks(root string) error {
 		linkTarget, err := os.Readlink(path)
 		if err != nil {
 			log.Warnf("Failed to read target of symlink %q: %v", path, err)
+
 			return fmt.Errorf("failed to read target of symlink %q: %w", path, err)
 		}
 
@@ -77,11 +79,14 @@ func RemoveObsoleteSymlinks(root string) error {
 		err = os.Remove(path)
 		if err != nil {
 			log.Warnf("Failed to remove symlink %q: %v", path, err)
+
 			return err
 		}
 		log.Infof("Removed symlink %q", path)
+
 		return nil
 	})
+
 	return err
 }
 
@@ -130,6 +135,7 @@ func ResolveInterLayerSymlinks(root, layerDigest, squashedImageDirectory string)
 	err := filepath.WalkDir(layerPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			log.Warnf("Failed to walk directory %q: %v", path, err)
+
 			return fmt.Errorf("failed to walk directory %q: %w", path, err)
 		}
 
@@ -141,11 +147,13 @@ func ResolveInterLayerSymlinks(root, layerDigest, squashedImageDirectory string)
 		if err = resolveSingleSymlink(root, path, layerPath, squashedImageDirectory); err != nil {
 			return fmt.Errorf("failed to resolve symlink %q: %w", path, err)
 		}
+
 		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to walk directory %q: %w", layerPath, err)
 	}
+
 	return nil
 }
 
@@ -170,6 +178,7 @@ func resolveSingleSymlink(root, symlink, layerPath, resolvedDirectory string) er
 	// Remove the existing symlink.
 	if err := os.Remove(symlink); err != nil && !os.IsNotExist(err) {
 		log.Warnf("Failed to remove symlink %q: %v", symlink, err)
+
 		return fmt.Errorf("failed to remove symlink %q: %w", symlink, err)
 	}
 
@@ -184,8 +193,10 @@ func resolveSingleSymlink(root, symlink, layerPath, resolvedDirectory string) er
 	// Recreate the symlink with the new destination path.
 	if err := os.Symlink(targetPathInSquashedLayer, symlink); err != nil {
 		log.Warnf("Failed to create symlink %q: %v", symlink, err)
+
 		return fmt.Errorf("failed to create symlink %q: %w", symlink, err)
 	}
+
 	return nil
 }
 
@@ -204,9 +215,11 @@ func TargetOutsideRoot(path, target string) bool {
 		// Absolute paths may still point outside of the root directory.
 		// e.g. "/../file.txt"
 		markerTarget := filepath.Join(markerDir, target)
+
 		return !strings.Contains(markerTarget, markerDir)
 	}
 
 	markerTargetAbs := filepath.Join(markerDir, filepath.Dir(path), target)
+
 	return !strings.Contains(markerTargetAbs, markerDir)
 }

--- a/artifact/image/symlink/symlink_test.go
+++ b/artifact/image/symlink/symlink_test.go
@@ -59,6 +59,7 @@ func TestTargetOutsideRoot(t *testing.T) {
 			if runtime.GOOS == "windows" {
 				return "\\\\..\\t.txt"
 			}
+
 			return "/../t.txt"
 		}(),
 		want: true,

--- a/artifact/image/tar/tar.go
+++ b/artifact/image/tar/tar.go
@@ -45,6 +45,7 @@ func SaveToTarball(path string, image v1.Image) error {
 		if strings.Contains(err.Error(), "invalid tar header") {
 			return fmt.Errorf("failed to copy image tar to %q: %v", path, err)
 		}
+
 		return fmt.Errorf("failed to copy image tar to %q: %w", path, err)
 	}
 

--- a/artifact/image/tar/tar_test.go
+++ b/artifact/image/tar/tar_test.go
@@ -76,6 +76,7 @@ func filesMatch(t *testing.T, path1, path2 string) bool {
 	if mustHashFile(t, path1) != mustHashFile(t, path2) {
 		return true
 	}
+
 	return false
 }
 
@@ -92,6 +93,7 @@ func mustHashFile(t *testing.T, path string) string {
 	if _, err := io.Copy(h, f); err != nil {
 		t.Fatalf("io.Copy(%v, %q) error: %v", h, path, err)
 	}
+
 	return string(h.Sum(nil))
 }
 
@@ -101,6 +103,7 @@ func mustImageFromPath(t *testing.T, path string) v1.Image {
 	if err != nil {
 		t.Fatalf("Failed to load image from path %q: %v", path, err)
 	}
+
 	return image
 }
 
@@ -110,5 +113,6 @@ func mustMkdirTemp(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
+
 	return dir
 }

--- a/artifact/image/unpack/unpack.go
+++ b/artifact/image/unpack/unpack.go
@@ -98,24 +98,28 @@ func DefaultUnpackerConfig() *UnpackerConfig {
 // WithMaxPass returns a UnpackerConfig with the specified MaxPass param.
 func (cfg *UnpackerConfig) WithMaxPass(maxPass int) *UnpackerConfig {
 	cfg.MaxPass = maxPass
+
 	return cfg
 }
 
 // WithMaxFileBytes returns a UnpackerConfig with the specified MaxFileBytes param.
 func (cfg *UnpackerConfig) WithMaxFileBytes(maxFileBytes int64) *UnpackerConfig {
 	cfg.MaxFileBytes = maxFileBytes
+
 	return cfg
 }
 
 // WithSymlinkResolution returns a UnpackerConfig with the specified SymlinkResolution param.
 func (cfg *UnpackerConfig) WithSymlinkResolution(resolution SymlinkResolution) *UnpackerConfig {
 	cfg.SymlinkResolution = resolution
+
 	return cfg
 }
 
 // WithRequirer returns a UnpackerConfig with the specified FileRequirer param.
 func (cfg *UnpackerConfig) WithRequirer(requirer require.FileRequirer) *UnpackerConfig {
 	cfg.Requirer = requirer
+
 	return cfg
 }
 
@@ -182,6 +186,7 @@ func (u *Unpacker) UnpackSquashed(dir string, image v1.Image) error {
 		if strings.Contains(err.Error(), "invalid tar header") {
 			return fmt.Errorf("invalid tar header when saving image to tarball (error message %q) with %q", tarPath, err.Error())
 		}
+
 		return fmt.Errorf("failed to save image to tarball %q: %w", tarPath, err)
 	}
 
@@ -203,6 +208,7 @@ func (u *Unpacker) UnpackSquashedFromTarball(dir string, tarPath string) error {
 		reader, err := os.Open(tarPath)
 		if err != nil {
 			log.Errorf("Failed to open tarball of image at %q: %v", tarPath, err)
+
 			return fmt.Errorf("failed to open tarball of image at %q: %w", tarPath, err)
 		}
 		log.Infof("Unpacking pass %d of %d", pass+1, u.MaxPass)
@@ -305,11 +311,13 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 			if err == io.EOF {
 				break
 			}
+
 			return nil, fmt.Errorf("failed to read next header in tarball: %w", err)
 		}
 
 		if header.Size > maxSizeBytes {
 			log.Infof("skipping file %q because its size (%d bytes) is larger than the max size (%d bytes)", header.Name, header.Size, maxSizeBytes)
+
 			continue
 		}
 
@@ -332,10 +340,12 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 		for _, p := range []string{fullPath, cleanPath, filepath.Join("/", cleanPath)} {
 			if requirer.FileRequired(p, header.FileInfo()) {
 				required = true
+
 				break
 			}
 			if _, ok := currRequiredTargets[p]; ok {
 				required = true
+
 				break
 			}
 		}
@@ -356,6 +366,7 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 			err := os.MkdirAll(parent, fs.ModePerm)
 			if err != nil {
 				log.Errorf("failed to create directory %q: %v", parent, err)
+
 				return nil, fmt.Errorf("failed to create directory %q: %w", parent, err)
 			}
 
@@ -364,6 +375,7 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 			err = os.WriteFile(fullPath, content, modeWithOwnerReadWrite)
 			if err != nil {
 				log.Errorf("failed to write file %q: %v", fullPath, err)
+
 				return nil, fmt.Errorf("failed to write file %q: %w", fullPath, err)
 			}
 
@@ -381,6 +393,7 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 
 			if symlink.TargetOutsideRoot(cleanPath, target) {
 				log.Warnf("Found symlink that points outside the root, skipping: %q -> %q", cleanPath, target)
+
 				continue
 			}
 
@@ -400,9 +413,11 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 					if symlinkErrStrategy == SymlinkErrReturn {
 						return nil, fmt.Errorf("failed to symlink %q to %q: %w", fullPath, targetPath, err)
 					}
+
 					continue
 				}
 				log.Infof("created symlink %q to %q", fullPath, targetPath)
+
 				continue
 			}
 
@@ -446,5 +461,6 @@ func (u *Unpacker) addSquashedImageDirectory(root string, image v1.Image) error 
 	if err := u.UnpackSquashed(squashedImagePath, image); err != nil {
 		return fmt.Errorf("failed to unpack all squashed image: %w", err)
 	}
+
 	return nil
 }

--- a/artifact/image/unpack/unpack_test.go
+++ b/artifact/image/unpack/unpack_test.go
@@ -204,6 +204,7 @@ func TestUnpackSquashed(t *testing.T) {
 				t.Fatalf("Failed to create temp dir: %v", err)
 			}
 			os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("some secret\n"), 0644)
+
 			return innerDir
 		}(),
 		image: mustImageFromPath(t, filepath.Join("testdata", "symlinks.tar")),
@@ -488,6 +489,7 @@ func mustNewUnpacker(t *testing.T, cfg *unpack.UnpackerConfig) *unpack.Unpacker 
 	if err != nil {
 		t.Fatalf("Failed to create unpacker: %v", err)
 	}
+
 	return u
 }
 
@@ -622,6 +624,7 @@ func mustNewSquashedImage(t *testing.T, pathsToContent map[string]contentAndMode
 	if err != nil {
 		t.Fatalf("unable append layer to image: %v", err)
 	}
+
 	return image
 }
 
@@ -632,6 +635,7 @@ func mustImageFromPath(t *testing.T, path string) v1.Image {
 	if err != nil {
 		t.Fatalf("Failed to load image from path %q: %v", path, err)
 	}
+
 	return image
 }
 
@@ -642,5 +646,6 @@ func mustMkdirTemp(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
+
 	return dir
 }

--- a/artifact/image/whiteout/whiteout.go
+++ b/artifact/image/whiteout/whiteout.go
@@ -54,24 +54,28 @@ func Files(scalibrfs scalibrfs.FS) (map[string]struct{}, error) {
 		if d.IsDir() && strings.HasPrefix(base, WhiteoutDirPrefix) {
 			whiteouts[path] = struct{}{}
 		}
+
 		return nil
 	})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to successfully walk fs to find whiteout files: %w", err)
 	}
+
 	return whiteouts, nil
 }
 
 // IsWhiteout returns true if a path is a whiteout path.
 func IsWhiteout(p string) bool {
 	_, file := path.Split(p)
+
 	return strings.HasPrefix(file, WhiteoutPrefix)
 }
 
 // ToWhiteout returns the whiteout version of a path.
 func ToWhiteout(p string) string {
 	dir, file := path.Split(p)
+
 	return path.Join(dir, fmt.Sprintf("%s%s", WhiteoutPrefix, file))
 }
 

--- a/binary/cdx/cdx.go
+++ b/binary/cdx/cdx.go
@@ -39,5 +39,6 @@ func Write(doc *cyclonedx.BOM, path string, format string) error {
 	}
 	defer f.Close()
 	encoder := cyclonedx.NewBOMEncoder(f, cdxFormat).SetPretty(true)
+
 	return encoder.Encode(doc)
 }

--- a/binary/cli/cli.go
+++ b/binary/cli/cli.go
@@ -59,6 +59,7 @@ func (i *Array) String() string {
 // For example, in the case of -o foo -o bar the library will call arr.Set("foo") then arr.Set("bar").
 func (i *Array) Set(value string) error {
 	*i = append(*i, strings.TrimSpace(value))
+
 	return nil
 }
 
@@ -85,6 +86,7 @@ func NewStringListFlag(defaultValue []string) StringListFlag {
 func (s *StringListFlag) Set(x string) error {
 	s.value = append(s.value, strings.Split(x, ",")...)
 	s.set = true
+
 	return nil
 }
 
@@ -98,6 +100,7 @@ func (s *StringListFlag) GetSlice() []string {
 	if s.set {
 		return s.value
 	}
+
 	return s.defaultValue
 }
 
@@ -105,6 +108,7 @@ func (s *StringListFlag) String() string {
 	if len(s.value) == 0 {
 		return ""
 	}
+
 	return fmt.Sprint(s.value)
 }
 
@@ -186,6 +190,7 @@ func ValidateFlags(flags *Flags) error {
 	if err := validateDetectorDependency(flags.DetectorsToRun, flags.ExtractorsToRun, flags.ExplicitExtractors); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -196,6 +201,7 @@ func validateResultPath(filePath string) error {
 	if err := proto.ValidExtension(filePath); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -210,6 +216,7 @@ func validateOutput(output []string) error {
 			return fmt.Errorf("output format %q not recognized, supported formats are %v", oFormat, supportedOutputFormats)
 		}
 	}
+
 	return nil
 }
 
@@ -221,6 +228,7 @@ func validateImagePlatform(imagePlatform string) error {
 	if len(platformDetails) < 2 {
 		return fmt.Errorf("Image platform '%s' is invalid. Must be in the form OS/Architecture (e.g. linux/amd64)", imagePlatform)
 	}
+
 	return nil
 }
 
@@ -234,6 +242,7 @@ func validateSPDXCreators(creators string) error {
 			return fmt.Errorf("invalid spdx-creators format, should follow a format like --spdx-creators=Tool:SCALIBR,Organization:Google")
 		}
 	}
+
 	return nil
 }
 
@@ -251,6 +260,7 @@ func validateMultiStringArg(arg []string) error {
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -259,11 +269,13 @@ func validateRegex(arg string) error {
 		return nil
 	}
 	_, err := regexp.Compile(arg)
+
 	return err
 }
 
 func validateGlob(arg string) error {
 	_, err := glob.Compile(arg)
+
 	return err
 }
 
@@ -296,6 +308,7 @@ func validateDetectorDependency(detectors []string, extractors []string, require
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -361,6 +374,7 @@ func (f *Flags) GetSPDXConfig() converter.SPDXConfig {
 			})
 		}
 	}
+
 	return converter.SPDXConfig{
 		DocumentName:      f.SPDXDocumentName,
 		DocumentNamespace: f.SPDXDocumentNamespace,
@@ -416,6 +430,7 @@ func (f *Flags) WriteScanResults(result *scalibr.ScanResult) error {
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -462,6 +477,7 @@ func (f *Flags) detectorsToRun() ([]detector.Detector, error) {
 			d.(*binary.Detector).OfflineVulnDBPath = f.GovulncheckDBPath
 		}
 	}
+
 	return dets, nil
 }
 
@@ -470,6 +486,7 @@ func multiStringToList(arg []string) []string {
 	for _, item := range arg {
 		result = append(result, strings.Split(item, ",")...)
 	}
+
 	return result
 }
 
@@ -501,6 +518,7 @@ func (f *Flags) scanRoots() ([]*scalibrfs.ScanRoot, error) {
 	for _, r := range scanRootPaths {
 		scanRoots = append(scanRoots, &scalibrfs.ScanRoot{FS: scalibrfs.DirFS(r), Path: r})
 	}
+
 	return scanRoots, nil
 }
 
@@ -517,6 +535,7 @@ func (f *Flags) scanRemoteImageOptions() (*[]remote.Option, error) {
 			},
 		))
 	}
+
 	return &imageOptions, nil
 }
 
@@ -535,6 +554,7 @@ func (f *Flags) capabilities() *plugin.Capabilities {
 			RunningSystem: false,
 		}
 	}
+
 	return &plugin.Capabilities{
 		OS:            platform.OS(),
 		Network:       network,
@@ -567,6 +587,7 @@ func filterByCapabilities(
 			df = append(df, det)
 		}
 	}
+
 	return ff, sf, df
 }
 
@@ -592,6 +613,7 @@ func (f *Flags) dirsToSkip(scanRoots []*scalibrfs.ScanRoot) []string {
 			}
 		}
 	}
+
 	return result
 }
 
@@ -600,5 +622,6 @@ func keys(m map[string][]string) []string {
 	for k := range m {
 		ret = append(ret, k)
 	}
+
 	return ret
 }

--- a/binary/proto/proto.go
+++ b/binary/proto/proto.go
@@ -102,6 +102,7 @@ func typeForPath(filePath string) (*fileType, error) {
 // ValidExtension returns an error if the file extension is not a proto file.
 func ValidExtension(path string) error {
 	_, err := typeForPath(path)
+
 	return err
 }
 
@@ -112,6 +113,7 @@ func Write(filePath string, outputProto proto.Message) error {
 	if err != nil {
 		return err
 	}
+
 	return write(filePath, outputProto, ft)
 }
 
@@ -119,6 +121,7 @@ func Write(filePath string, outputProto proto.Message) error {
 // on the value of the format parameter ("textproto" or "binproto")
 func WriteWithFormat(filePath string, outputProto proto.Message, format string) error {
 	ft := &fileType{isGZipped: false, isBinProto: format == "binproto"}
+
 	return write(filePath, outputProto, ft)
 }
 
@@ -154,6 +157,7 @@ func write(filePath string, outputProto proto.Message, ft *fileType) error {
 	} else if _, err := f.Write(p); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -205,6 +209,7 @@ func scanStatusToProto(s *plugin.ScanStatus) *spb.ScanStatus {
 	default:
 		e = spb.ScanStatus_UNSPECIFIED
 	}
+
 	return &spb.ScanStatus{Status: e, FailureReason: s.FailureReason}
 }
 
@@ -233,6 +238,7 @@ func inventoryToProto(i *extractor.Inventory) (*spb.Inventory, error) {
 		LayerDetails: layerDetailsToProto(i.LayerDetails),
 	}
 	setProtoMetadata(i.Metadata, inventoryProto)
+
 	return inventoryProto, nil
 }
 
@@ -514,6 +520,7 @@ func personsToProto(persons []*packagejson.Person) []string {
 	for _, p := range persons {
 		personStrings = append(personStrings, p.PersonString())
 	}
+
 	return personStrings
 }
 
@@ -521,6 +528,7 @@ func purlToProto(p *purl.PackageURL) *spb.Purl {
 	if p == nil {
 		return nil
 	}
+
 	return &spb.Purl{
 		Purl:       p.String(),
 		Type:       p.Type,
@@ -540,6 +548,7 @@ func annotationsToProto(as []extractor.Annotation) []spb.Inventory_AnnotationEnu
 	for _, a := range as {
 		ps = append(ps, annotationToProto(a))
 	}
+
 	return ps
 }
 
@@ -555,6 +564,7 @@ func annotationToProto(s extractor.Annotation) spb.Inventory_AnnotationEnum {
 	default:
 		e = spb.Inventory_UNSPECIFIED
 	}
+
 	return e
 }
 
@@ -562,6 +572,7 @@ func layerDetailsToProto(ld *extractor.LayerDetails) *spb.LayerDetails {
 	if ld == nil {
 		return nil
 	}
+
 	return &spb.LayerDetails{
 		Index:       int32(ld.Index),
 		DiffId:      ld.DiffID,
@@ -574,6 +585,7 @@ func sourceCodeIdentifierToProto(s *extractor.SourceCodeIdentifier) *spb.SourceC
 	if s == nil {
 		return nil
 	}
+
 	return &spb.SourceCodeIdentifier{
 		Repo:   s.Repo,
 		Commit: s.Commit,
@@ -585,6 +597,7 @@ func qualifiersToProto(qs purl.Qualifiers) []*spb.Qualifier {
 	for _, q := range qs {
 		result = append(result, &spb.Qualifier{Key: q.Key, Value: q.Value})
 	}
+
 	return result
 }
 
@@ -612,6 +625,7 @@ func findingToProto(f *detector.Finding) (*spb.Finding, error) {
 	if f.Adv.ID == nil {
 		return nil, ErrAdvisoryIDMissing
 	}
+
 	return &spb.Finding{
 		Adv: &spb.Advisory{
 			Id: &spb.AdvisoryId{
@@ -662,6 +676,7 @@ func severityToProto(s *detector.Severity) *spb.Severity {
 	if s.CVSSV3 != nil {
 		r.CvssV3 = cvssToProto(s.CVSSV3)
 	}
+
 	return r
 }
 

--- a/binary/scalibr/scalibr.go
+++ b/binary/scalibr/scalibr.go
@@ -90,5 +90,6 @@ func parseFlags() *cli.Flags {
 		log.Errorf("Error parsing CLI args: %v", err)
 		os.Exit(1)
 	}
+
 	return flags
 }

--- a/binary/scanrunner/scanrunner.go
+++ b/binary/scanrunner/scanrunner.go
@@ -34,6 +34,7 @@ func RunScan(flags *cli.Flags) int {
 	cfg, err := flags.GetScanConfig()
 	if err != nil {
 		log.Errorf("%v.GetScanConfig(): %v", flags, err)
+
 		return 1
 	}
 
@@ -52,11 +53,13 @@ func RunScan(flags *cli.Flags) int {
 
 	if err := flags.WriteScanResults(result); err != nil {
 		log.Errorf("Error writing scan results: %v", err)
+
 		return 1
 	}
 
 	if result.Status.Status != plugin.ScanStatusSucceeded {
 		log.Errorf("Scan wasn't successful: %s", result.Status.FailureReason)
+
 		return 1
 	}
 

--- a/binary/scanrunner/scanrunner_test.go
+++ b/binary/scanrunner/scanrunner_test.go
@@ -41,6 +41,7 @@ func createDetectorTestFiles(t *testing.T) string {
 	if err := os.WriteFile(passwdFile, []byte("content"), 0644); err != nil {
 		t.Fatalf("Error while creating file %s: %v", passwdFile, err)
 	}
+
 	return dir
 }
 
@@ -61,6 +62,7 @@ func createExtractorTestFiles(t *testing.T) string {
 	if err := os.WriteFile(dstFile, data, 0644); err != nil {
 		t.Fatalf("os.WriteFile(%s): %v", dstFile, err)
 	}
+
 	return dir
 }
 
@@ -72,6 +74,7 @@ func createFailingDetectorTestFiles(t *testing.T) string {
 	if err := os.Mkdir(passwdDir, 0600); err != nil {
 		t.Fatalf("error creating directory %v: %v", passwdDir, err)
 	}
+
 	return dir
 }
 

--- a/binary/spdx/spdx.go
+++ b/binary/spdx/spdx.go
@@ -50,6 +50,7 @@ func Write23(doc *v2_3.Document, path string, format string) error {
 	if err = writeFun(doc, f); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/clients/datasource/cache.go
+++ b/clients/datasource/cache.go
@@ -38,6 +38,7 @@ func gobMarshal(v any) ([]byte, error) {
 
 func gobUnmarshal(b []byte, v any) error {
 	dec := gob.NewDecoder(bytes.NewReader(b))
+
 	return dec.Decode(v)
 }
 
@@ -69,6 +70,7 @@ func (rq *RequestCache[K, V]) Get(key K, fn func() (V, error)) (V, error) {
 	rq.mu.Lock()
 	if v, ok := rq.cache[key]; ok {
 		rq.mu.Unlock()
+
 		return v, nil
 	}
 

--- a/clients/datasource/cache_test.go
+++ b/clients/datasource/cache_test.go
@@ -42,6 +42,7 @@ func TestRequestCache(t *testing.T) {
 					// Count how many times this function gets called for this key,
 					// then return the key as the value.
 					atomic.AddInt32(&fnCalls[i], 1)
+
 					return i, nil
 				})
 				wg.Done()

--- a/clients/datasource/http_auth.go
+++ b/clients/datasource/http_auth.go
@@ -139,6 +139,7 @@ func (auth *HTTPAuthentication) Get(ctx context.Context, httpClient *http.Client
 		}
 		if ok {
 			usedMethod = method
+
 			break
 		}
 	}
@@ -157,6 +158,7 @@ func (auth *HTTPAuthentication) Get(ctx context.Context, httpClient *http.Client
 func (auth *HTTPAuthentication) authIndex(wwwAuth []string, authScheme string) int {
 	return slices.IndexFunc(wwwAuth, func(s string) bool {
 		scheme, _, _ := strings.Cut(s, " ")
+
 		return scheme == authScheme
 	})
 }

--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -164,6 +164,7 @@ func (m *MavenRegistryAPIClient) GetProject(ctx context.Context, groupID, artifa
 			if sv.Extension == "pom" {
 				// We only look for pom.xml for project metadata.
 				snapshot = string(sv.Value)
+
 				break
 			}
 		}

--- a/common/linux/proc/nettcp_linux.go
+++ b/common/linux/proc/nettcp_linux.go
@@ -167,6 +167,7 @@ func parseIP(hexa string) (*net.IP, error) {
 
 	if len(b) == 4 {
 		ip := net.IPv4(b[3], b[2], b[1], b[0])
+
 		return &ip, nil
 	}
 

--- a/common/linux/proc/process_linux.go
+++ b/common/linux/proc/process_linux.go
@@ -52,6 +52,7 @@ func ReadProcessCmdline(ctx context.Context, pid int64, root string, fsys scalib
 	}
 
 	cmd := strings.Trim(string(cmdline), "\x00")
+
 	return strings.Split(cmd, string('\x00')), nil
 }
 

--- a/common/windows/registry/offline.go
+++ b/common/windows/registry/offline.go
@@ -48,6 +48,7 @@ func (o *OfflineOpener) Open() (Registry, error) {
 	reg, err := regparser.NewRegistry(f)
 	if err != nil {
 		f.Close()
+
 		return nil, err
 	}
 

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -86,12 +86,14 @@ func ToSPDX23(r *scalibr.ScanResult, c SPDXConfig) *v2_3.Document {
 		p := ToPURL(i)
 		if p == nil {
 			log.Warnf("Inventory %v has no PURL, skipping", i)
+
 			continue
 		}
 		pName := p.Name
 		pVersion := p.Version
 		if pName == "" || pVersion == "" {
 			log.Warnf("Inventory %v PURL name or version empty, skipping", i)
+
 			continue
 		}
 		pID := SPDXRefPrefix + "Package-" + replaceSPDXIDInvalidChars(pName) + "-" + uuid.New().String()
@@ -148,6 +150,7 @@ func ToSPDX23(r *scalibr.ScanResult, c SPDXConfig) *v2_3.Document {
 		},
 	}
 	creators = append(creators, c.Creators...)
+
 	return &v2_3.Document{
 		SPDXVersion:       "SPDX-2.3",
 		DataLicense:       "CC0-1.0",
@@ -173,6 +176,7 @@ func toDocElementID(id string) common.DocElementID {
 			SpecialID: NoAssertion,
 		}
 	}
+
 	return common.DocElementID{
 		ElementRefID: common.ElementID(id),
 	}
@@ -260,5 +264,6 @@ func extractCPEs(i *extractor.Inventory) []string {
 	if m, ok := i.Metadata.(*cdxe.Metadata); ok {
 		return m.CPEs
 	}
+
 	return nil
 }

--- a/detector/cis/generic_linux/etcpasswdpermissions/detector_helper_test.go
+++ b/detector/cis/generic_linux/etcpasswdpermissions/detector_helper_test.go
@@ -29,8 +29,10 @@ func (f *fakeFS) Open(name string) (fs.File, error) {
 		if f.exists {
 			return &fakeFile{perms: f.perms, uid: f.uid, gid: f.gid}, nil
 		}
+
 		return nil, os.ErrNotExist
 	}
+
 	return nil, errors.New("failed to open")
 }
 func (fakeFS) ReadDir(name string) ([]fs.DirEntry, error) {

--- a/detector/cis/generic_linux/etcpasswdpermissions/etcpasswdpermissions.go
+++ b/detector/cis/generic_linux/etcpasswdpermissions/etcpasswdpermissions.go
@@ -70,6 +70,7 @@ func (Detector) ScanFS(ctx context.Context, fs fs.FS, ix *inventoryindex.Invento
 			// File doesn't exist, check not applicable.
 			return nil, nil
 		}
+
 		return nil, err
 	}
 	defer f.Close()
@@ -105,6 +106,7 @@ func (Detector) ScanFS(ctx context.Context, fs fs.FS, ix *inventoryindex.Invento
 	recommendation := "Run the following command to set permissions on /etc/passwd :\n" +
 		"# chown root:root /etc/passwd\n" +
 		"# chmod 644 /etc/passwd"
+
 	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{

--- a/detector/cve/cve202016846/cve202016846.go
+++ b/detector/cve/cve202016846/cve202016846.go
@@ -124,6 +124,7 @@ func findSaltVersions(ix *inventoryindex.InventoryIndex) (string, *extractor.Inv
 			return i.Version, i, r.affectedVersions
 		}
 	}
+
 	return "", nil, []string{}
 }
 
@@ -132,6 +133,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	saltVersion, inventory, affectedVersions := findSaltVersions(ix)
 	if saltVersion == "" {
 		log.Debugf("No Salt version found")
+
 		return nil, nil
 	}
 	isVulnVersion := false
@@ -143,6 +145,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 
 	if !isVulnVersion {
 		log.Infof("Version %q not vuln", saltVersion)
+
 		return nil, nil
 	}
 
@@ -150,11 +153,13 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 
 	if !CheckForCherrypy(saltServerIP, saltServerPort) {
 		log.Infof("Cherry py not found. Version %q not vulnerable", saltVersion)
+
 		return nil, nil
 	}
 
 	if !ExploitSalt(ctx, saltServerIP, saltServerPort) {
 		log.Infof("Version %q not vulnerable", saltVersion)
+
 		return nil, nil
 	}
 
@@ -198,11 +203,13 @@ func CheckForCherrypy(saltIP string, saltServerPort int) bool {
 	resp, err := client.Get(target)
 	if err != nil {
 		log.Infof("Request failed: %v", err)
+
 		return false
 	}
 	defer resp.Body.Close()
 
 	serverHeader := resp.Header.Get("Server")
+
 	return strings.Contains(serverHeader, "CherryPy")
 }
 
@@ -220,6 +227,7 @@ func ExploitSalt(ctx context.Context, saltIP string, saltServerPort int) bool {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		log.Infof("Error marshaling JSON:", err)
+
 		return false
 	}
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
@@ -228,6 +236,7 @@ func ExploitSalt(ctx context.Context, saltIP string, saltServerPort int) bool {
 	req, err := http.NewRequestWithContext(ctx, "POST", target, bytes.NewBuffer(jsonData))
 	if err != nil {
 		log.Infof("Error creating request: %v\n", err)
+
 		return false
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -237,15 +246,18 @@ func ExploitSalt(ctx context.Context, saltIP string, saltServerPort int) bool {
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			log.Infof("Request needs to timeout. POST request hangs up otherwise")
+
 			return true
 		}
 		log.Infof("Error sending request: %v\n", err)
+
 		return false
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		log.Infof("Unexpected status code: %d\n", resp.StatusCode)
+
 		return false
 	}
 
@@ -254,6 +266,7 @@ func ExploitSalt(ctx context.Context, saltIP string, saltServerPort int) bool {
 
 func fileExists(filesys scalibrfs.FS, path string) bool {
 	_, err := fs.Stat(filesys, path)
+
 	return !os.IsNotExist(err)
 }
 
@@ -263,5 +276,6 @@ func randomString(length int) string {
 	for i := range b {
 		b[i] = charSet[seededRand.Intn(len(charSet)-1)]
 	}
+
 	return string(b)
 }

--- a/detector/cve/cve202233891/cve202233891.go
+++ b/detector/cve/cve202233891/cve202233891.go
@@ -102,6 +102,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	sparkUIVersion, inventory, affectedVersions := findApacheSparkUIPackage(ix)
 	if sparkUIVersion == "" {
 		log.Debugf("No Apache Spark UI version found")
+
 		return nil, nil
 	}
 
@@ -114,6 +115,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 
 	if !isVulnVersion {
 		log.Infof("Version %q not vuln", sparkUIVersion)
+
 		return nil, nil
 	}
 	log.Infof("Found Potentially vulnerable Apache Spark UI version %v", sparkUIVersion)
@@ -126,6 +128,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 		// We expect to receive a 403 error
 		if retCode != 403 {
 			log.Infof("Version %q not vuln (HTTP query didn't return 403: %v)", sparkUIVersion, retCode)
+
 			continue
 		}
 
@@ -136,6 +139,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 			}
 			log.Infof("File %v found, this server is vulnerable. Removing the file now", randFilePath)
 			vulnerable = true
+
 			break
 		}
 		log.Infof("Version %q not vuln (Temp file not found)", sparkUIVersion)
@@ -143,6 +147,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	if !vulnerable {
 		return nil, nil
 	}
+
 	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
@@ -172,6 +177,7 @@ func sparkUIHTTPQuery(ctx context.Context, sparkDomain string, sparkPort int, cm
 
 	if err != nil {
 		log.Infof("Error when sending request %s to the server", targetURL)
+
 		return 0
 	}
 
@@ -187,11 +193,13 @@ func findApacheSparkUIPackage(ix *inventoryindex.InventoryIndex) (string, *extra
 			return i.Version, i, r.affectedVersions
 		}
 	}
+
 	return "", nil, []string{}
 }
 
 func fileExists(filesys scalibrfs.FS, path string) bool {
 	_, err := fs.Stat(filesys, path)
+
 	return !os.IsNotExist(err)
 }
 
@@ -201,5 +209,6 @@ func randomString(length int) string {
 	for i := range b {
 		b[i] = charSet[seededRand.Intn(len(charSet)-1)]
 	}
+
 	return string(b)
 }

--- a/detector/cve/cve202338408/cve202338408.go
+++ b/detector/cve/cve202338408/cve202338408.go
@@ -75,11 +75,13 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	openSSHVersion := getOpenSSHVersion()
 	if openSSHVersion == "" {
 		log.Debugf("No OpenSSH version found")
+
 		return nil, nil
 	}
 	isVulnVersion := versionLessEqual("5.5", openSSHVersion) && versionLessEqual(openSSHVersion, "9.3p1")
 	if !isVulnVersion {
 		log.Debugf("Version %q not vuln", openSSHVersion)
+
 		return nil, nil
 	}
 	log.Debugf("Found OpenSSH in range 5.5 to 9.3p1 (inclusive): %v", openSSHVersion)
@@ -151,6 +153,7 @@ func getOpenSSHVersion() string {
 	log.Debugf("ssh -V stdout: %s", string(out))
 	if err != nil {
 		log.Errorf("Command \"ssh -V\": %v", err)
+
 		return ""
 	}
 
@@ -158,6 +161,7 @@ func getOpenSSHVersion() string {
 	if len(matches) >= 2 {
 		return matches[1]
 	}
+
 	return ""
 }
 
@@ -171,11 +175,13 @@ func buildExtra(isVulnVersion bool, configsWithForward []fileLocations, socketFi
 			slist = append(slist, "0")
 		}
 	}
+
 	return strings.Join(slist, ":")
 }
 
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
+
 	return !os.IsNotExist(err)
 }
 
@@ -205,6 +211,7 @@ func sshConfigContainsForward(path string) []int {
 	f, err := os.Open(path)
 	if err != nil {
 		log.Warnf("sshConfigContainsForward(%q): %v", path, err)
+
 		return nil
 	}
 	defer f.Close()
@@ -254,6 +261,7 @@ func findHistoryFiles() []string {
 	if err != nil {
 		log.Errorf("filepath.Glob(\"/root/.histfile\"): %v", err)
 	}
+
 	return append(append(append(pHistory, pHistfile...), pRootHistory...), pRootHistfile...)
 }
 
@@ -261,6 +269,7 @@ func findString(path string, re *regexp.Regexp) []int {
 	f, err := os.Open(path)
 	if err != nil {
 		log.Warnf("findString(%q, %v): %v", path, re, err)
+
 		return nil
 	}
 	defer f.Close()

--- a/detector/cve/cve20236019/cve20236019.go
+++ b/detector/cve/cve20236019/cve20236019.go
@@ -74,6 +74,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	rayVersion, inventory := findRayPackage(ix)
 	if rayVersion == "" {
 		log.Debugf("No Ray version found")
+
 		return nil, nil
 	}
 	log.Infof("Ray version found")
@@ -81,6 +82,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	// Check if Ray version is vulnerable (< 2.8.1)
 	if !isVulnerableVersion(rayVersion) {
 		log.Infof("Ray version %q is not vulnerable", rayVersion)
+
 		return nil, nil
 	}
 	log.Infof("Found potentially vulnerable Ray version %v", rayVersion)
@@ -88,6 +90,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	// Check for the "Ray Dashboard" string in the HTTP response
 	if !isDashboardPresent(ctx) {
 		log.Infof("Ray Dashboard not found in HTTP response")
+
 		return nil, nil
 	}
 	// Attempt the curl request
@@ -96,8 +99,10 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 		log.Infof("Vulnerability exploited successfully")
 	} else {
 		log.Infof("Exploit attempt failed")
+
 		return nil, nil
 	}
+
 	return []*detector.Finding{{
 		Adv: &detector.Advisory{
 			ID: &detector.AdvisoryID{
@@ -123,6 +128,7 @@ func findRayPackage(ix *inventoryindex.InventoryIndex) (string, *extractor.Inven
 	for _, i := range inventory {
 		return i.Version, i
 	}
+
 	return "", nil
 }
 
@@ -132,17 +138,20 @@ func isVulnerableVersion(version string) bool {
 	parts := strings.Split(version, ".")
 	if len(parts) < 2 {
 		log.Errorf("Invalid Ray version format: %s", version)
+
 		return false // Consider this not vulnerable to avoid false positives
 	}
 	// Parse the major and minor version components
 	major, err := strconv.Atoi(parts[0])
 	if err != nil {
 		log.Errorf("Error parsing major version: %v", err)
+
 		return false
 	}
 	minor, err := strconv.Atoi(parts[1])
 	if err != nil {
 		log.Errorf("Error parsing minor version: %v", err)
+
 		return false
 	}
 	// Check if the version is less than 2.8.1
@@ -155,6 +164,7 @@ func isDashboardPresent(ctx context.Context) bool {
 	req, err := http.NewRequestWithContext(ctx, "GET", "http://127.0.0.1:8265", nil)
 	if err != nil {
 		log.Errorf("Error creating HTTP request: %v", err)
+
 		return false
 	}
 
@@ -163,6 +173,7 @@ func isDashboardPresent(ctx context.Context) bool {
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Errorf("Error making HTTP request: %v", err)
+
 		return false
 	}
 	defer resp.Body.Close()
@@ -172,12 +183,14 @@ func isDashboardPresent(ctx context.Context) bool {
 	for scanner.Scan() {
 		if strings.Contains(scanner.Text(), "Ray Dashboard") {
 			log.Infof("Ray Dashboard found in HTTP response")
+
 			return true
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		log.Errorf("Error reading HTTP response: %v", err)
 	}
+
 	return false
 }
 
@@ -191,6 +204,7 @@ func attemptExploit(ctx context.Context) string {
 	// Perform the HTTP query
 	statusCode := rayRequest(ctx, "127.0.0.1", 8265, testCmd)
 	log.Infof("HTTP request returned status code: %d", statusCode)
+
 	return randomFilePath
 }
 
@@ -202,6 +216,7 @@ func rayRequest(ctx context.Context, host string, port int, cmd string) int {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		log.Errorf("Error creating HTTP request: %v", err)
+
 		return 500 // Return an error code
 	}
 
@@ -210,6 +225,7 @@ func rayRequest(ctx context.Context, host string, port int, cmd string) int {
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Infof("Error when sending request %s to the server", url)
+
 		return 500 // Return an error code
 	}
 	defer resp.Body.Close()
@@ -220,6 +236,7 @@ func rayRequest(ctx context.Context, host string, port int, cmd string) int {
 
 func fileExists(filesys scalibrfs.FS, path string) bool {
 	_, err := fs.Stat(filesys, path)
+
 	return !os.IsNotExist(err)
 }
 
@@ -232,5 +249,6 @@ func generateRandomString(length int) string {
 	for i := range length {
 		bytes[i] = letters[rand.Intn(len(letters))]
 	}
+
 	return string(bytes)
 }

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -153,6 +153,7 @@ func Run(ctx context.Context, c stats.Collector, detectors []Detector, scanRoot 
 	if err := validateAdvisories(findings); err != nil {
 		return []*Finding{}, status, err
 	}
+
 	return findings, status, nil
 }
 
@@ -173,5 +174,6 @@ func validateAdvisories(findings []*Finding) error {
 		}
 		ids[*f.Adv.ID] = *f.Adv
 	}
+
 	return nil
 }

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -171,5 +171,6 @@ func TestRun(t *testing.T) {
 func withDetectorName(f *detector.Finding, det string) *detector.Finding {
 	c := *f
 	c.Detectors = []string{det}
+
 	return &c
 }

--- a/detector/govulncheck/binary/binary.go
+++ b/detector/govulncheck/binary/binary.go
@@ -62,6 +62,7 @@ func (d Detector) Requirements() *plugin.Capabilities {
 	if d.OfflineVulnDBPath == "" {
 		net = plugin.NetworkAny
 	}
+
 	return &plugin.Capabilities{Network: net, DirectFS: true}
 }
 
@@ -91,16 +92,19 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 			out, err := d.runGovulncheck(ctx, l, scanRoot.Path)
 			if err != nil {
 				allErrs = appendError(allErrs, fmt.Errorf("d.runGovulncheck(%s): %w", l, err))
+
 				continue
 			}
 			r, err := parseVulnsFromOutput(out, l)
 			if err != nil {
 				allErrs = appendError(allErrs, fmt.Errorf("d.parseVulnsFromOutput(%v, %s): %w", out, l, err))
+
 				continue
 			}
 			result = append(result, r...)
 		}
 	}
+
 	return result, allErrs
 }
 
@@ -122,6 +126,7 @@ func (d Detector) runGovulncheck(ctx context.Context, binaryPath, scanRoot strin
 		return nil, err
 	}
 	log.Debugf("govulncheck complete")
+
 	return &out, nil
 }
 
@@ -171,6 +176,7 @@ func parseVulnsFromOutput(out *bytes.Buffer, binaryPath string) ([]*detector.Fin
 			Extra:  extra,
 		})
 	}
+
 	return result, nil
 }
 
@@ -185,6 +191,7 @@ func getAdvisoryID(e *osvEntry) *detector.AdvisoryID {
 		} else {
 			continue
 		}
+
 		return &detector.AdvisoryID{
 			Publisher: publisher,
 			Reference: a,
@@ -201,5 +208,6 @@ func appendError(err1, err2 error) error {
 	if err1 == nil {
 		return err2
 	}
+
 	return fmt.Errorf("%w\n%w", err1, err2)
 }

--- a/detector/govulncheck/binary/binary_test.go
+++ b/detector/govulncheck/binary/binary_test.go
@@ -125,5 +125,6 @@ func setupInventoryIndex(names []string) *inventoryindex.InventoryIndex {
 		})
 	}
 	ix, _ := inventoryindex.New(invs)
+
 	return ix
 }

--- a/detector/list/list.go
+++ b/detector/list/list.go
@@ -77,6 +77,7 @@ func concat(InitMaps ...InitMap) InitMap {
 	for _, m := range InitMaps {
 		maps.Copy(result, m)
 	}
+
 	return result
 }
 
@@ -94,6 +95,7 @@ func FromCapabilities(capabs *plugin.Capabilities) []detector.Detector {
 			all = append(all, initer())
 		}
 	}
+
 	return FilterByCapabilities(all, capabs)
 }
 
@@ -107,6 +109,7 @@ func FilterByCapabilities(dets []detector.Detector, capabs *plugin.Capabilities)
 			result = append(result, det)
 		}
 	}
+
 	return result
 }
 
@@ -129,5 +132,6 @@ func DetectorsFromNames(names []string) ([]detector.Detector, error) {
 	for _, d := range resultMap {
 		result = append(result, d)
 	}
+
 	return result, nil
 }

--- a/detector/list/list_test.go
+++ b/detector/list/list_test.go
@@ -50,6 +50,7 @@ func TestFromCapabilities(t *testing.T) {
 	for _, ex := range dl.FromCapabilities(capab) {
 		if ex.Name() == want {
 			found = true
+
 			break
 		}
 		if ex.Name() == dontWant {

--- a/detector/weakcredentials/etcshadow/cracker.go
+++ b/detector/weakcredentials/etcshadow/cracker.go
@@ -53,6 +53,7 @@ func (c passwordCracker) Crack(ctx context.Context, hash string) (string, error)
 	case strings.HasPrefix(hash, sha512_crypt.MagicPrefix):
 		return c.sha512cryptCracker.Crack(ctx, hash)
 	}
+
 	return "", ErrNotCracked
 }
 
@@ -70,6 +71,7 @@ func (c bcryptCracker) Crack(ctx context.Context, hash string) (string, error) {
 			return v, nil
 		}
 	}
+
 	return "", ErrNotCracked
 }
 
@@ -88,5 +90,6 @@ func (c sha512CryptCracker) Crack(ctx context.Context, hash string) (string, err
 			return v, nil
 		}
 	}
+
 	return "", ErrNotCracked
 }

--- a/detector/weakcredentials/etcshadow/etcshadow.go
+++ b/detector/weakcredentials/etcshadow/etcshadow.go
@@ -64,6 +64,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 			// File doesn't exist, check not applicable.
 			return nil, nil
 		}
+
 		return nil, err
 	}
 	defer f.Close()

--- a/detector/weakcredentials/etcshadow/etcshadow_test.go
+++ b/detector/weakcredentials/etcshadow/etcshadow_test.go
@@ -59,6 +59,7 @@ func (f fakeFS) Open(name string) (fs.File, error) {
 	if content, ok := f.files[name]; ok {
 		return &fakeFile{content, 0}, nil
 	}
+
 	return nil, os.ErrNotExist
 }
 func (fakeFS) ReadDir(name string) ([]fs.DirEntry, error) {
@@ -81,8 +82,10 @@ func (f *fakeFile) Read(buffer []byte) (count int, err error) {
 	size := copy(buffer, f.content[f.position:])
 	if size > 0 {
 		f.position += size
+
 		return size, nil
 	}
+
 	return 0, io.EOF
 }
 

--- a/detector/weakcredentials/filebrowser/filebrowser.go
+++ b/detector/weakcredentials/filebrowser/filebrowser.go
@@ -94,6 +94,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 		if !isVulnerable(ctx, fileBrowserIP, fileBrowserPort) {
 			continue
 		}
+
 		return []*detector.Finding{{
 			Adv: &detector.Advisory{
 				ID: &detector.AdvisoryID{
@@ -119,6 +120,7 @@ func isVulnerable(ctx context.Context, fileBrowserIP string, fileBrowserPort int
 	if !checkLogin(ctx, fileBrowserIP, fileBrowserPort) {
 		return false
 	}
+
 	return true
 }
 
@@ -130,6 +132,7 @@ func checkAccessibility(ctx context.Context, fileBrowserIP string, fileBrowserPo
 	req, err := http.NewRequestWithContext(ctx, "GET", targetURL, nil)
 	if err != nil {
 		log.Infof("Error while constructing request %s to the server: %v", targetURL, err)
+
 		return false
 	}
 
@@ -140,6 +143,7 @@ func checkAccessibility(ctx context.Context, fileBrowserIP string, fileBrowserPo
 		} else {
 			log.Debugf("Error when sending request %s to the server: %v", targetURL, err)
 		}
+
 		return false
 	}
 	defer resp.Body.Close()
@@ -151,18 +155,21 @@ func checkAccessibility(ctx context.Context, fileBrowserIP string, fileBrowserPo
 	// Expected size for the response is around 6 kilobytes.
 	if resp.ContentLength > 20*1024 {
 		log.Infof("Filesize is too large: %d bytes", resp.ContentLength)
+
 		return false
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Infof("Error reading response body: %v", err)
+
 		return false
 	}
 
 	bodyString := string(bodyBytes)
 	if !strings.Contains(bodyString, "File Browser") {
 		log.Infof("Response body does not contain 'File Browser'")
+
 		return false
 	}
 
@@ -183,6 +190,7 @@ func checkLogin(ctx context.Context, fileBrowserIP string, fileBrowserPort int) 
 	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, io.NopCloser(bytes.NewBuffer(requestBody)))
 	if err != nil {
 		log.Infof("Error while constructing request %s to the server: %v", targetURL, err)
+
 		return false
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -194,6 +202,7 @@ func checkLogin(ctx context.Context, fileBrowserIP string, fileBrowserPort int) 
 		} else {
 			log.Infof("Error when sending request %s to the server: %v", targetURL, err)
 		}
+
 		return false
 	}
 	defer resp.Body.Close()

--- a/detector/weakcredentials/winlocal/samreg/crypto.go
+++ b/detector/weakcredentials/winlocal/samreg/crypto.go
@@ -88,6 +88,7 @@ func deriveRID(rid []byte) ([]byte, []byte, error) {
 
 	rid1 := []byte{rid[0], rid[1], rid[2], rid[3], rid[0], rid[1], rid[2]}
 	rid2 := []byte{rid[3], rid[0], rid[1], rid[2], rid[3], rid[0], rid[1]}
+
 	return transformRID(rid1), transformRID(rid2), nil
 }
 
@@ -113,6 +114,7 @@ func decryptDES(rid []byte, encryptedHash []byte) ([]byte, error) {
 	decryptedHash := make([]byte, 16)
 	block1.Decrypt(decryptedHash[:8], encryptedHash[:8])
 	block2.Decrypt(decryptedHash[8:], encryptedHash[8:])
+
 	return decryptedHash, nil
 }
 
@@ -127,6 +129,7 @@ func decryptRC4Hash(rid []byte, syskey, hash []byte, hashConstant []byte) ([]byt
 
 	rc4Decrypted := make([]byte, 16)
 	c.XORKeyStream(rc4Decrypted, hash)
+
 	return decryptDES(rid, rc4Decrypted[:16])
 }
 
@@ -149,5 +152,6 @@ func decryptAESHash(rid []byte, syskey, hash []byte, iv []byte) ([]byte, error) 
 	mode := cipher.NewCBCDecrypter(block, iv)
 	aesDecrypted := make([]byte, 32)
 	mode.CryptBlocks(aesDecrypted, hash)
+
 	return decryptDES(rid, aesDecrypted)
 }

--- a/detector/weakcredentials/winlocal/samreg/domainf.go
+++ b/detector/weakcredentials/winlocal/samreg/domainf.go
@@ -98,6 +98,7 @@ func (s *domainF) deriveSyskeyAES(origSyskey []byte, fDomKeyPart []byte) ([]byte
 	mode := cipher.NewCBCDecrypter(block, keyData.Salt[:])
 	derivedKey := make([]byte, keyData.DataLength)
 	mode.CryptBlocks(derivedKey, data)
+
 	return derivedKey[:16], nil
 }
 

--- a/extractor/filesystem/containers/containerd/containerd_test.go
+++ b/extractor/filesystem/containers/containerd/containerd_test.go
@@ -277,6 +277,7 @@ func createScanInput(t *testing.T, root string, path string) *filesystem.ScanInp
 		t.Fatal(err)
 	}
 	input := &filesystem.ScanInput{Path: path, Reader: reader, Root: root, Info: info}
+
 	return input
 }
 

--- a/extractor/filesystem/errors.go
+++ b/extractor/filesystem/errors.go
@@ -35,5 +35,6 @@ func ExtractorErrorToFileExtractedResult(err error) stats.FileExtractedResult {
 	} else if errors.Is(err, ErrExtractorMemoryLimitExceeded) {
 		return stats.FileExtractedResultErrorMemoryLimitExceeded
 	}
+
 	return stats.FileExtractedResultErrorUnknown
 }

--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -219,6 +219,7 @@ func RunFS(ctx context.Context, config *Config, wc *walkContext) ([]*extractor.I
 					wc.printStatus()
 				case <-quit:
 					ticker.Stop()
+
 					return
 				}
 			}
@@ -285,6 +286,7 @@ func walkIndividualFiles(fsys scalibrfs.FS, paths []string, fn fs.WalkDirFunc) e
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -310,6 +312,7 @@ func (wc *walkContext) handleFile(path string, d fs.DirEntry, fserr error) error
 		} else {
 			log.Errorf("fserr (non-permission error): %v", fserr)
 		}
+
 		return nil
 	}
 	if d.Type().IsDir() {
@@ -317,6 +320,7 @@ func (wc *walkContext) handleFile(path string, d fs.DirEntry, fserr error) error
 		if wc.shouldSkipDir(path) { // Skip everything inside this dir.
 			return fs.SkipDir
 		}
+
 		return nil
 	}
 
@@ -340,6 +344,7 @@ func (wc *walkContext) handleFile(path string, d fs.DirEntry, fserr error) error
 			wc.runExtractor(ex, path)
 		}
 	}
+
 	return nil
 }
 
@@ -359,6 +364,7 @@ func (api *lazyFileAPI) Stat() (fs.FileInfo, error) {
 		api.currentStatCalled = true
 		api.currentFileInfo, api.currentStatErr = fs.Stat(api.fs, api.currentPath)
 	}
+
 	return api.currentFileInfo, api.currentStatErr
 }
 
@@ -372,6 +378,7 @@ func (wc *walkContext) shouldSkipDir(path string) bool {
 	if wc.skipDirGlob != nil {
 		return wc.skipDirGlob.Match(path)
 	}
+
 	return false
 }
 
@@ -379,6 +386,7 @@ func (wc *walkContext) runExtractor(ex Extractor, path string) {
 	rc, err := wc.fs.Open(path)
 	if err != nil {
 		addErrToMap(wc.errors, ex.Name(), fmt.Errorf("Open(%s): %v", path, err))
+
 		return
 	}
 	defer rc.Close()
@@ -386,6 +394,7 @@ func (wc *walkContext) runExtractor(ex Extractor, path string) {
 	info, err := rc.Stat()
 	if err != nil {
 		addErrToMap(wc.errors, ex.Name(), fmt.Errorf("stat(%s): %v", path, err))
+
 		return
 	}
 
@@ -423,6 +432,7 @@ func (wc *walkContext) UpdateScanRoot(absRoot string, fs scalibrfs.FS) error {
 	wc.scanRoot = absRoot
 	wc.fs = fs
 	wc.fileAPI.fs = fs
+
 	return nil
 }
 
@@ -431,6 +441,7 @@ func expandAbsolutePath(scanRoot string, paths []string) []string {
 	for _, l := range paths {
 		locations = append(locations, filepath.Join(scanRoot, l))
 	}
+
 	return locations
 }
 
@@ -493,6 +504,7 @@ func pathStringListToMap(paths []string) map[string]bool {
 	for _, p := range paths {
 		result[p] = true
 	}
+
 	return result
 }
 
@@ -509,6 +521,7 @@ func errToExtractorStatus(extractors []Extractor, foundInv map[string]bool, erro
 	for _, ex := range extractors {
 		result = append(result, plugin.StatusFromErr(ex, foundInv[ex.Name()], errors[ex.Name()]))
 	}
+
 	return result
 }
 
@@ -602,5 +615,6 @@ func IsInterestingExecutable(api FileAPI) bool {
 	}
 
 	mode, err := api.Stat()
+
 	return err == nil && mode.Mode()&0111 != 0
 }

--- a/extractor/filesystem/filesystem_test.go
+++ b/extractor/filesystem/filesystem_test.go
@@ -50,14 +50,17 @@ type pathsMapFS struct {
 
 func (fsys pathsMapFS) Open(name string) (fs.File, error) {
 	name = filepath.ToSlash(name)
+
 	return fsys.mapfs.Open(name)
 }
 func (fsys pathsMapFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	name = filepath.ToSlash(name)
+
 	return fsys.mapfs.ReadDir(name)
 }
 func (fsys pathsMapFS) Stat(name string) (fs.FileInfo, error) {
 	name = filepath.ToSlash(name)
+
 	return fsys.mapfs.Stat(name)
 }
 
@@ -613,6 +616,7 @@ func invLess(i1, i2 *extractor.Inventory) bool {
 	if i1.Name != i2.Name {
 		return i1.Name < i2.Name
 	}
+
 	return false
 }
 
@@ -623,6 +627,7 @@ func (fakeFS) Open(name string) (fs.File, error) {
 	if name == "." {
 		return &fakeDir{dirs: []fs.DirEntry{&fakeDirEntry{}}}, nil
 	}
+
 	return nil, errors.New("failed to open")
 }
 func (fakeFS) ReadDir(name string) ([]fs.DirEntry, error) {
@@ -643,6 +648,7 @@ func (f *fakeDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	if n <= 0 {
 		t := f.dirs
 		f.dirs = []fs.DirEntry{}
+
 		return t, nil
 	}
 	if len(f.dirs) == 0 {
@@ -651,6 +657,7 @@ func (f *fakeDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	n = min(n, len(f.dirs))
 	t := f.dirs[:n]
 	f.dirs = f.dirs[n:]
+
 	return t, nil
 }
 
@@ -662,6 +669,7 @@ func (i *fakeFileInfo) Mode() fs.FileMode {
 	if i.dir {
 		return fs.ModeDir + 0777
 	}
+
 	return 0777
 }
 func (fakeFileInfo) ModTime() time.Time { return time.Now() }

--- a/extractor/filesystem/internal/parent_dir.go
+++ b/extractor/filesystem/internal/parent_dir.go
@@ -28,5 +28,6 @@ func ParentDir(path string, n int) string {
 			}
 		}
 	}
+
 	return path
 }

--- a/extractor/filesystem/internal/regex_helpers.go
+++ b/extractor/filesystem/internal/regex_helpers.go
@@ -41,6 +41,7 @@ func MatchNamedCaptureGroups(regEx *regexp.Regexp, content string) map[string]st
 			break
 		}
 	}
+
 	return results
 }
 
@@ -53,5 +54,6 @@ func isEmptyMap(m map[string]string) bool {
 			return false
 		}
 	}
+
 	return true
 }

--- a/extractor/filesystem/internal/walkdir_iterate.go
+++ b/extractor/filesystem/internal/walkdir_iterate.go
@@ -44,6 +44,7 @@ func walkDirUnsorted(fsys scalibrfs.FS, name string, d fs.DirEntry, walkDirFn fs
 			// Successfully skipped directory.
 			err = nil
 		}
+
 		return err
 	}
 
@@ -57,6 +58,7 @@ func walkDirUnsorted(fsys scalibrfs.FS, name string, d fs.DirEntry, walkDirFn fs
 			if err == fs.SkipDir && d.IsDir() {
 				err = nil
 			}
+
 			return err
 		}
 		// End iteration after an error
@@ -79,6 +81,7 @@ func walkDirUnsorted(fsys scalibrfs.FS, name string, d fs.DirEntry, walkDirFn fs
 				if err == fs.SkipDir && d.IsDir() {
 					err = nil
 				}
+
 				return err
 			}
 			// End iteration after an error
@@ -89,9 +92,11 @@ func walkDirUnsorted(fsys scalibrfs.FS, name string, d fs.DirEntry, walkDirFn fs
 			if err == fs.SkipDir {
 				break
 			}
+
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -113,6 +118,7 @@ func WalkDirUnsorted(fsys scalibrfs.FS, root string, fn fs.WalkDirFunc) error {
 	if err == fs.SkipDir || err == fs.SkipAll {
 		return nil
 	}
+
 	return err
 }
 
@@ -136,8 +142,10 @@ func readDir(fsys scalibrfs.FS, name string) (*dirIterator, error) {
 		if err != nil {
 			return nil, &fs.PathError{Op: "readdir", Path: name, Err: errors.New("not implemented")}
 		}
+
 		return &dirIterator{files: files, curr: 0}, nil
 	}
+
 	return &dirIterator{dir: dir}, nil
 }
 
@@ -158,6 +166,7 @@ func (i *dirIterator) next() (fs.DirEntry, error) {
 			return nil, io.EOF
 		}
 		i.curr++
+
 		return i.files[i.curr-1], nil
 	}
 
@@ -174,5 +183,6 @@ func (i *dirIterator) close() error {
 	if i.dir == nil {
 		return nil
 	}
+
 	return i.dir.Close()
 }

--- a/extractor/filesystem/internal/walkdir_iterate_test.go
+++ b/extractor/filesystem/internal/walkdir_iterate_test.go
@@ -79,6 +79,7 @@ func makeTree() scalibrfs.FS {
 			fsys[path] = &fstest.MapFile{Mode: fs.ModeDir}
 		}
 	})
+
 	return fsys
 }
 
@@ -97,8 +98,10 @@ func mark(tree *Node, entry fs.DirEntry, err error, errors *[]error, clearErr bo
 		if clearErr {
 			return nil
 		}
+
 		return err
 	}
+
 	return nil
 }
 
@@ -156,6 +159,7 @@ func TestIssue51617(t *testing.T) {
 		if d.IsDir() {
 			saw = append(saw, path)
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -183,6 +187,7 @@ func (fakeFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	} else if name == "dir" {
 		return []fs.DirEntry{&fakeDirEntry{name: "file2.txt", isDir: false}}, nil
 	}
+
 	return nil, errors.New("file not found")
 }
 func (fakeFS) Stat(name string) (fs.FileInfo, error) {

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v1-revisions_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v1-revisions_test.go
@@ -168,6 +168,7 @@ func TestExtractor_Extract_v1_revisions(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
@@ -240,6 +240,7 @@ func TestExtractor_Extract_v1(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v2_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v2_test.go
@@ -168,6 +168,7 @@ func TestExtractor_Extract_v2(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/dart/pubspec/pubspec.go
+++ b/extractor/filesystem/language/dart/pubspec/pubspec.go
@@ -50,6 +50,7 @@ func (pld *pubspecLockDescription) UnmarshalYAML(value *yaml.Node) error {
 	}
 	if err := value.Decode(&m); err == nil {
 		pld.Ref = m.Ref
+
 		return nil
 	}
 
@@ -111,6 +112,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		for _, str := range strings.Split(pkg.Dependency, " ") {
 			if str == "dev" {
 				pkgDetails.Metadata = osv.DepGroupMetadata{DepGroupVals: []string{"dev"}}
+
 				break
 			}
 		}

--- a/extractor/filesystem/language/dart/pubspec/pubspec_test.go
+++ b/extractor/filesystem/language/dart/pubspec/pubspec_test.go
@@ -300,6 +300,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/dotnet/depsjson/depsjson.go
+++ b/extractor/filesystem/language/dotnet/depsjson/depsjson.go
@@ -98,10 +98,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	fileinfo, err := api.Stat()
 	if err != nil || (e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes) {
 		e.reportFileRequired(path, stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -129,6 +131,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return packages, err
 }
 
@@ -151,12 +154,14 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	decoder := json.NewDecoder(input.Reader)
 	if err := decoder.Decode(&deps); err != nil {
 		log.Errorf("Error parsing deps.json: %v", err)
+
 		return nil, err
 	}
 
 	// Check if the decoded content is empty (i.e., no libraries)
 	if len(deps.Libraries) == 0 {
 		log.Warn("Empty deps.json file or no libraries found")
+
 		return nil, fmt.Errorf("empty deps.json file or no libraries found")
 	}
 
@@ -166,6 +171,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 		name, version := splitNameAndVersion(nameVersion)
 		if name == "" || version == "" {
 			log.Warnf("Skipping library with missing name or version: %s", nameVersion)
+
 			continue
 		}
 		// If the library type is "project", this is the root/main package.
@@ -191,6 +197,7 @@ func splitNameAndVersion(nameVersion string) (string, string) {
 	if len(parts) != 2 {
 		return "", ""
 	}
+
 	return parts[0], parts[1]
 }
 

--- a/extractor/filesystem/language/dotnet/packagesconfig/packagesconfig.go
+++ b/extractor/filesystem/language/dotnet/packagesconfig/packagesconfig.go
@@ -111,10 +111,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	fileinfo, err := api.Stat()
 	if err != nil || (e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes) {
 		e.reportFileRequired(path, stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -142,6 +144,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return packages, err
 }
 
@@ -160,6 +163,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	decoder := xml.NewDecoder(input.Reader)
 	if err := decoder.Decode(&packages); err != nil {
 		log.Errorf("Error parsing packages.config: %v", err)
+
 		return nil, err
 	}
 
@@ -167,6 +171,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for _, pkg := range packages.Packages {
 		if pkg.ID == "" || pkg.Version == "" {
 			log.Warnf("Skipping package with missing name or version: %+v", pkg)
+
 			continue
 		}
 

--- a/extractor/filesystem/language/dotnet/packagesconfig/packagesconfig_test.go
+++ b/extractor/filesystem/language/dotnet/packagesconfig/packagesconfig_test.go
@@ -245,6 +245,7 @@ func TestExtract(t *testing.T) {
 			// Compare errors if any
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/dotnet/packageslockjson/packageslockjson.go
+++ b/extractor/filesystem/language/dotnet/packageslockjson/packageslockjson.go
@@ -111,10 +111,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -143,6 +145,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 

--- a/extractor/filesystem/language/elixir/mixlock/mixlock.go
+++ b/extractor/filesystem/language/elixir/mixlock/mixlock.go
@@ -101,10 +101,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	fileinfo, err := api.Stat()
 	if err != nil || (e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes) {
 		e.reportFileRequired(path, stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -132,6 +134,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return packages, err
 }
 

--- a/extractor/filesystem/language/elixir/mixlock/mixlock_test.go
+++ b/extractor/filesystem/language/elixir/mixlock/mixlock_test.go
@@ -224,6 +224,7 @@ func TestExtract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/erlang/mixlock/mixlock_test.go
+++ b/extractor/filesystem/language/erlang/mixlock/mixlock_test.go
@@ -337,6 +337,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/erlang/mixlock/mixlockutils/mixlockutils.go
+++ b/extractor/filesystem/language/erlang/mixlock/mixlockutils/mixlockutils.go
@@ -58,6 +58,7 @@ func ParseMixLockFile(input *filesystem.ScanInput) ([]*extractor.Inventory, erro
 			// This is a git dependency line, doesn't have version info
 			if len(match) < 4 {
 				log.Errorf("invalid mix.lock dependency line %q", line)
+
 				continue
 			}
 			name = match[1]
@@ -71,6 +72,7 @@ func ParseMixLockFile(input *filesystem.ScanInput) ([]*extractor.Inventory, erro
 			}
 			if len(match) < 6 {
 				log.Errorf("invalid mix.lock dependency line %q", line)
+
 				continue
 			}
 			name = match[1]

--- a/extractor/filesystem/language/golang/gobinary/gobinary.go
+++ b/extractor/filesystem/language/golang/gobinary/gobinary.go
@@ -100,10 +100,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(api.Path(), fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(api.Path(), fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -136,11 +138,13 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	if err != nil {
 		log.Debugf("error parsing the contents of Go binary (%s) for extraction: %v", input.Path, err)
 		e.reportFileExtracted(input.Path, input.Info, err)
+
 		return []*extractor.Inventory{}, nil
 	}
 
 	inventory, err := e.extractPackagesFromBuildInfo(binfo, input.Path)
 	e.reportFileExtracted(input.Path, input.Info, err)
+
 	return inventory, err
 }
 
@@ -205,6 +209,7 @@ func validateGoVersion(vers string) (string, error) {
 
 	// Strip the "go" prefix from the Go version. (e.g. go1.16.3 => 1.16.3)
 	res := strings.TrimPrefix(goVersion, "go")
+
 	return res, nil
 }
 

--- a/extractor/filesystem/language/golang/gobinary/gobinary_test.go
+++ b/extractor/filesystem/language/golang/gobinary/gobinary_test.go
@@ -351,5 +351,6 @@ func createInventories(invs []*extractor.Inventory, location string) []*extracto
 			Name: i.Name, Version: i.Version, Locations: []string{location},
 		})
 	}
+
 	return res
 }

--- a/extractor/filesystem/language/golang/gomod/gomod.go
+++ b/extractor/filesystem/language/golang/gomod/gomod.go
@@ -135,6 +135,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	for _, p := range packages {
 		dedupedPs[mapKey{name: p.Name, version: p.Version}] = p
 	}
+
 	return maps.Values(dedupedPs), nil
 }
 

--- a/extractor/filesystem/language/golang/gomod/gomod_test.go
+++ b/extractor/filesystem/language/golang/gomod/gomod_test.go
@@ -269,6 +269,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/haskell/cabal/cabal.go
+++ b/extractor/filesystem/language/haskell/cabal/cabal.go
@@ -105,10 +105,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -138,6 +140,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 

--- a/extractor/filesystem/language/haskell/cabal/cabal_test.go
+++ b/extractor/filesystem/language/haskell/cabal/cabal_test.go
@@ -245,6 +245,7 @@ func TestExtract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/haskell/stacklock/stacklock.go
+++ b/extractor/filesystem/language/haskell/stacklock/stacklock.go
@@ -105,10 +105,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -138,6 +140,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 

--- a/extractor/filesystem/language/haskell/stacklock/stacklock_test.go
+++ b/extractor/filesystem/language/haskell/stacklock/stacklock_test.go
@@ -212,6 +212,7 @@ func TestExtract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/java/archive/archive.go
+++ b/extractor/filesystem/language/java/archive/archive.go
@@ -146,10 +146,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -179,6 +181,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			UncompressedBytes: openedBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -199,6 +202,7 @@ func (e Extractor) extractWithMax(ctx context.Context, input *filesystem.ScanInp
 	if int(input.Info.Size()) < e.minZipBytes {
 		log.Warnf("%s ignoring zip with size %d because it is smaller than min size %d at %q",
 			e.Name(), input.Info.Size(), e.minZipBytes, input.Path)
+
 		return nil, openedBytes, nil
 	}
 
@@ -268,6 +272,7 @@ func (e Extractor) extractWithMax(ctx context.Context, input *filesystem.ScanInp
 			if err != nil {
 				log.Errorf("%s failed to extract from pom.properties at %q: %v", e.Name(), path, err)
 				errs = append(errs, err)
+
 				continue
 			}
 			if pp.valid() {
@@ -288,6 +293,7 @@ func (e Extractor) extractWithMax(ctx context.Context, input *filesystem.ScanInp
 			if err != nil {
 				log.Errorf("%s failed to extract from manifest.mf at %q: %v", e.Name(), path, err)
 				errs = append(errs, err)
+
 				continue
 			}
 			if mf.valid() {
@@ -310,6 +316,7 @@ func (e Extractor) extractWithMax(ctx context.Context, input *filesystem.ScanInp
 				if err != nil {
 					log.Errorf("%s failed to open file  %q: %v", e.Name(), path, err)
 					errs = append(errs, err)
+
 					return
 				}
 				// Do not need to handle error from f.Close() because it only happens if the file was previously closed.
@@ -324,6 +331,7 @@ func (e Extractor) extractWithMax(ctx context.Context, input *filesystem.ScanInp
 				if err != nil {
 					log.Errorf("%s failed to extract %q: %v", e.Name(), path, err)
 					errs = append(errs, err)
+
 					return
 				}
 				inventory = append(inventory, subInventory...)
@@ -424,6 +432,7 @@ func IsArchive(path string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -434,6 +443,7 @@ func isManifest(path string) bool {
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*Metadata)
+
 	return &purl.PackageURL{
 		Type:      purl.TypeMaven,
 		Namespace: strings.ToLower(m.GroupID),

--- a/extractor/filesystem/language/java/archive/archive_test.go
+++ b/extractor/filesystem/language/java/archive/archive_test.go
@@ -663,6 +663,7 @@ func defaultConfigWith(cfg archive.Config) archive.Config {
 	// ignores defaults
 	newCfg.ExtractFromFilename = cfg.ExtractFromFilename
 	newCfg.HashJars = cfg.HashJars
+
 	return newCfg
 }
 

--- a/extractor/filesystem/language/java/archive/filename.go
+++ b/extractor/filesystem/language/java/archive/filename.go
@@ -52,6 +52,7 @@ func ParseFilename(filePath string) *JarProps {
 		// We attempt to extract such group IDs here.
 		groupID = name[:i]
 	}
+
 	return &JarProps{ArtifactID: name, Version: version, GroupID: groupID}
 }
 
@@ -93,5 +94,6 @@ func isVersion(str string) bool {
 	if buildAndDigit.MatchString(str) {
 		return true
 	}
+
 	return releaseAndDigit.MatchString(str)
 }

--- a/extractor/filesystem/language/java/archive/manifest.go
+++ b/extractor/filesystem/language/java/archive/manifest.go
@@ -126,6 +126,7 @@ func getGroupID(h textproto.MIMEHeader) string {
 	if strings.Contains(g, ";") {
 		g = strings.Split(g, ";")[0]
 	}
+
 	return g
 }
 
@@ -139,6 +140,7 @@ func getFirstValidGroupID(h textproto.MIMEHeader, names []string) string {
 			return strings.ToLower(groupID)
 		}
 	}
+
 	return ""
 }
 
@@ -169,6 +171,7 @@ func getArtifactID(h textproto.MIMEHeader) string {
 	for _, k := range keys {
 		log.Debugf("  %s: %s\n", k, h.Get(k))
 	}
+
 	return getFirstValidArtifactID(h, keys)
 }
 
@@ -199,6 +202,7 @@ func getFirst(h textproto.MIMEHeader, names []string) string {
 			return h.Get(n)
 		}
 	}
+
 	return ""
 }
 
@@ -243,6 +247,7 @@ func getFirstValidArtifactID(h textproto.MIMEHeader, names []string) string {
 			return h.Get(n)
 		}
 	}
+
 	return ""
 }
 

--- a/extractor/filesystem/language/java/archive/pomproperties.go
+++ b/extractor/filesystem/language/java/archive/pomproperties.go
@@ -66,5 +66,6 @@ func parsePomProps(f *zip.File) (PomProps, error) {
 		return p, fmt.Errorf("error while scanning zip file %q for pom properties: %w", f.Name, s.Err())
 	}
 	log.Debugf("Data from pom.properties: groupid: %s artifactid: %s version: %s", p.GroupID, p.ArtifactID, p.Version)
+
 	return p, nil
 }

--- a/extractor/filesystem/language/java/gradlelockfile/gradlelockfile.go
+++ b/extractor/filesystem/language/java/gradlelockfile/gradlelockfile.go
@@ -122,6 +122,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*javalockfile.Metadata)
+
 	return &purl.PackageURL{
 		Type:      purl.TypeMaven,
 		Namespace: strings.ToLower(m.GroupID),

--- a/extractor/filesystem/language/java/gradlelockfile/gradlelockfile_test.go
+++ b/extractor/filesystem/language/java/gradlelockfile/gradlelockfile_test.go
@@ -213,6 +213,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml.go
@@ -62,6 +62,7 @@ func (e Extractor) Requirements() *plugin.Capabilities {
 // FileRequired returns true if the specified file matches Gradle verification metadata lockfile patterns.
 func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	path := api.Path()
+
 	return filepath.Base(filepath.Dir(path)) == "gradle" && filepath.Base(path) == "verification-metadata.xml"
 }
 
@@ -95,6 +96,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*javalockfile.Metadata)
+
 	return &purl.PackageURL{
 		Type:      purl.TypeMaven,
 		Namespace: strings.ToLower(m.GroupID),

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
@@ -459,6 +459,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/java/pomxml/pomxml.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml.go
@@ -218,6 +218,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	m := i.Metadata.(*javalockfile.Metadata)
+
 	return &purl.PackageURL{
 		Type:      purl.TypeMaven,
 		Namespace: strings.ToLower(m.GroupID),

--- a/extractor/filesystem/language/java/pomxml/pomxml_test.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml_test.go
@@ -276,6 +276,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
@@ -61,6 +61,7 @@ func NewConfig(registry string) Config {
 		URL:             registry,
 		ReleasesEnabled: true,
 	})
+
 	return Config{
 		DependencyClient:       depClient,
 		MavenRegistryAPIClient: mavenClient,
@@ -232,6 +233,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	g, a, _ := strings.Cut(i.Name, ":")
+
 	return &purl.PackageURL{
 		Type:      purl.TypeMaven,
 		Namespace: g,

--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet_test.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet_test.go
@@ -254,6 +254,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 
@@ -362,6 +363,7 @@ func TestExtractor_Extract_WithMockServer(t *testing.T) {
 
 	if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 		t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 		return
 	}
 

--- a/extractor/filesystem/language/javascript/bunlock/bunlock_test.go
+++ b/extractor/filesystem/language/javascript/bunlock/bunlock_test.go
@@ -829,6 +829,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/javascript/packagejson/metadata.go
+++ b/extractor/filesystem/language/javascript/packagejson/metadata.go
@@ -75,6 +75,7 @@ func (p *Person) PersonString() string {
 	if p.URL != "" {
 		result += fmt.Sprintf(" (%s)", p.URL)
 	}
+
 	return result
 }
 
@@ -92,5 +93,6 @@ func rawToPerson(rawJSON map[string]any) map[string]string {
 			personMap[key] = val
 		}
 	}
+
 	return personMap
 }

--- a/extractor/filesystem/language/javascript/packagejson/packagejson.go
+++ b/extractor/filesystem/language/javascript/packagejson/packagejson.go
@@ -120,10 +120,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -143,6 +145,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	i, err := parse(input.Path, input.Reader)
 	if err != nil {
 		e.reportFileExtracted(input.Path, input.Info, err)
+
 		return nil, fmt.Errorf("packagejson.parse(%s): %w", input.Path, err)
 	}
 
@@ -153,6 +156,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	}
 
 	e.reportFileExtracted(input.Path, input.Info, nil)
+
 	return inventory, nil
 }
 
@@ -183,14 +187,17 @@ func parse(path string, r io.Reader) (*extractor.Inventory, error) {
 
 	if !p.hasNameAndVersionValues() {
 		log.Debugf("package.json file %s does not have a version and/or name", path)
+
 		return nil, nil
 	}
 	if p.isVSCodeExtension() {
 		log.Debugf("package.json file %s is a Visual Studio Code Extension Manifest, not an NPM package", path)
+
 		return nil, nil
 	}
 	if p.isUnityPackage() {
 		log.Debugf("package.json file %s is a Unity package, not an NPM package", path)
+
 		return nil, nil
 	}
 
@@ -223,6 +230,7 @@ func (p packageJSON) isVSCodeExtension() bool {
 			return true
 		}
 	}
+
 	return p.Contributes != nil
 }
 
@@ -244,6 +252,7 @@ func removeEmptyPersons(persons []*Person) []*Person {
 			result = append(result, p)
 		}
 	}
+
 	return result
 }
 

--- a/extractor/filesystem/language/javascript/packagejson/packagejson_test.go
+++ b/extractor/filesystem/language/javascript/packagejson/packagejson_test.go
@@ -379,6 +379,7 @@ func defaultConfigWith(cfg packagejson.Config) packagejson.Config {
 	if cfg.MaxFileSizeBytes > 0 {
 		newCfg.MaxFileSizeBytes = cfg.MaxFileSizeBytes
 	}
+
 	return newCfg
 }
 

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
@@ -849,6 +849,7 @@ func TestNPMLockExtractor_Extract_V1(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v2_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v2_test.go
@@ -565,6 +565,7 @@ func TestNPMLockExtractor_Extract_V2(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson.go
@@ -254,10 +254,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileInfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileInfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileInfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock-v9_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock-v9_test.go
@@ -350,6 +350,7 @@ func TestExtractor_Extract_v9(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
@@ -174,6 +174,7 @@ func parsePnpmLock(lockfile pnpmLockfile) ([]*extractor.Inventory, error) {
 		if err != nil {
 			errs = append(errs, err)
 			log.Errorf("failed to extract package version from %q: %v", pkg, err)
+
 			continue
 		}
 

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
@@ -744,6 +744,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/javascript/yarnlock/yarnlock-v1_test.go
+++ b/extractor/filesystem/language/javascript/yarnlock/yarnlock-v1_test.go
@@ -527,6 +527,7 @@ func TestExtractor_Extract_v1(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/javascript/yarnlock/yarnlock-v2_test.go
+++ b/extractor/filesystem/language/javascript/yarnlock/yarnlock-v2_test.go
@@ -359,6 +359,7 @@ func TestExtractor_Extract_v2(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/javascript/yarnlock/yarnlock.go
+++ b/extractor/filesystem/language/javascript/yarnlock/yarnlock.go
@@ -66,6 +66,7 @@ var (
 
 func shouldSkipYarnLine(line string) bool {
 	line = strings.TrimSpace(line)
+
 	return line == "" || strings.HasPrefix(line, "#")
 }
 
@@ -142,6 +143,7 @@ func extractYarnPackageName(header string) string {
 	if isScoped {
 		name = "@" + name
 	}
+
 	return name
 }
 
@@ -153,6 +155,7 @@ func determineYarnPackageVersion(props []string) string {
 			return matched[1]
 		}
 	}
+
 	return ""
 }
 
@@ -163,6 +166,7 @@ func determineYarnPackageResolution(props []string) string {
 			return matched[1]
 		}
 	}
+
 	return ""
 }
 

--- a/extractor/filesystem/language/php/composerlock/composerlock_test.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock_test.go
@@ -203,6 +203,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/python/condameta/condameta.go
+++ b/extractor/filesystem/language/python/condameta/condameta.go
@@ -115,10 +115,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -147,6 +149,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -179,6 +182,7 @@ func parse(r io.Reader) (*condaPackage, error) {
 	if err := json.NewDecoder(r).Decode(&pkg); err != nil {
 		return nil, fmt.Errorf("failed to parse Conda metadata: %w", err)
 	}
+
 	return &pkg, nil
 }
 

--- a/extractor/filesystem/language/python/condameta/condameta_test.go
+++ b/extractor/filesystem/language/python/condameta/condameta_test.go
@@ -227,6 +227,7 @@ func TestExtract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/python/internal/pypipurl/pythonpurl.go
+++ b/extractor/filesystem/language/python/internal/pypipurl/pythonpurl.go
@@ -37,6 +37,7 @@ var specialCharRunFinder = regexp.MustCompile("[-_.]+")
 // return them as is.
 func MakePackageURL(i *extractor.Inventory) *purl.PackageURL {
 	normalizedName := specialCharRunFinder.ReplaceAllLiteralString(strings.ToLower(i.Name), "-")
+
 	return &purl.PackageURL{
 		Type:    purl.TypePyPi,
 		Name:    normalizedName,

--- a/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
+++ b/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
@@ -234,6 +234,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
+++ b/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
@@ -232,6 +232,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
+++ b/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
@@ -308,6 +308,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -117,10 +117,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -175,6 +177,7 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 		newInv, newPaths, err := openAndExtractFromFile(path, fs)
 		if err != nil {
 			log.Warnf("openAndExtractFromFile(%s): %w", path, err)
+
 			continue
 		}
 		found[path] = true
@@ -195,6 +198,7 @@ func openAndExtractFromFile(path string, fs scalibrfs.FS) ([]*extractor.Inventor
 		return nil, nil, err
 	}
 	defer reader.Close()
+
 	return extractFromPath(reader, path, fs)
 }
 
@@ -269,6 +273,7 @@ func readLine(scanner *bufio.Scanner, builder *strings.Builder) string {
 	if strings.HasSuffix(l, `\`) {
 		builder.WriteString(l[:len(l)-1])
 		scanner.Scan()
+
 		return readLine(scanner, builder)
 	} else {
 		builder.WriteString(l)
@@ -302,6 +307,7 @@ func getLowestVersion(s string) (name, version, comparator string) {
 		if strings.Contains(s, sep) {
 			t = strings.SplitN(s, sep, 2)
 			comp = sep
+
 			break
 		}
 	}
@@ -346,6 +352,7 @@ func splitPerRequirementOptions(s string) (string, []string) {
 	for _, hashOptionMatch := range reHashOption.FindAllStringSubmatch(s, -1) {
 		hashes = append(hashes, hashOptionMatch[1])
 	}
+
 	return reTextAfterFirstOptionInclusive.ReplaceAllString(s, ""), hashes
 }
 

--- a/extractor/filesystem/language/python/setup/setup.go
+++ b/extractor/filesystem/language/python/setup/setup.go
@@ -106,10 +106,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -139,6 +141,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 

--- a/extractor/filesystem/language/python/setup/setup_test.go
+++ b/extractor/filesystem/language/python/setup/setup_test.go
@@ -363,6 +363,7 @@ func TestExtract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 
@@ -400,5 +401,6 @@ func defaultConfigWith(cfg setup.Config) setup.Config {
 	if cfg.Stats != nil {
 		newCfg.Stats = cfg.Stats
 	}
+
 	return newCfg
 }

--- a/extractor/filesystem/language/python/uvlock/uvlock_test.go
+++ b/extractor/filesystem/language/python/uvlock/uvlock_test.go
@@ -213,6 +213,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/python/wheelegg/wheelegg.go
+++ b/extractor/filesystem/language/python/wheelegg/wheelegg.go
@@ -124,13 +124,16 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 			// file at all, so we check the file size after checking the file suffix.
 			if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 				e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 				return false
 			}
 
 			e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -169,6 +172,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -204,6 +208,7 @@ func (e Extractor) extractZip(ctx context.Context, input *filesystem.ScanInput) 
 		}
 		inventory = append(inventory, i)
 	}
+
 	return inventory, nil
 }
 
@@ -230,6 +235,7 @@ func (e Extractor) extractSingleFile(r io.Reader, path string) (*extractor.Inven
 	}
 
 	i.Locations = []string{path}
+
 	return i, nil
 }
 
@@ -244,6 +250,7 @@ func parse(r io.Reader) (*extractor.Inventory, error) {
 		if err != nil {
 			return nil, fmt.Errorf("ReadMIMEHeader(): %w %s %s", err, h.Get("Name"), h.Get("version"))
 		}
+
 		return nil, fmt.Errorf("Name or version is empty (name: %q, version: %q)", name, version)
 	}
 

--- a/extractor/filesystem/language/python/wheelegg/wheelegg_test.go
+++ b/extractor/filesystem/language/python/wheelegg/wheelegg_test.go
@@ -300,6 +300,7 @@ func defaultConfigWith(cfg wheelegg.Config) wheelegg.Config {
 	if cfg.Stats != nil {
 		newCfg.Stats = cfg.Stats
 	}
+
 	return newCfg
 }
 

--- a/extractor/filesystem/language/r/renvlock/renvlock_test.go
+++ b/extractor/filesystem/language/r/renvlock/renvlock_test.go
@@ -119,6 +119,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/ruby/gemfilelock/gemfilelock.go
+++ b/extractor/filesystem/language/ruby/gemfilelock/gemfilelock.go
@@ -106,6 +106,7 @@ func parseLockfileSections(input *filesystem.ScanInput) ([]*gemlockSection, erro
 	if currentSection != nil {
 		sections = append(sections, currentSection)
 	}
+
 	return sections, nil
 }
 
@@ -125,6 +126,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			m := nameVersionRegexp.FindStringSubmatch(s)
 			if len(m) < 3 || m[1] == "" || m[2] == "" {
 				log.Errorf("Invalid spec line: %s", s)
+
 				continue
 			}
 			name, version := m[1], m[2]
@@ -141,6 +143,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			invs = append(invs, i)
 		}
 	}
+
 	return invs, nil
 }
 

--- a/extractor/filesystem/language/ruby/gemfilelock/gemfilelock_test.go
+++ b/extractor/filesystem/language/ruby/gemfilelock/gemfilelock_test.go
@@ -690,6 +690,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/ruby/gemspec/gemspec.go
+++ b/extractor/filesystem/language/ruby/gemspec/gemspec.go
@@ -106,10 +106,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -136,6 +138,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	}
 
 	i.Locations = []string{input.Path}
+
 	return []*extractor.Inventory{i}, nil
 }
 
@@ -170,6 +173,7 @@ func extract(path string, r io.Reader) (*extractor.Inventory, error) {
 			if start != "" {
 				foundStart = true
 			}
+
 			continue
 		}
 		if gemName != "" && gemVer != "" {
@@ -179,6 +183,7 @@ func extract(path string, r io.Reader) (*extractor.Inventory, error) {
 			nameArr := reName.FindStringSubmatch(line)
 			if len(nameArr) > 1 {
 				gemName = nameArr[1]
+
 				continue
 			}
 		}
@@ -186,6 +191,7 @@ func extract(path string, r io.Reader) (*extractor.Inventory, error) {
 			verArr := reVer.FindStringSubmatch(line)
 			if len(verArr) > 1 {
 				gemVer = verArr[1]
+
 				continue
 			}
 		}
@@ -198,6 +204,7 @@ func extract(path string, r io.Reader) (*extractor.Inventory, error) {
 	// This was likely a marshalled gemspec. Not a readable text file.
 	if !foundStart {
 		log.Warnf("error scanning gemspec (%s) could not find start of spec definition", path)
+
 		return nil, nil
 	}
 

--- a/extractor/filesystem/language/rust/cargoauditable/cargoauditable.go
+++ b/extractor/filesystem/language/rust/cargoauditable/cargoauditable.go
@@ -122,6 +122,7 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 			FileSizeBytes: fileinfo.Size(),
 		})
 	}
+
 	return !sizeLimitExceeded
 }
 
@@ -140,6 +141,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			return []*extractor.Inventory{}, nil
 		}
 		log.Debugf("error getting dependency information from binary (%s) for extraction: %v", input.Path, err)
+
 		return nil, fmt.Errorf("rustaudit.GetDependencyInfo(%q): %w", input.Path, err)
 	}
 
@@ -155,6 +157,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			})
 		}
 	}
+
 	return inventory, nil
 }
 

--- a/extractor/filesystem/language/rust/cargolock/cargolock_test.go
+++ b/extractor/filesystem/language/rust/cargolock/cargolock_test.go
@@ -167,6 +167,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/rust/cargotoml/cargotoml.go
+++ b/extractor/filesystem/language/rust/cargotoml/cargotoml.go
@@ -75,6 +75,7 @@ func (v *cargoTomlDependency) UnmarshalTOML(data any) error {
 			// if the key exists but the type is wrong return an error
 			return "", fmt.Errorf("invalid type for key %q: expected string, got %T", key, v)
 		}
+
 		return s, nil
 	}
 
@@ -82,6 +83,7 @@ func (v *cargoTomlDependency) UnmarshalTOML(data any) error {
 	case string:
 		// if the type is string then the data is version
 		v.Version = data
+
 		return nil
 	case map[string]any:
 		var err error
@@ -94,6 +96,7 @@ func (v *cargoTomlDependency) UnmarshalTOML(data any) error {
 		if v.Rev, err = getString(data, "rev"); err != nil {
 			return err
 		}
+
 		return nil
 	default:
 		return errors.New("invalid format for Cargo.toml dependency")

--- a/extractor/filesystem/language/rust/cargotoml/cargotoml_test.go
+++ b/extractor/filesystem/language/rust/cargotoml/cargotoml_test.go
@@ -203,6 +203,7 @@ func TestExtractor_Extract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/swift/packageresolved/packageresolved.go
+++ b/extractor/filesystem/language/swift/packageresolved/packageresolved.go
@@ -98,10 +98,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -130,6 +132,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 

--- a/extractor/filesystem/language/swift/packageresolved/packageresolved_test.go
+++ b/extractor/filesystem/language/swift/packageresolved/packageresolved_test.go
@@ -214,6 +214,7 @@ func TestExtract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/swift/podfilelock/podfilelock.go
+++ b/extractor/filesystem/language/swift/podfilelock/podfilelock.go
@@ -93,10 +93,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 
 	if e.maxFileSizeBytes > 0 && fileInfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileInfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileInfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -125,6 +127,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 

--- a/extractor/filesystem/language/swift/podfilelock/podfilelock_test.go
+++ b/extractor/filesystem/language/swift/podfilelock/podfilelock_test.go
@@ -237,6 +237,7 @@ func TestExtract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/language/wordpress/plugins/plugins.go
+++ b/extractor/filesystem/language/wordpress/plugins/plugins.go
@@ -107,10 +107,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 

--- a/extractor/filesystem/language/wordpress/plugins/plugins_test.go
+++ b/extractor/filesystem/language/wordpress/plugins/plugins_test.go
@@ -202,6 +202,7 @@ func TestExtract(t *testing.T) {
 
 			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+
 				return
 			}
 

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -254,6 +254,7 @@ func concat(InitMaps ...InitMap) InitMap {
 	for _, m := range InitMaps {
 		maps.Copy(result, m)
 	}
+
 	return result
 }
 
@@ -271,6 +272,7 @@ func FromCapabilities(capabs *plugin.Capabilities) []filesystem.Extractor {
 			all = append(all, initer())
 		}
 	}
+
 	return FilterByCapabilities(all, capabs)
 }
 
@@ -284,6 +286,7 @@ func FilterByCapabilities(exs []filesystem.Extractor, capabs *plugin.Capabilitie
 			result = append(result, ex)
 		}
 	}
+
 	return result
 }
 
@@ -306,6 +309,7 @@ func ExtractorsFromNames(names []string) ([]filesystem.Extractor, error) {
 	for _, e := range resultMap {
 		result = append(result, e)
 	}
+
 	return result, nil
 }
 
@@ -322,5 +326,6 @@ func ExtractorFromName(name string) (filesystem.Extractor, error) {
 	if e.Name() != name {
 		return nil, fmt.Errorf("not an exact name for an extractor: %s", name)
 	}
+
 	return e, nil
 }

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -50,6 +50,7 @@ func TestFromCapabilities(t *testing.T) {
 	for _, ex := range el.FromCapabilities(capab) {
 		if ex.Name() == want {
 			found = true
+
 			break
 		}
 		if ex.Name() == dontWant {

--- a/extractor/filesystem/os/apk/apk.go
+++ b/extractor/filesystem/os/apk/apk.go
@@ -97,10 +97,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(api.Path(), fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(api.Path(), fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -129,6 +131,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -150,6 +153,7 @@ func parseSingleApkRecord(scanner *bufio.Scanner) (map[string]string, error) {
 			}
 
 			group[key] = val
+
 			continue
 		}
 
@@ -213,6 +217,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 
 		if pkg.Name == "" || pkg.Version == "" {
 			log.Warnf("APK package name or version is empty (name: %q, version: %q)", pkg.Name, pkg.Version)
+
 			continue
 		}
 
@@ -227,6 +232,7 @@ func toNamespace(m *Metadata) string {
 		return m.OSID
 	}
 	log.Errorf("os-release[ID] not set, fallback to 'alpine'")
+
 	return "alpine"
 }
 
@@ -236,6 +242,7 @@ func toDistro(m *Metadata) string {
 		return m.OSVersionID
 	}
 	log.Errorf("VERSION_ID not set in os-release")
+
 	return ""
 }
 
@@ -253,6 +260,7 @@ func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	if m.Architecture != "" {
 		q[purl.Arch] = m.Architecture
 	}
+
 	return &purl.PackageURL{
 		Type:       purl.TypeApk,
 		Name:       strings.ToLower(i.Name),
@@ -268,6 +276,7 @@ func (Extractor) Ecosystem(i *extractor.Inventory) string {
 	if version == "" {
 		return "Alpine"
 	}
+
 	return "Alpine:" + trimDistroVersion(version)
 }
 
@@ -279,5 +288,6 @@ func trimDistroVersion(distro string) string {
 	if len(parts) < 2 {
 		return "v" + distro
 	}
+
 	return fmt.Sprintf("v%s.%s", parts[0], parts[1])
 }

--- a/extractor/filesystem/os/apk/apk_test.go
+++ b/extractor/filesystem/os/apk/apk_test.go
@@ -417,6 +417,7 @@ func getInventory(path, pkgName, origin, version, osID, osVersionID, maintainer,
 			Commit: commit,
 		}
 	}
+
 	return i
 }
 

--- a/extractor/filesystem/os/cos/cos.go
+++ b/extractor/filesystem/os/cos/cos.go
@@ -110,10 +110,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -142,6 +144,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -190,9 +193,11 @@ func toDistro(m *Metadata) string {
 
 	if m.OSVersion != "" {
 		log.Warnf("VERSION_ID not set in os-release, fallback to VERSION")
+
 		return fmt.Sprintf("cos-%s", m.OSVersion)
 	}
 	log.Errorf("VERSION and VERSION_ID not set in os-release")
+
 	return ""
 }
 
@@ -204,6 +209,7 @@ func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	if distro != "" {
 		q[purl.Distro] = distro
 	}
+
 	return &purl.PackageURL{
 		Type:       purl.TypeCOS,
 		Name:       i.Name,

--- a/extractor/filesystem/os/dpkg/dpkg.go
+++ b/extractor/filesystem/os/dpkg/dpkg.go
@@ -124,10 +124,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -168,6 +170,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -194,8 +197,10 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 			} else {
 				if strings.Contains(input.Path, "status.d") {
 					log.Warnf("Failed to read MIME header from %q: %v", input.Path, err)
+
 					return []*extractor.Inventory{}, nil
 				}
+
 				return pkgs, err
 			}
 		}
@@ -210,6 +215,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 		if !e.includeNotInstalled && (!strings.Contains(input.Path, "status.d") || h.Get("Status") != "") {
 			if h.Get("Status") == "" {
 				log.Warnf("Package %q has no status field", h.Get("Package"))
+
 				continue
 			}
 			installed, err := statusInstalled(h.Get("Status"))
@@ -227,6 +233,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 			if !eof { // Expected when reaching the last line.
 				log.Warnf("DPKG package name or version is empty (name: %q, version: %q)", pkgName, pkgVersion)
 			}
+
 			continue
 		}
 
@@ -265,6 +272,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 
 		pkgs = append(pkgs, i)
 	}
+
 	return pkgs, nil
 }
 
@@ -276,6 +284,7 @@ func statusInstalled(status string) (bool, error) {
 	if len(parts) != 3 {
 		return false, fmt.Errorf("invalid DPKG Status field %q", status)
 	}
+
 	return parts[2] == "installed", nil
 }
 
@@ -290,8 +299,10 @@ func parseSourceNameVersion(source string) (string, string, error) {
 		}
 		n := source[:idx]
 		v := source[idx+2 : len(source)-1]
+
 		return n, v, nil
 	}
+
 	return source, "", nil
 }
 
@@ -312,9 +323,11 @@ func toDistro(m *Metadata) string {
 	// fallback: e.g. 22.04
 	if m.OSVersionID != "" {
 		log.Warnf("VERSION_CODENAME not set in os-release, fallback to VERSION_ID")
+
 		return m.OSVersionID
 	}
 	log.Errorf("VERSION_CODENAME and VERSION_ID not set in os-release")
+
 	return ""
 }
 
@@ -342,6 +355,7 @@ func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	for _, location := range i.Locations {
 		if location == "usr/lib/opkg/status" {
 			typePurl = purl.TypeOpkg
+
 			break
 		}
 	}
@@ -367,5 +381,6 @@ func (Extractor) Ecosystem(i *extractor.Inventory) string {
 	if m.OSVersionID == "" {
 		return osID
 	}
+
 	return osID + ":" + m.OSVersionID
 }

--- a/extractor/filesystem/os/flatpak/flatpak.go
+++ b/extractor/filesystem/os/flatpak/flatpak.go
@@ -128,10 +128,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -166,6 +168,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	if i == nil {
 		return []*extractor.Inventory{}, nil
 	}
+
 	return []*extractor.Inventory{i}, nil
 }
 
@@ -219,6 +222,7 @@ func toNamespace(m *Metadata) string {
 		return m.OSID
 	}
 	log.Errorf("os-release[ID] not set, fallback to ''")
+
 	return ""
 }
 
@@ -228,6 +232,7 @@ func toDistro(m *Metadata) string {
 		v = m.OSBuildID
 		if v == "" {
 			log.Errorf("VERSION_ID and BUILD_ID not set in os-release")
+
 			return ""
 		}
 		log.Errorf("os-release[VERSION_ID] not set, fallback to BUILD_ID")
@@ -236,8 +241,10 @@ func toDistro(m *Metadata) string {
 	id := m.OSID
 	if id == "" {
 		log.Errorf("os-release[ID] not set, fallback to ''")
+
 		return v
 	}
+
 	return fmt.Sprintf("%s-%s", id, v)
 }
 
@@ -249,6 +256,7 @@ func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	if distro != "" {
 		q[purl.Distro] = distro
 	}
+
 	return &purl.PackageURL{
 		Type:       purl.TypeFlatpak,
 		Namespace:  toNamespace(m),

--- a/extractor/filesystem/os/homebrew/homebrew.go
+++ b/extractor/filesystem/os/homebrew/homebrew.go
@@ -98,6 +98,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	if p == nil {
 		return []*extractor.Inventory{}, nil
 	}
+
 	return []*extractor.Inventory{
 		{
 			Name:      p.AppName,
@@ -123,6 +124,7 @@ func SplitPath(path string) *BrewPath {
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/extractor/filesystem/os/kernel/module/module.go
+++ b/extractor/filesystem/os/kernel/module/module.go
@@ -111,10 +111,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -144,6 +146,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -236,6 +239,7 @@ func (Extractor) Ecosystem(i *extractor.Inventory) string {
 	if m.OSVersionID == "" {
 		return osID
 	}
+
 	return osID + ":" + m.OSVersionID
 }
 
@@ -244,6 +248,7 @@ func toNamespace(m *Metadata) string {
 		return m.OSID
 	}
 	log.Errorf("os-release[ID] not set, fallback to 'linux'")
+
 	return "linux"
 }
 
@@ -271,5 +276,6 @@ func toDistro(m *Metadata) string {
 		return m.OSVersionID
 	}
 	log.Errorf("VERSION_ID not set in os-release")
+
 	return ""
 }

--- a/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
+++ b/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
@@ -114,10 +114,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -147,6 +149,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -228,6 +231,7 @@ func parseVmlinuzMetadata(magicType []string) Metadata {
 			swapConv, err := strconv.ParseInt(swapHex, 16, 32)
 			if err != nil {
 				log.Errorf("Failed to parse swap device: %v", err)
+
 				continue
 			}
 			m.SwapDevice = int32(swapConv)
@@ -238,6 +242,7 @@ func parseVmlinuzMetadata(magicType []string) Metadata {
 			rootConv, err := strconv.ParseInt(rootHex, 16, 32)
 			if err != nil {
 				log.Errorf("Failed to parse swap device: %v", err)
+
 				continue
 			}
 			m.RootDevice = int32(rootConv)
@@ -247,6 +252,7 @@ func parseVmlinuzMetadata(magicType []string) Metadata {
 			m.VideoMode = t
 		}
 	}
+
 	return m
 }
 
@@ -257,6 +263,7 @@ func (Extractor) Ecosystem(i *extractor.Inventory) string {
 	if m.OSVersionID == "" {
 		return osID
 	}
+
 	return osID + ":" + m.OSVersionID
 }
 
@@ -265,6 +272,7 @@ func toNamespace(m *Metadata) string {
 		return m.OSID
 	}
 	log.Errorf("os-release[ID] not set, fallback to 'linux'")
+
 	return "linux"
 }
 
@@ -292,5 +300,6 @@ func toDistro(m *Metadata) string {
 		return m.OSVersionID
 	}
 	log.Errorf("VERSION_ID not set in os-release")
+
 	return ""
 }

--- a/extractor/filesystem/os/macapps/macapps.go
+++ b/extractor/filesystem/os/macapps/macapps.go
@@ -113,10 +113,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -151,6 +153,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	if i == nil {
 		return []*extractor.Inventory{}, nil
 	}
+
 	return []*extractor.Inventory{i}, nil
 }
 

--- a/extractor/filesystem/os/nix/nix.go
+++ b/extractor/filesystem/os/nix/nix.go
@@ -123,6 +123,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	pkgVersion := matches[3]
 	if pkgHash == "" || pkgName == "" || pkgVersion == "" {
 		log.Warnf("NIX package name/version/hash is empty (name: %v, version: %v, hash: %v)", pkgName, pkgVersion, pkgHash)
+
 		return nil, nil
 	}
 

--- a/extractor/filesystem/os/osrelease/osrelease.go
+++ b/extractor/filesystem/os/osrelease/osrelease.go
@@ -34,9 +34,11 @@ func GetOSRelease(fs scalibrfs.FS) (map[string]string, error) {
 			if os.IsNotExist(err) {
 				continue
 			}
+
 			return nil, err
 		}
 		defer f.Close()
+
 		return parse(f), nil
 	}
 
@@ -58,6 +60,7 @@ func parse(r io.Reader) map[string]string {
 		kv := strings.SplitN(line, "=", 2)
 		m[kv[0]] = resolveString(kv[1])
 	}
+
 	return m
 }
 
@@ -67,5 +70,6 @@ func resolveString(s string) string {
 	if strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"") {
 		s = s[1 : len(s)-1]
 	}
+
 	return s
 }

--- a/extractor/filesystem/os/pacman/pacman.go
+++ b/extractor/filesystem/os/pacman/pacman.go
@@ -112,10 +112,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -145,6 +147,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -182,8 +185,10 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 		if err != nil {
 			if err == io.EOF {
 				log.Warnf("Reached EOF for desc file in %v", input.Path)
+
 				break
 			}
+
 			return pkgs, fmt.Errorf("%s halted at %q: %v", e.Name(), input.Path, err)
 		}
 	}
@@ -256,6 +261,7 @@ func (Extractor) Ecosystem(i *extractor.Inventory) string {
 	if m.OSVersionID == "" {
 		return osID
 	}
+
 	return osID + ":" + m.OSVersionID
 }
 
@@ -264,6 +270,7 @@ func toNamespace(m *Metadata) string {
 		return m.OSID
 	}
 	log.Errorf("os-id not set, fallback to 'linux'")
+
 	return "linux"
 }
 
@@ -294,5 +301,6 @@ func toDistro(m *Metadata) string {
 		return m.OSVersionID
 	}
 	log.Errorf("VERSION_ID not set in os-release")
+
 	return ""
 }

--- a/extractor/filesystem/os/portage/portage.go
+++ b/extractor/filesystem/os/portage/portage.go
@@ -112,10 +112,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -153,6 +155,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
 		FileSizeBytes: fileSizeBytes,
 	})
+
 	return inventory, err
 }
 
@@ -167,6 +170,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	content, err := io.ReadAll(input.Reader)
 	if err != nil {
 		log.Errorf("unable to read file %s: %v", input.Path, err)
+
 		return nil, err
 	}
 
@@ -205,6 +209,7 @@ func splitPackageAndVersion(path string) (string, string) {
 		if len(part) > 0 && unicode.IsDigit(rune(part[0])) {
 			versionParts = parts[i:]
 			nameParts = parts[:i]
+
 			break
 		}
 	}
@@ -221,6 +226,7 @@ func toNamespace(m *Metadata) string {
 		return m.OSID
 	}
 	log.Errorf("os-release[ID] not set, fallback to 'linux'")
+
 	return "linux"
 }
 
@@ -229,6 +235,7 @@ func toDistro(m *Metadata) string {
 		return m.OSVersionID
 	}
 	log.Errorf("VERSION_ID not set in os-release")
+
 	return ""
 }
 
@@ -240,6 +247,7 @@ func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	if distro != "" {
 		q[purl.Distro] = distro
 	}
+
 	return &purl.PackageURL{
 		Type:       purl.TypePortage,
 		Name:       m.PackageName,
@@ -256,5 +264,6 @@ func (Extractor) Ecosystem(i *extractor.Inventory) string {
 	if m.OSVersionID == "" {
 		return osID
 	}
+
 	return osID + ":" + m.OSVersionID
 }

--- a/extractor/filesystem/os/rpm/rpm_linux.go
+++ b/extractor/filesystem/os/rpm/rpm_linux.go
@@ -128,10 +128,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -160,6 +162,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -276,6 +279,7 @@ func toNamespace(m *Metadata) string {
 		return m.OSID
 	}
 	log.Errorf("os-release[ID] not set, fallback to ''")
+
 	return ""
 }
 
@@ -285,6 +289,7 @@ func toDistro(m *Metadata) string {
 		v = m.OSBuildID
 		if v == "" {
 			log.Errorf("VERSION_ID and BUILD_ID not set in os-release")
+
 			return ""
 		}
 		log.Errorf("os-release[VERSION_ID] not set, fallback to BUILD_ID")
@@ -293,8 +298,10 @@ func toDistro(m *Metadata) string {
 	id := m.OSID
 	if id == "" {
 		log.Errorf("os-release[ID] not set, fallback to ''")
+
 		return v
 	}
+
 	return fmt.Sprintf("%s-%s", id, v)
 }
 
@@ -315,6 +322,7 @@ func (e Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	if m.Architecture != "" {
 		q[purl.Arch] = m.Architecture
 	}
+
 	return &purl.PackageURL{
 		Type:       purl.TypeRPM,
 		Namespace:  toNamespace(m),

--- a/extractor/filesystem/os/rpm/rpm_test.go
+++ b/extractor/filesystem/os/rpm/rpm_test.go
@@ -997,6 +997,7 @@ func CopyFileToTempDir(t *testing.T, filepath, root string) (string, error) {
 	if err := os.WriteFile(newfile, bytes, 0400); err != nil {
 		return "", err
 	}
+
 	return newfile, nil
 }
 
@@ -1025,5 +1026,6 @@ func scalibrFilesInTmp(t *testing.T) []string {
 			filenames = append(filenames, f.Name())
 		}
 	}
+
 	return filenames
 }

--- a/extractor/filesystem/os/snap/snap.go
+++ b/extractor/filesystem/os/snap/snap.go
@@ -119,10 +119,12 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	}
 	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
 		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+
 		return false
 	}
 
 	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+
 	return true
 }
 
@@ -151,6 +153,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 			FileSizeBytes: fileSizeBytes,
 		})
 	}
+
 	return inventory, err
 }
 
@@ -189,6 +192,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 		},
 		Locations: []string{input.Path},
 	}
+
 	return []*extractor.Inventory{inventory}, nil
 }
 
@@ -197,6 +201,7 @@ func toNamespace(m *Metadata) string {
 		return m.OSID
 	}
 	log.Errorf("os-release[ID] not set, fallback to ''")
+
 	return ""
 }
 
@@ -208,9 +213,11 @@ func toDistro(m *Metadata) string {
 	// fallback: e.g. 22.04
 	if m.OSVersionID != "" {
 		log.Warnf("VERSION_CODENAME not set in os-release, fallback to VERSION_ID")
+
 		return m.OSVersionID
 	}
 	log.Errorf("VERSION_CODENAME and VERSION_ID not set in os-release")
+
 	return ""
 }
 
@@ -239,5 +246,6 @@ func (Extractor) Ecosystem(i *extractor.Inventory) string {
 		return "Ubuntu"
 	}
 	log.Errorf("os-release[ID] not set, fallback to '' ecosystem")
+
 	return ""
 }

--- a/extractor/filesystem/sbom/cdx/cdx.go
+++ b/extractor/filesystem/sbom/cdx/cdx.go
@@ -92,6 +92,7 @@ func findExtractor(path string) extractFunc {
 		if hasFileExtension(path, ext) {
 			return func(rdr io.Reader) (cyclonedx.BOM, error) {
 				var cdxBOM cyclonedx.BOM
+
 				return cdxBOM, cyclonedx.NewBOMDecoder(rdr, format).Decode(&cdxBOM)
 			}
 		}
@@ -101,6 +102,7 @@ func findExtractor(path string) extractFunc {
 		if strings.ToLower(filepath.Base(path)) == name {
 			return func(rdr io.Reader) (cyclonedx.BOM, error) {
 				var cdxBOM cyclonedx.BOM
+
 				return cdxBOM, cyclonedx.NewBOMDecoder(rdr, format).Decode(&cdxBOM)
 			}
 		}
@@ -144,6 +146,7 @@ func (e Extractor) convertCdxBomToInventory(cdxBom *cyclonedx.BOM, path string) 
 		inv.Metadata = m
 		if m.PURL == nil && len(m.CPEs) == 0 {
 			log.Warnf("Neither CPE nor PURL found for package: %+v", cdxPkg)
+
 			continue
 		}
 		results = append(results, inv)

--- a/extractor/filesystem/sbom/cdx/cdx_test.go
+++ b/extractor/filesystem/sbom/cdx/cdx_test.go
@@ -223,5 +223,6 @@ func purlFromString(t *testing.T, purlStr string) *purl.PackageURL {
 	if err != nil {
 		t.Fatalf("purlFromString(%s): %v", purlStr, err)
 	}
+
 	return &res
 }

--- a/extractor/filesystem/sbom/spdx/spdx.go
+++ b/extractor/filesystem/sbom/spdx/spdx.go
@@ -69,6 +69,7 @@ var extensionHandlers = map[string]extractFunc{
 // FileRequired returns true if the specified file is a supported spdx file.
 func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	_, isSupported := findExtractor(api.Path())
+
 	return isSupported
 }
 
@@ -134,6 +135,7 @@ func (e Extractor) convertSpdxDocToInventory(spdxDoc *spdx.Document, path string
 		inv.Metadata = m
 		if m.PURL == nil && len(m.CPEs) == 0 {
 			log.Warnf("Neither CPE nor PURL found for package: %+v", spdxPkg)
+
 			continue
 		}
 		results = append(results, inv)

--- a/extractor/standalone/containers/containerd/containerd_linux.go
+++ b/extractor/standalone/containers/containerd/containerd_linux.go
@@ -131,6 +131,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 	if e.checkIfSocketExists {
 		if _, err := os.Stat(e.socketAddr); err != nil {
 			log.Infof("Containerd socket %v does not exist, skipping extraction.", e.socketAddr)
+
 			return inventory, err
 		}
 	}
@@ -141,6 +142,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 		cli, err := containerd.New(e.socketAddr)
 		if err != nil {
 			log.Errorf("Failed to connect to containerd socket %v, error: %v", e.socketAddr, err)
+
 			return inventory, err
 		}
 		e.client = cli
@@ -154,6 +156,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 	ctrMetadata, err := containersFromAPI(ctx, e.client)
 	if err != nil {
 		log.Errorf("Could not get container inventory from the containerd: %v", err)
+
 		return inventory, err
 	}
 
@@ -168,6 +171,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 	}
 
 	defer e.client.Close()
+
 	return inventory, nil
 }
 
@@ -178,6 +182,7 @@ func containersFromAPI(ctx context.Context, client CtrdClient) ([]Metadata, erro
 	nss, err := namespacesFromAPI(ctx, client)
 	if err != nil {
 		log.Errorf("Could not get a list of namespaces from the containerd: %v", err)
+
 		return nil, err
 	}
 
@@ -187,11 +192,13 @@ func containersFromAPI(ctx context.Context, client CtrdClient) ([]Metadata, erro
 		ctrs, err := containersMetadata(ctx, client, ns, defaultContainerdRootfsPrefix)
 		if err != nil {
 			log.Errorf("Could not get a list of containers from the containerd: %v", err)
+
 			return nil, err
 		}
 		// Merge all containers metadata items for all namespaces into a single list.
 		metadata = append(metadata, ctrs...)
 	}
+
 	return metadata, nil
 }
 
@@ -221,11 +228,13 @@ func containersMetadata(ctx context.Context, client CtrdClient, namespace string
 		md, err := taskMetadata(ctx, client, task, namespace, defaultAbsoluteToBundlePath)
 		if err != nil {
 			log.Errorf("Failed to get task metadata for task %v: %v", task.ID, err)
+
 			continue
 		}
 
 		containersMetadata = append(containersMetadata, md)
 	}
+
 	return containersMetadata, nil
 }
 
@@ -235,30 +244,35 @@ func taskMetadata(ctx context.Context, client CtrdClient, task *task.Process, na
 	container, err := client.LoadContainer(ctx, task.ID)
 	if err != nil {
 		log.Errorf("Failed to load container for task %v, error: %v", task.ID, err)
+
 		return md, err
 	}
 
 	info, err := container.Info(ctx)
 	if err != nil {
 		log.Errorf("Failed to obtain container info for container %v, error: %v", task.ID, err)
+
 		return md, err
 	}
 
 	image, err := container.Image(ctx)
 	if err != nil {
 		log.Errorf("Failed to obtain container image for container %v, error: %v", task.ID, err)
+
 		return md, err
 	}
 
 	ctdTask, err := container.Task(ctx, nil)
 	if err != nil {
 		log.Errorf("Failed to obtain containerd container task data for container %v, error: %v", task.ID, err)
+
 		return md, err
 	}
 
 	spec, err := ctdTask.Spec(ctx)
 	if err != nil {
 		log.Errorf("Failed to obtain containerd container task spec for container %v, error: %v", task.ID, err)
+
 		return md, err
 	}
 	// Defined in https://github.com/opencontainers/runtime-spec/blob/main/config.md#root. For POSIX

--- a/extractor/standalone/containers/containerd/fakeclient/fake_containerd_client.go
+++ b/extractor/standalone/containers/containerd/fakeclient/fake_containerd_client.go
@@ -77,6 +77,7 @@ func (c *CtrdClient) LoadContainer(ctx context.Context, id string) (containerd.C
 	if ctr, ok := c.ctrTasksIDs[id]; ok {
 		return ctr, nil
 	}
+
 	return nil, fmt.Errorf("no container found with task id %v", id)
 }
 
@@ -103,6 +104,7 @@ func initContainerTasks(tsks []*task.Process, ctrs []containerd.Container) (map[
 		for _, task := range tsks {
 			if task.ID == ctr.ID() {
 				ctrTasksIDs[ctr.ID()] = ctr
+
 				break
 			}
 		}
@@ -111,6 +113,7 @@ func initContainerTasks(tsks []*task.Process, ctrs []containerd.Container) (map[
 			return nil, fmt.Errorf("no task found for container %v", ctr.ID())
 		}
 	}
+
 	return ctrTasksIDs, nil
 }
 
@@ -147,6 +150,7 @@ func (s *TasksService) List(ctx context.Context, in *tasks.ListTasksRequest, opt
 		for _, t := range s.tasks {
 			if id == t.ID {
 				tsks = append(tsks, t)
+
 				break
 			}
 		}

--- a/extractor/standalone/list/list.go
+++ b/extractor/standalone/list/list.go
@@ -79,6 +79,7 @@ func concat(InitMaps ...InitMap) InitMap {
 	for _, m := range InitMaps {
 		maps.Copy(result, m)
 	}
+
 	return result
 }
 
@@ -96,6 +97,7 @@ func FromCapabilities(capabs *plugin.Capabilities) []standalone.Extractor {
 			all = append(all, initer())
 		}
 	}
+
 	return FilterByCapabilities(all, capabs)
 }
 
@@ -109,6 +111,7 @@ func FilterByCapabilities(exs []standalone.Extractor, capabs *plugin.Capabilitie
 			result = append(result, ex)
 		}
 	}
+
 	return result
 }
 
@@ -131,6 +134,7 @@ func ExtractorsFromNames(names []string) ([]standalone.Extractor, error) {
 	for _, e := range resultMap {
 		result = append(result, e)
 	}
+
 	return result, nil
 }
 
@@ -147,5 +151,6 @@ func ExtractorFromName(name string) (standalone.Extractor, error) {
 	if e.Name() != name {
 		return nil, fmt.Errorf("not an exact name for an extractor: %s", name)
 	}
+
 	return e, nil
 }

--- a/extractor/standalone/os/netports/netports_linux.go
+++ b/extractor/standalone/os/netports/netports_linux.go
@@ -94,12 +94,14 @@ func (e Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([]
 			pid, ok := inodeToPID[entry.Inode]
 			if !ok {
 				inventories = append(inventories, e.newInventory(ctx, port, proto, []string{"unknown"}))
+
 				continue
 			}
 
 			cmdline, cached := pidCommandLinesCache[pid]
 			if cached {
 				inventories = append(inventories, e.newInventory(ctx, port, proto, cmdline))
+
 				continue
 			}
 

--- a/extractor/standalone/standalone.go
+++ b/extractor/standalone/standalone.go
@@ -72,6 +72,7 @@ func Run(ctx context.Context, config *Config) ([]*extractor.Inventory, []*plugin
 		inv, err := extractor.Extract(ctx, scanInput)
 		if err != nil {
 			statuses = append(statuses, plugin.StatusFromErr(extractor, false, err))
+
 			continue
 		}
 		for _, i := range inv {

--- a/extractor/standalone/windows/common/winproducts/winproducts.go
+++ b/extractor/standalone/windows/common/winproducts/winproducts.go
@@ -65,6 +65,7 @@ func windowsFlavor(installType string) string {
 	}
 
 	log.Infof("Please report to scalibr devteam: unknown Windows flavor: %q", flavor)
+
 	return "server"
 }
 

--- a/extractor/standalone/windows/dismpatch/dismparser/dism_parser.go
+++ b/extractor/standalone/windows/dismpatch/dismparser/dism_parser.go
@@ -86,5 +86,6 @@ func findVersion(identity string) string {
 	if len(pkgVer) > 1 {
 		return pkgVer[1]
 	}
+
 	return ""
 }

--- a/extractor/standalone/windows/ospackages/ospackages_dummy.go
+++ b/extractor/standalone/windows/ospackages/ospackages_dummy.go
@@ -69,6 +69,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e *Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	log.Warnf("Trying to use ospackages on %s, which is not supported", runtime.GOOS)
+
 	return nil
 }
 

--- a/extractor/standalone/windows/regosversion/regosversion_dummy.go
+++ b/extractor/standalone/windows/regosversion/regosversion_dummy.go
@@ -69,6 +69,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e *Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	log.Warnf("Trying to use regosversion on %s, which is not supported", runtime.GOOS)
+
 	return nil
 }
 

--- a/extractor/standalone/windows/regpatchlevel/regpatchlevel_dummy.go
+++ b/extractor/standalone/windows/regpatchlevel/regpatchlevel_dummy.go
@@ -69,6 +69,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 // ToPURL converts an inventory created by this extractor into a PURL.
 func (e *Extractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
 	log.Warnf("Trying to use regpatchlevel on %s, which is not supported", runtime.GOOS)
+
 	return nil
 }
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -64,6 +64,7 @@ func (r *ScanRoot) WithAbsolutePath() (*ScanRoot, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &ScanRoot{FS: r.FS, Path: absroot}, nil
 }
 

--- a/internal/guidedremediation/lockfile/npm/packagelockjson.go
+++ b/internal/guidedremediation/lockfile/npm/packagelockjson.go
@@ -133,6 +133,7 @@ func (r readWriter) Read(path string, fsys scalibrfs.FS) (*resolve.Graph, error)
 				// But there are some cases (with workspaces) that npm doesn't error,
 				// so just always ignore the error to make it work.
 				log.Warnf("package-lock.json is missing dependency %s for %s", depName, node.ActualName)
+
 				continue
 			}
 			if err := g.AddEdge(node.NodeID, depNode, depSpec.Version, depSpec.DepType); err != nil {

--- a/internal/guidedremediation/manifest/maven/pomxml.go
+++ b/internal/guidedremediation/manifest/maven/pomxml.go
@@ -179,6 +179,7 @@ func GetReadWriter(registry string) (manifest.ReadWriter, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return readWriter{MavenRegistryAPIClient: client}, nil
 }
 

--- a/internal/guidedremediation/manifest/npm/packagejson.go
+++ b/internal/guidedremediation/manifest/npm/packagejson.go
@@ -45,6 +45,7 @@ func MakeRequirementKey(requirement resolve.RequirementVersion) manifest.Require
 	// Declaring a dependency in multiple places (dependencies, devDependencies, optionalDependencies) only installs it once at one version.
 	// Aliases & non-registry dependencies are keyed on their 'KnownAs' attribute.
 	knownAs, _ := requirement.Type.GetAttr(dep.KnownAs)
+
 	return RequirementKey{
 		PackageKey: requirement.PackageKey,
 		KnownAs:    knownAs,
@@ -90,6 +91,7 @@ func (m *npmManifest) LocalManifests() []manifest.Manifest {
 	for i, l := range m.localManifests {
 		locals[i] = l
 	}
+
 	return locals
 }
 
@@ -231,11 +233,13 @@ func parse(path string, fsys scalibrfs.FS, doWorkspaces bool) (*npmManifest, err
 		req, ok := makeNPMReqVer(pkg, ver)
 		if !ok {
 			log.Warnf("Skipping unsupported requirement: \"%s\": \"%s\"", pkg, ver)
+
 			continue
 		}
 		if isWorkspace(req) {
 			// workspaces seem to always be evaluated separately
 			workspaceReqVers[req.PackageKey] = req
+
 			continue
 		}
 		manif.requirements = append(manif.requirements, req)
@@ -245,12 +249,14 @@ func parse(path string, fsys scalibrfs.FS, doWorkspaces bool) (*npmManifest, err
 		req, ok := makeNPMReqVer(pkg, ver)
 		if !ok {
 			log.Warnf("Skipping unsupported requirement: \"%s\": \"%s\"", pkg, ver)
+
 			continue
 		}
 		req.Type.AddAttr(dep.Opt, "")
 		if isWorkspace(req) {
 			// workspaces seem to always be evaluated separately
 			workspaceReqVers[req.PackageKey] = req
+
 			continue
 		}
 		idx := slices.IndexFunc(manif.requirements, func(imp resolve.RequirementVersion) bool {
@@ -268,11 +274,13 @@ func parse(path string, fsys scalibrfs.FS, doWorkspaces bool) (*npmManifest, err
 		req, ok := makeNPMReqVer(pkg, ver)
 		if !ok {
 			log.Warnf("Skipping unsupported requirement: \"%s\": \"%s\"", pkg, ver)
+
 			continue
 		}
 		if isWorkspace(req) {
 			// workspaces seem to always be evaluated separately
 			workspaceReqVers[req.PackageKey] = req
+
 			continue
 		}
 		idx := slices.IndexFunc(manif.requirements, func(imp resolve.RequirementVersion) bool {

--- a/internal/guidedremediation/manifest/npm/packagejson_test.go
+++ b/internal/guidedremediation/manifest/npm/packagejson_test.go
@@ -36,6 +36,7 @@ func aliasType(t *testing.T, aliasedName string) dep.Type {
 
 func makeVK(t *testing.T, name, version string, versionType resolve.VersionType) resolve.VersionKey {
 	t.Helper()
+
 	return resolve.VersionKey{
 		PackageKey: resolve.PackageKey{
 			System: resolve.NPM,

--- a/internal/guidedremediation/matchertest/mock_vulnerability_matcher.go
+++ b/internal/guidedremediation/matchertest/mock_vulnerability_matcher.go
@@ -39,6 +39,7 @@ func (mvc MockVulnerabilityMatcher) MatchVulnerabilities(ctx context.Context, in
 			}
 		}
 	}
+
 	return result, nil
 }
 
@@ -61,5 +62,6 @@ func NewMockVulnerabilityMatcher(t *testing.T, vulnsYAML string) MockVulnerabili
 	if err := dec.Decode(&vulns); err != nil {
 		t.Fatalf("failed decoding mock vulns: %v", err)
 	}
+
 	return MockVulnerabilityMatcher(vulns.Vulns)
 }

--- a/internal/guidedremediation/remediation/remediation.go
+++ b/internal/guidedremediation/remediation/remediation.go
@@ -92,6 +92,7 @@ func (opts *Options) matchSeverity(v resolution.Vulnerability) bool {
 			for _, affected := range v.OSV.Affected {
 				if vulns.IsAffected(&osvschema.Vulnerability{Affected: []osvschema.Affected{affected}}, inv) {
 					severities = append(severities, affected.Severity...)
+
 					break
 				}
 			}
@@ -217,6 +218,7 @@ func ConstructPatches(oldRes, newRes *ResolvedManifest) Patch {
 				VersionFrom: "",
 				VersionTo:   req.Version,
 			})
+
 			continue
 		}
 		if req.Version == oldReq.Version {

--- a/internal/guidedremediation/remediation/strategy/override/override.go
+++ b/internal/guidedremediation/remediation/strategy/override/override.go
@@ -63,6 +63,7 @@ func ComputePatches(ctx context.Context, cl resolve.Client, vm matcher.Vulnerabi
 			if !errors.Is(r.err, errOverrideImpossible) {
 				log.Warnf("error attempting to compute override patch for vulns %v: %v", r.vulnIDs, r.err)
 			}
+
 			continue
 		}
 
@@ -221,6 +222,7 @@ func getVersionsGreater(ctx context.Context, cl resolve.Client, vk resolve.Versi
 		parsed, err := sv.Parse(ver.Version)
 		if err != nil {
 			log.Warnf("error parsing version %s: %v", parsed, err)
+
 			continue
 		}
 		semvers[ver.VersionKey] = parsed

--- a/internal/guidedremediation/resolution/dependency_subgraph_test.go
+++ b/internal/guidedremediation/resolution/dependency_subgraph_test.go
@@ -120,6 +120,7 @@ func checkSubgraphVersions(t *testing.T, sg *resolution.DependencySubgraph, g *r
 	for nID, node := range sg.Nodes {
 		if nID < 0 || int(nID) >= len(g.Nodes) {
 			t.Errorf("DependencySubgraph contains invalid node ID: %v", nID)
+
 			continue
 		}
 		want := g.Nodes[nID].Version
@@ -161,6 +162,7 @@ func checkSubgraphEdges(t *testing.T, sg *resolution.DependencySubgraph) {
 		for _, e := range node.Parents {
 			if e.To != nID {
 				t.Errorf("DependencySubgraph node %v contains invalid parent edge: %v", nID, e)
+
 				continue
 			}
 			parent, ok := sg.Nodes[e.From]
@@ -179,6 +181,7 @@ func checkSubgraphEdges(t *testing.T, sg *resolution.DependencySubgraph) {
 		for _, e := range node.Children {
 			if e.From != nID {
 				t.Errorf("DependencySubgraph node %v contains invalid child edge: %v", nID, e)
+
 				continue
 			}
 			child, ok := sg.Nodes[e.To]
@@ -205,6 +208,7 @@ func checkSubgraphNodesReachable(t *testing.T, sg *resolution.DependencySubgraph
 		node, ok := sg.Nodes[nID]
 		if !ok {
 			t.Errorf("DependencySubgraph missing expected node %v", nID)
+
 			continue
 		}
 		for _, e := range node.Children {
@@ -244,6 +248,7 @@ func checkSubgraphDistances(t *testing.T, sg *resolution.DependencySubgraph) {
 
 		if len(node.Children) == 0 {
 			t.Errorf("DependencySubgraph node %v has no child nodes", nID)
+
 			continue
 		}
 		e := slices.MinFunc(node.Children, func(a, b resolve.Edge) int { return cmp.Compare(sg.Nodes[a.To].Distance, sg.Nodes[b.To].Distance) })

--- a/internal/guidedremediation/resolution/resolve_test.go
+++ b/internal/guidedremediation/resolution/resolve_test.go
@@ -83,6 +83,7 @@ func (m mockManifest) Requirements() []resolve.RequirementVersion {
 			Type: r.typ.Clone(),
 		}
 	}
+
 	return reqs
 }
 
@@ -95,6 +96,7 @@ func (m mockManifest) LocalManifests() []manifest.Manifest {
 	for i, lm := range m.localManifests {
 		ret[i] = lm
 	}
+
 	return ret
 }
 
@@ -114,6 +116,7 @@ func TestResolveNPM(t *testing.T) {
 	aliasType := func(knownAs string) dep.Type {
 		var typ dep.Type
 		typ.AddAttr(dep.KnownAs, knownAs)
+
 		return typ
 	}
 	// Create a mock manifest with dependencies, including aliases and workspaces.

--- a/internal/guidedremediation/resolution/vulnerabilities_test.go
+++ b/internal/guidedremediation/resolution/vulnerabilities_test.go
@@ -33,6 +33,7 @@ func TestFindVulnerabilities(t *testing.T) {
 	aliasType := func(knownAs string) dep.Type {
 		var typ dep.Type
 		typ.AddAttr(dep.KnownAs, knownAs)
+
 		return typ
 	}
 	m := mockManifest{

--- a/internal/guidedremediation/severity/severity.go
+++ b/internal/guidedremediation/severity/severity.go
@@ -43,6 +43,7 @@ func CalculateScore(severity osvschema.Severity) (float64, error) {
 		if err != nil {
 			return -1.0, err
 		}
+
 		return vec.BaseScore(), nil
 	case osvschema.SeverityCVSSV3:
 		switch {
@@ -51,12 +52,14 @@ func CalculateScore(severity osvschema.Severity) (float64, error) {
 			if err != nil {
 				return -1.0, err
 			}
+
 			return vec.BaseScore(), nil
 		case strings.HasPrefix(severity.Score, "CVSS:3.1/"):
 			vec, err := gocvss31.ParseVector(severity.Score)
 			if err != nil {
 				return -1.0, err
 			}
+
 			return vec.BaseScore(), nil
 		default:
 			return -1.0, fmt.Errorf("unsupported CVSS_V3 version: %s", severity.Score)
@@ -66,6 +69,7 @@ func CalculateScore(severity osvschema.Severity) (float64, error) {
 		if err != nil {
 			return -1.0, err
 		}
+
 		return vec.Score(), nil
 
 	default:

--- a/internal/guidedremediation/vulns/vulns.go
+++ b/internal/guidedremediation/vulns/vulns.go
@@ -86,6 +86,7 @@ func IsAffected(vuln *osvschema.Vulnerability, inv *extractor.Inventory) bool {
 				if e.Fixed != "" {
 					return e.Fixed
 				}
+
 				return e.LastAffected
 			}
 			slices.SortFunc(events, func(a, b osvschema.Event) int {
@@ -95,6 +96,7 @@ func IsAffected(vuln *osvschema.Vulnerability, inv *extractor.Inventory) bool {
 					if bVer == "0" {
 						return 0
 					}
+
 					return -1
 				}
 				if bVer == "0" {
@@ -108,6 +110,7 @@ func IsAffected(vuln *osvschema.Vulnerability, inv *extractor.Inventory) bool {
 				if eVer == "0" {
 					return -1
 				}
+
 				return sys.Compare(eVer, v)
 			})
 			if exact {
@@ -124,5 +127,6 @@ func IsAffected(vuln *osvschema.Vulnerability, inv *extractor.Inventory) bool {
 			}
 		}
 	}
+
 	return false
 }

--- a/internal/mavenutil/maven.go
+++ b/internal/mavenutil/maven.go
@@ -132,6 +132,7 @@ func loadParentLocal(input *filesystem.ScanInput, parent maven.Parent, path stri
 		// Only mark parent as found when the identifiers and packaging are expected.
 		return false, "", nil
 	}
+
 	return true, parentPath, nil
 }
 
@@ -149,6 +150,7 @@ func loadParentRemote(ctx context.Context, mavenClient *datasource.MavenRegistry
 		// The identifiers in parent does not match what we want.
 		return maven.Project{}, fmt.Errorf("parent identifiers mismatch: %v, expect %v", proj.ProjectKey, parent.ProjectKey)
 	}
+
 	return proj, nil
 }
 

--- a/internal/mavenutil/maven_test.go
+++ b/internal/mavenutil/maven_test.go
@@ -97,6 +97,7 @@ func TestCompareVersions(t *testing.T) {
 	}
 	semVer := func(version string) *semver.Version {
 		parsed, _ := resolve.Maven.Semver().Parse(version)
+
 		return parsed
 	}
 

--- a/inventoryindex/inventory_index.go
+++ b/inventoryindex/inventory_index.go
@@ -40,6 +40,7 @@ func New(inv []*extractor.Inventory) (*InventoryIndex, error) {
 		}
 		invMap[p.Type][p.Name] = append(invMap[p.Type][p.Name], i)
 	}
+
 	return &InventoryIndex{invMap: invMap}, nil
 }
 
@@ -51,6 +52,7 @@ func (ix *InventoryIndex) GetAll() []*extractor.Inventory {
 			result = append(result, i...)
 		}
 	}
+
 	return result
 }
 
@@ -65,6 +67,7 @@ func (ix *InventoryIndex) GetAllOfType(packageType string) []*extractor.Inventor
 	for _, i := range m {
 		result = append(result, i...)
 	}
+
 	return result
 }
 
@@ -79,6 +82,7 @@ func (ix *InventoryIndex) GetSpecific(name string, packageType string) []*extrac
 	if !ok {
 		return result
 	}
+
 	return i
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -132,6 +132,7 @@ func ValidateRequirements(p Plugin, capabs *Capabilities) error {
 	if len(errs) == 0 {
 		return nil
 	}
+
 	return fmt.Errorf("plugin %s can't be enabled: %s", p.Name(), strings.Join(errs, ", "))
 }
 
@@ -148,6 +149,7 @@ func StatusFromErr(p Plugin, partial bool, err error) *Status {
 		}
 		status.FailureReason = err.Error()
 	}
+
 	return &Status{
 		Name:    p.Name(),
 		Version: p.Version(),
@@ -165,5 +167,6 @@ func (s *ScanStatus) String() string {
 	case ScanStatusFailed:
 		return fmt.Sprintf("FAILED: %s", s.FailureReason)
 	}
+
 	return "UNSPECIFIED"
 }

--- a/purl/purl.go
+++ b/purl/purl.go
@@ -135,6 +135,7 @@ func QualifiersFromMap(mm map[string]string) Qualifiers {
 			delete(mm, key)
 		}
 	}
+
 	return Qualifiers(packageurl.QualifiersFromMap(mm))
 }
 
@@ -147,6 +148,7 @@ func (p PackageURL) String() string {
 		Qualifiers: packageurl.Qualifiers(p.Qualifiers),
 		Subpath:    p.Subpath,
 	}
+
 	return (&purl).String()
 }
 
@@ -159,6 +161,7 @@ func FromString(purl string) (PackageURL, error) {
 	if !validType(p.Type) {
 		return PackageURL{}, fmt.Errorf("invalid PURL type %q", p.Type)
 	}
+
 	return PackageURL{
 		Type:       p.Type,
 		Namespace:  p.Namespace,
@@ -214,6 +217,7 @@ func validType(t string) bool {
 	// purl type is case-insensitive, canonical form is lower-case
 	t = strings.ToLower(t)
 	_, ok := types[t]
+
 	return ok
 }
 

--- a/scalibr.go
+++ b/scalibr.go
@@ -126,6 +126,7 @@ func (cfg *ScanConfig) EnableRequiredExtractors() error {
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -148,6 +149,7 @@ func (cfg *ScanConfig) ValidatePluginRequirements() error {
 			errs = append(errs, err)
 		}
 	}
+
 	return errors.Join(errs...)
 }
 
@@ -192,6 +194,7 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 	}
 	if sro.Err != nil {
 		sro.EndTime = time.Now()
+
 		return newScanResult(sro)
 	}
 	extractorConfig := &filesystem.Config{
@@ -212,6 +215,7 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 	if err != nil {
 		sro.Err = err
 		sro.EndTime = time.Now()
+
 		return newScanResult(sro)
 	}
 
@@ -226,6 +230,7 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 	if err != nil {
 		sro.Err = err
 		sro.EndTime = time.Now()
+
 		return newScanResult(sro)
 	}
 
@@ -236,6 +241,7 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 	if err != nil {
 		sro.Err = err
 		sro.EndTime = time.Now()
+
 		return newScanResult(sro)
 	}
 
@@ -249,6 +255,7 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 	}
 
 	sro.EndTime = time.Now()
+
 	return newScanResult(sro)
 }
 
@@ -297,6 +304,7 @@ func (s Scanner) ScanContainer(ctx context.Context, img *image.Image, config *Sc
 
 	// Populate the LayerDetails field of the inventory by tracing the layer origins.
 	trace.PopulateLayerDetails(ctx, inventory, chainLayers, extractorConfig)
+
 	return scanResult, nil
 }
 
@@ -329,6 +337,7 @@ func newScanResult(o *newScanResultOptions) *ScanResult {
 
 	// Sort results for better diffing.
 	sortResults(r)
+
 	return r
 }
 
@@ -338,6 +347,7 @@ func hasFailedPlugins(statuses []*plugin.Status) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -364,6 +374,7 @@ func CmpInventories(a, b *extractor.Inventory) int {
 	}
 	aloc := fmt.Sprintf("%v", a.Locations)
 	bloc := fmt.Sprintf("%v", b.Locations)
+
 	return cmp.Compare(aloc, bloc)
 }
 
@@ -375,6 +386,7 @@ func cmpFindings(a, b *detector.Finding) int {
 	if a.Adv.ID.Reference != b.Adv.ID.Reference {
 		return cmpString(a.Adv.ID.Reference, b.Adv.ID.Reference)
 	}
+
 	return cmpString(a.Extra, b.Extra)
 }
 
@@ -384,5 +396,6 @@ func cmpString(a, b string) int {
 	} else if a > b {
 		return 1
 	}
+
 	return 0
 }

--- a/scalibr_test.go
+++ b/scalibr_test.go
@@ -187,6 +187,7 @@ func TestScan(t *testing.T) {
 func withDetectorName(f *detector.Finding, det string) *detector.Finding {
 	c := *f
 	c.Detectors = []string{det}
+
 	return &c
 }
 

--- a/testing/fakedetector/fake_detector.go
+++ b/testing/fakedetector/fake_detector.go
@@ -43,6 +43,7 @@ func New(name string, version int, finding *detector.Finding, err error) detecto
 		c = &detector.Finding{}
 		*c = *finding
 	}
+
 	return &fakeDetector{
 		DetName:    name,
 		DetVersion: version,
@@ -68,6 +69,7 @@ func (d *fakeDetector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, i
 	if d.Finding == nil {
 		return nil, d.Err
 	}
+
 	return []*detector.Finding{d.Finding}, d.Err
 }
 
@@ -115,5 +117,6 @@ func NewWithOptions(opts ...Option) detector.Detector {
 	for _, opt := range opts {
 		opt(fd)
 	}
+
 	return fd
 }

--- a/testing/testcollector/test_collector.go
+++ b/testing/testcollector/test_collector.go
@@ -50,6 +50,7 @@ func (c *Collector) FileRequiredResult(path string) stats.FileRequiredResult {
 	if filestats, ok := c.fileRequiredStats[path]; ok {
 		return filestats.Result
 	}
+
 	return ""
 }
 
@@ -59,6 +60,7 @@ func (c *Collector) FileExtractedResult(path string) stats.FileExtractedResult {
 	if filestats, ok := c.fileExtractedStats[path]; ok {
 		return filestats.Result
 	}
+
 	return ""
 }
 
@@ -68,5 +70,6 @@ func (c *Collector) FileExtractedFileSize(path string) int64 {
 	if filestats, ok := c.fileExtractedStats[path]; ok {
 		return filestats.FileSizeBytes
 	}
+
 	return 0
 }


### PR DESCRIPTION
This is generally considered to improve readability by making it easier to spot when the control flow is changing

Relates to #274