### PR TITLE
fix: ensure that `host:port` joining is done correct for IPv6 addresses

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,7 +61,7 @@ linters:
 #    - nlreturn
 #    - noctx
     - nolintlint
-#    - nosprintfhostport
+    - nosprintfhostport
 #    - perfsprint
 #    - prealloc
     - predeclared

--- a/detector/cve/cve202016846/cve202016846.go
+++ b/detector/cve/cve202016846/cve202016846.go
@@ -35,8 +35,10 @@ import (
 	"fmt"
 	"io/fs"
 	"math/rand"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -192,7 +194,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 
 // CheckForCherrypy checks for the presence of Cherrypy in the server headers.
 func CheckForCherrypy(saltIP string, saltServerPort int) bool {
-	target := fmt.Sprintf("http://%s:%d", saltIP, saltServerPort)
+	target := fmt.Sprintf("http://%s", net.JoinHostPort(saltIP, strconv.Itoa(saltServerPort)))
 
 	client := &http.Client{Timeout: defaultTimeout}
 	resp, err := client.Get(target)
@@ -208,7 +210,7 @@ func CheckForCherrypy(saltIP string, saltServerPort int) bool {
 
 // ExploitSalt attempts to exploit the Salt server if vulnerable.
 func ExploitSalt(ctx context.Context, saltIP string, saltServerPort int) bool {
-	target := fmt.Sprintf("http://%s:%d/run", saltIP, saltServerPort)
+	target := fmt.Sprintf("http://%s/run", net.JoinHostPort(saltIP, strconv.Itoa(saltServerPort)))
 	data := map[string]any{
 		"client":   "ssh",
 		"tgt":      "*",

--- a/detector/cve/cve202233891/cve202233891.go
+++ b/detector/cve/cve202233891/cve202233891.go
@@ -24,8 +24,10 @@ import (
 	"fmt"
 	"io/fs"
 	"math/rand"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -165,7 +167,7 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 func sparkUIHTTPQuery(ctx context.Context, sparkDomain string, sparkPort int, cmdExec string) int {
 	client := &http.Client{Timeout: defaultTimeout}
 
-	targetURL := fmt.Sprintf("http://%s:%d/?doAs=`%s`", sparkDomain, sparkPort, cmdExec)
+	targetURL := fmt.Sprintf("http://%s/?doAs=`%s`", net.JoinHostPort(sparkDomain, strconv.Itoa(sparkPort)), cmdExec)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	req.Header.Add("Accept", "*/*")
 	resp, err := client.Do(req)

--- a/detector/cve/cve20236019/cve20236019.go
+++ b/detector/cve/cve20236019/cve20236019.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io/fs"
 	"math/rand"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -196,7 +197,7 @@ func attemptExploit(ctx context.Context) string {
 
 // rayRequest sends an HTTP GET request to the Ray Dashboard and executes the provided command
 func rayRequest(ctx context.Context, host string, port int, cmd string) int {
-	url := fmt.Sprintf("http://%s:%d/worker/cpu_profile?pid=3354&ip=127.0.0.1&duration=5&native=0&format=%s", host, port, cmd)
+	url := fmt.Sprintf("http://%s/worker/cpu_profile?pid=3354&ip=127.0.0.1&duration=5&native=0&format=%s", net.JoinHostPort(host, strconv.Itoa(port)), cmd)
 
 	// Create a new HTTP request
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/detector/cve/cve20242912/cve20242912.go
+++ b/detector/cve/cve20242912/cve20242912.go
@@ -28,8 +28,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -106,7 +108,7 @@ func findBentomlVersions(ix *inventoryindex.InventoryIndex) (string, *extractor.
 
 // CheckAccessibility checks if the BentoML server is reachable
 func CheckAccessibility(ctx context.Context, ip string, port int) bool {
-	target := fmt.Sprintf("http://%s:%d/summarize", ip, port)
+	target := fmt.Sprintf("http://%s/summarize", net.JoinHostPort(ip, strconv.Itoa(port)))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 	if err != nil {
@@ -126,7 +128,7 @@ func CheckAccessibility(ctx context.Context, ip string, port int) bool {
 
 // ExploitBentoml sends payload to the BentoML service
 func ExploitBentoml(ctx context.Context, ip string, port int) bool {
-	target := fmt.Sprintf("http://%s:%d/summarize", ip, port)
+	target := fmt.Sprintf("http://%s/summarize", net.JoinHostPort(ip, strconv.Itoa(port)))
 
 	payload, err := base64.StdEncoding.DecodeString(string(pickledPayload))
 	if err != nil {

--- a/detector/weakcredentials/filebrowser/filebrowser.go
+++ b/detector/weakcredentials/filebrowser/filebrowser.go
@@ -25,7 +25,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -125,7 +127,7 @@ func isVulnerable(ctx context.Context, fileBrowserIP string, fileBrowserPort int
 // checkAccessibility checks if the filebrowser instance is accessible given an IP and port.
 func checkAccessibility(ctx context.Context, fileBrowserIP string, fileBrowserPort int) bool {
 	client := &http.Client{Timeout: requestTimeout}
-	targetURL := fmt.Sprintf("http://%s:%d/", fileBrowserIP, fileBrowserPort)
+	targetURL := fmt.Sprintf("http://%s/", net.JoinHostPort(fileBrowserIP, strconv.Itoa(fileBrowserPort)))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {
@@ -172,7 +174,7 @@ func checkAccessibility(ctx context.Context, fileBrowserIP string, fileBrowserPo
 // checkLogin checks if the login with default credentials is successful.
 func checkLogin(ctx context.Context, fileBrowserIP string, fileBrowserPort int) bool {
 	client := &http.Client{Timeout: requestTimeout}
-	targetURL := fmt.Sprintf("http://%s:%d/api/login", fileBrowserIP, fileBrowserPort)
+	targetURL := fmt.Sprintf("http://%s/api/login", net.JoinHostPort(fileBrowserIP, strconv.Itoa(fileBrowserPort)))
 
 	//nolint:errchkjson // this is a static struct, so it cannot fail
 	requestBody, _ := json.Marshal(map[string]string{


### PR DESCRIPTION
IPv6 addresses need to be wrapped in square brackets when a port is being specified which `net.JoinHostPort` takes care of automatically.

This also enables the `nosprintfhostport` linter to catch this going forward.

Relates to #274