### PR TITLE
perf: do string operations fast

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -62,7 +62,7 @@ linters:
 #    - noctx
     - nolintlint
 #    - nosprintfhostport
-#    - perfsprint
+    - perfsprint
 #    - prealloc
     - predeclared
     - promlinter

--- a/artifact/image/layerscanning/image/image.go
+++ b/artifact/image/layerscanning/image/image.go
@@ -282,7 +282,7 @@ func FromV1Image(v1Image v1.Image, config *Config) (*Image, error) {
 // v1.Layers found in the image from the tarball, and the max symlink depth.
 func initializeChainLayers(v1Layers []v1.Layer, configFile *v1.ConfigFile, maxSymlinkDepth int) ([]*chainLayer, error) {
 	if configFile == nil {
-		return nil, fmt.Errorf("config file is nil")
+		return nil, errors.New("config file is nil")
 	}
 
 	var chainLayers []*chainLayer
@@ -524,7 +524,7 @@ func populateEmptyDirectoryNodes(virtualPath, originLayerID, extractDir string, 
 func (img *Image) handleSymlink(virtualPath, originLayerID string, header *tar.Header, isWhiteout bool, requiredTargets map[string]bool) (*fileNode, error) {
 	targetPath := filepath.ToSlash(header.Linkname)
 	if targetPath == "" {
-		return nil, fmt.Errorf("symlink header has no target path")
+		return nil, errors.New("symlink header has no target path")
 	}
 
 	if symlink.TargetOutsideRoot(virtualPath, targetPath) {

--- a/artifact/image/layerscanning/image/image_test.go
+++ b/artifact/image/layerscanning/image/image_test.go
@@ -72,14 +72,14 @@ type fakeV1Image struct {
 
 func (fakeV1Image *fakeV1Image) Layers() ([]v1.Layer, error) {
 	if fakeV1Image.errorOnLayers {
-		return nil, fmt.Errorf("error on layers")
+		return nil, errors.New("error on layers")
 	}
 	return fakeV1Image.layers, nil
 }
 
 func (fakeV1Image *fakeV1Image) ConfigFile() (*v1.ConfigFile, error) {
 	if fakeV1Image.errorOnConfigFile {
-		return nil, fmt.Errorf("error on config file")
+		return nil, errors.New("error on config file")
 	}
 	return fakeV1Image.config, nil
 }

--- a/artifact/image/layerscanning/testing/fakechainlayer/fake_chain_layer.go
+++ b/artifact/image/layerscanning/testing/fakechainlayer/fake_chain_layer.go
@@ -17,7 +17,7 @@
 package fakechainlayer
 
 import (
-	"fmt"
+	"errors"
 	"io/fs"
 	"os"
 	"path"
@@ -107,5 +107,5 @@ func (fakeChainLayer *FakeChainLayer) Stat(name string) (fs.FileInfo, error) {
 // ReadDir is not used in the trace package since individual files are opened instead of
 // directories.
 func (fakeChainLayer *FakeChainLayer) ReadDir(name string) ([]fs.DirEntry, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }

--- a/artifact/image/layerscanning/testing/fakelayer/fake_layer.go
+++ b/artifact/image/layerscanning/testing/fakelayer/fake_layer.go
@@ -17,7 +17,7 @@
 package fakelayer
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -80,7 +80,7 @@ func (fakeLayer *FakeLayer) IsEmpty() bool {
 
 // Uncompressed is not used for the purposes of layer scanning, thus a nil value is returned.
 func (fakeLayer *FakeLayer) Uncompressed() (io.ReadCloser, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -107,5 +107,5 @@ func (fakeLayer *FakeLayer) Stat(name string) (fs.FileInfo, error) {
 // ReadDir is not used in the trace package since individual files are opened instead of
 // directories.
 func (fakeLayer *FakeLayer) ReadDir(name string) ([]fs.DirEntry, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }

--- a/artifact/image/layerscanning/testing/fakev1layer/fake_v1_layer.go
+++ b/artifact/image/layerscanning/testing/fakev1layer/fake_v1_layer.go
@@ -17,7 +17,7 @@
 package fakev1layer
 
 import (
-	"fmt"
+	"errors"
 	"io"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -45,7 +45,7 @@ func New(diffID string, buildCommand string, isEmpty bool, uncompressed io.ReadC
 // DiffID returns the diffID of the layer.
 func (fakeV1Layer *FakeV1Layer) DiffID() (v1.Hash, error) {
 	if fakeV1Layer.diffID == "" {
-		return v1.Hash{}, fmt.Errorf("diffID is empty")
+		return v1.Hash{}, errors.New("diffID is empty")
 	}
 	return v1.Hash{
 		Algorithm: "sha256",
@@ -65,12 +65,12 @@ func (fakeV1Layer *FakeV1Layer) Uncompressed() (io.ReadCloser, error) {
 
 // Compressed is not used for the purposes of layer scanning, thus a nil value is returned.
 func (fakeV1Layer *FakeV1Layer) Compressed() (io.ReadCloser, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 // Size is not used for the purposes of layer scanning, thus a zero value is returned.
 func (fakeV1Layer *FakeV1Layer) Size() (int64, error) {
-	return 0, fmt.Errorf("not implemented")
+	return 0, errors.New("not implemented")
 }
 
 // MediaType returns a fake media type.

--- a/artifact/image/layerscanning/trace/trace.go
+++ b/artifact/image/layerscanning/trace/trace.go
@@ -18,7 +18,6 @@ package trace
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/fs"
 	"slices"
 	"sort"
@@ -207,12 +206,12 @@ func areInventoriesEqual(inv1 *extractor.Inventory, inv2 *extractor.Inventory) b
 func getLayerFSFromChainLayer(chainLayer scalibrImage.ChainLayer) (scalibrfs.FS, error) {
 	layer := chainLayer.Layer()
 	if layer == nil {
-		return nil, fmt.Errorf("chain layer has no layer")
+		return nil, errors.New("chain layer has no layer")
 	}
 
 	fs := layer.FS()
 	if fs == nil {
-		return nil, fmt.Errorf("layer has no filesystem")
+		return nil, errors.New("layer has no filesystem")
 	}
 
 	return fs, nil

--- a/artifact/image/whiteout/whiteout.go
+++ b/artifact/image/whiteout/whiteout.go
@@ -86,7 +86,7 @@ func ToPath(p string) string {
 	nonWhitoutPath := path.Join(dir, file)
 
 	if dir != "" && file == "" {
-		nonWhitoutPath = fmt.Sprintf("%s/", nonWhitoutPath)
+		nonWhitoutPath = nonWhitoutPath + "/"
 	}
 
 	return nonWhitoutPath

--- a/binary/cli/cli.go
+++ b/binary/cli/cli.go
@@ -203,7 +203,7 @@ func validateOutput(output []string) error {
 	for _, item := range output {
 		o := strings.Split(item, "=")
 		if len(o) != 2 {
-			return fmt.Errorf("invalid output format, should follow a format like -o textproto=result.textproto -o spdx23-json=result.spdx.json")
+			return errors.New("invalid output format, should follow a format like -o textproto=result.textproto -o spdx23-json=result.spdx.json")
 		}
 		oFormat := o[0]
 		if !slices.Contains(supportedOutputFormats, oFormat) {
@@ -231,7 +231,7 @@ func validateSPDXCreators(creators string) error {
 	for _, item := range strings.Split(creators, ",") {
 		c := strings.Split(item, ":")
 		if len(c) != 2 {
-			return fmt.Errorf("invalid spdx-creators format, should follow a format like --spdx-creators=Tool:SCALIBR,Organization:Google")
+			return errors.New("invalid spdx-creators format, should follow a format like --spdx-creators=Tool:SCALIBR,Organization:Google")
 		}
 	}
 	return nil
@@ -247,7 +247,7 @@ func validateMultiStringArg(arg []string) error {
 		}
 		for _, item := range strings.Split(item, ",") {
 			if len(item) == 0 {
-				return fmt.Errorf("list item cannot be left empty")
+				return errors.New("list item cannot be left empty")
 			}
 		}
 	}

--- a/binary/proto/proto.go
+++ b/binary/proto/proto.go
@@ -18,7 +18,6 @@ package proto
 import (
 	"compress/gzip"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -589,10 +588,10 @@ func qualifiersToProto(qs purl.Qualifiers) []*spb.Qualifier {
 }
 
 // ErrAdvisoryMissing will be returned if the Advisory is not set on a finding.
-var ErrAdvisoryMissing = fmt.Errorf("Advisory missing in finding")
+var ErrAdvisoryMissing = errors.New("Advisory missing in finding")
 
 // ErrAdvisoryIDMissing will be returned if the Advisory ID is not set on a finding.
-var ErrAdvisoryIDMissing = fmt.Errorf("Advisory ID missing in finding")
+var ErrAdvisoryIDMissing = errors.New("Advisory ID missing in finding")
 
 func findingToProto(f *detector.Finding) (*spb.Finding, error) {
 	if f.Adv == nil {

--- a/common/linux/proc/nettcp_linux.go
+++ b/common/linux/proc/nettcp_linux.go
@@ -20,7 +20,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/hex"
-	"fmt"
+	"errors"
 	"io"
 	"net"
 	"strconv"
@@ -33,10 +33,10 @@ const (
 )
 
 var (
-	errInvalidFileFormat   = fmt.Errorf("invalid format for proc net file")
-	errInvalidState        = fmt.Errorf("invalid state in proc net file")
-	errInvalidAddressBlock = fmt.Errorf("invalid address block format in proc net file")
-	errInvalidAddressSize  = fmt.Errorf("invalid address size in proc net file")
+	errInvalidFileFormat   = errors.New("invalid format for proc net file")
+	errInvalidState        = errors.New("invalid state in proc net file")
+	errInvalidAddressBlock = errors.New("invalid address block format in proc net file")
+	errInvalidAddressSize  = errors.New("invalid address size in proc net file")
 )
 
 // NetTCPInfo contains the parsed /proc/net/{tcp,tcp6} files.

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -97,7 +97,7 @@ func ToSPDX23(r *scalibr.ScanResult, c SPDXConfig) *v2_3.Document {
 		pID := SPDXRefPrefix + "Package-" + replaceSPDXIDInvalidChars(pName) + "-" + uuid.New().String()
 		pSourceInfo := fmt.Sprintf("Identified by the %s extractor", i.Extractor.Name())
 		if len(i.Locations) == 1 {
-			pSourceInfo += fmt.Sprintf(" from %s", i.Locations[0])
+			pSourceInfo += " from " + i.Locations[0]
 		} else if l := len(i.Locations); l > 1 {
 			pSourceInfo += fmt.Sprintf(" from %d locations, including %s and %s", l, i.Locations[0], i.Locations[1])
 		}

--- a/detector/cis/generic_linux/etcpasswdpermissions/etcpasswdpermissions.go
+++ b/detector/cis/generic_linux/etcpasswdpermissions/etcpasswdpermissions.go
@@ -85,7 +85,7 @@ func (Detector) ScanFS(ctx context.Context, fs fs.FS, ix *inventoryindex.Invento
 
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-		return nil, fmt.Errorf("failed to get file ownership info")
+		return nil, errors.New("failed to get file ownership info")
 	}
 
 	if stat.Uid != 0 {

--- a/detector/cve/cve202011978/cve202011978.go
+++ b/detector/cve/cve202011978/cve202011978.go
@@ -58,7 +58,7 @@ const (
 
 var (
 	seededRand      = rand.New(rand.NewSource(time.Now().UnixNano()))
-	randFilePath    = fmt.Sprintf("/tmp/%s", randomString(16))
+	randFilePath    = "/tmp/" + randomString(16)
 	airflowPackages = []airflowPackageNames{
 		{
 			packageType: "pypi",

--- a/detector/cve/cve202016846/cve202016846.go
+++ b/detector/cve/cve202016846/cve202016846.go
@@ -66,7 +66,7 @@ const (
 
 var (
 	seededRand   = rand.New(rand.NewSource(time.Now().UnixNano()))
-	randFilePath = fmt.Sprintf("/tmp/%s", randomString(16))
+	randFilePath = "/tmp/" + randomString(16)
 	saltPackages = []saltPackageNames{
 		{
 			packageType: "pypi",

--- a/detector/cve/cve202233891/cve202233891.go
+++ b/detector/cve/cve202233891/cve202233891.go
@@ -120,8 +120,8 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 
 	vulnerable := false
 	for _, port := range sparkServersPorts {
-		randFilePath := fmt.Sprintf("/tmp/%s", randomString(16))
-		testCmd := fmt.Sprintf("touch%%20%s", randFilePath)
+		randFilePath := "/tmp/" + randomString(16)
+		testCmd := "touch%%20" + randFilePath
 		retCode := sparkUIHTTPQuery(ctx, "127.0.0.1", port, testCmd)
 		// We expect to receive a 403 error
 		if retCode != 403 {

--- a/detector/cve/cve20236019/cve20236019.go
+++ b/detector/cve/cve20236019/cve20236019.go
@@ -184,10 +184,10 @@ func isDashboardPresent(ctx context.Context) bool {
 // attemptExploit attempts to exploit the vulnerability by touching a random file via HTTP query
 func attemptExploit(ctx context.Context) string {
 	// Generate a random file path
-	randomFilePath := fmt.Sprintf("/tmp/%s", generateRandomString(16))
+	randomFilePath := "/tmp/" + generateRandomString(16)
 
 	// Format the command for the query
-	testCmd := fmt.Sprintf("touch%%20%s", randomFilePath)
+	testCmd := "touch%%20" + randomFilePath
 	// Perform the HTTP query
 	statusCode := rayRequest(ctx, "127.0.0.1", 8265, testCmd)
 	log.Infof("HTTP request returned status code: %d", statusCode)

--- a/detector/weakcredentials/winlocal/samreg/crypto.go
+++ b/detector/weakcredentials/winlocal/samreg/crypto.go
@@ -20,7 +20,7 @@ import (
 	"crypto/des"
 	"crypto/md5"
 	"crypto/rc4"
-	"fmt"
+	"errors"
 	"slices"
 )
 
@@ -54,7 +54,7 @@ const (
 )
 
 var (
-	errInvalidRIDSize = fmt.Errorf("RID cannot be derived: is not 4 bytes")
+	errInvalidRIDSize = errors.New("RID cannot be derived: is not 4 bytes")
 )
 
 // transformRID performs a set of bitwise operations on the provided key to derive one of the two
@@ -138,7 +138,7 @@ func decryptAESHash(rid []byte, syskey, hash []byte, iv []byte) ([]byte, error) 
 	}
 
 	if len(hash)%aes.BlockSize != 0 {
-		return nil, fmt.Errorf("hash length not aligned with AES block size")
+		return nil, errors.New("hash length not aligned with AES block size")
 	}
 
 	block, err := aes.NewCipher(syskey)

--- a/detector/weakcredentials/winlocal/samreg/domainf.go
+++ b/detector/weakcredentials/winlocal/samreg/domainf.go
@@ -21,7 +21,7 @@ import (
 	"crypto/md5"
 	"crypto/rc4"
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"slices"
 )
 
@@ -30,9 +30,9 @@ const (
 )
 
 var (
-	errDomainFTooShort = fmt.Errorf("domain F structure is too short")
-	errInvalidChecksum = fmt.Errorf("error while deriving syskey: invalid checksum")
-	errInvalidRevision = fmt.Errorf("error while deriving syskey: invalid revision")
+	errDomainFTooShort = errors.New("domain F structure is too short")
+	errInvalidChecksum = errors.New("error while deriving syskey: invalid checksum")
+	errInvalidRevision = errors.New("error while deriving syskey: invalid revision")
 )
 
 // domainF is a lazy-parsed domain F structure containing the domain's information in the

--- a/detector/weakcredentials/winlocal/samreg/samreg.go
+++ b/detector/weakcredentials/winlocal/samreg/samreg.go
@@ -16,6 +16,7 @@
 package samreg
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/google/osv-scalibr/common/windows/registry"
@@ -27,9 +28,9 @@ const (
 )
 
 var (
-	errFailedToParseUsers   = fmt.Errorf("SAM hive: failed to parse users")
-	errFailedToParseDomainF = fmt.Errorf("SAM hive: failed to parse domain F structure")
-	errFailedToOpenDomain   = fmt.Errorf("SAM hive: failed to open the account domain registry")
+	errFailedToParseUsers   = errors.New("SAM hive: failed to parse users")
+	errFailedToParseDomainF = errors.New("SAM hive: failed to parse domain F structure")
+	errFailedToOpenDomain   = errors.New("SAM hive: failed to open the account domain registry")
 )
 
 // SAMRegistry is a wrapper around a loaded SAM registry.

--- a/detector/weakcredentials/winlocal/samreg/userf.go
+++ b/detector/weakcredentials/winlocal/samreg/userf.go
@@ -14,14 +14,14 @@
 
 package samreg
 
-import "fmt"
+import "errors"
 
 const (
 	userFAccountEnabledOffset = 0x38
 )
 
 var (
-	errUserFTooShort = fmt.Errorf("userF structure is too short")
+	errUserFTooShort = errors.New("userF structure is too short")
 )
 
 // userF is a lazy-parsed user F structure containing the user's information in the SAM hive.

--- a/detector/weakcredentials/winlocal/samreg/userv.go
+++ b/detector/weakcredentials/winlocal/samreg/userv.go
@@ -17,14 +17,14 @@ package samreg
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
+	"errors"
 
 	"golang.org/x/text/encoding/unicode"
 )
 
 var (
-	errReadOutOfBounds = fmt.Errorf("failed to read: out of bounds")
-	errNoHashInfoFound = fmt.Errorf("no hash information found")
+	errReadOutOfBounds = errors.New("failed to read: out of bounds")
+	errNoHashInfoFound = errors.New("no hash information found")
 )
 
 // userV is the V structure containing the user's information in the SAM hive.

--- a/detector/weakcredentials/winlocal/systemreg/systemreg.go
+++ b/detector/weakcredentials/winlocal/systemreg/systemreg.go
@@ -17,6 +17,7 @@ package systemreg
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/google/osv-scalibr/common/windows/registry"
@@ -26,7 +27,7 @@ import (
 var (
 	syskeyPaths = []string{"JD", "Skew1", "GBG", "Data"}
 
-	errNoCurrentControlSet = fmt.Errorf("system hive: failed to find CurrentControlSet")
+	errNoCurrentControlSet = errors.New("system hive: failed to find CurrentControlSet")
 )
 
 // SystemRegistry is a wrapper around a SYSTEM registry.

--- a/detector/weakcredentials/winlocal/winlocal_dummy.go
+++ b/detector/weakcredentials/winlocal/winlocal_dummy.go
@@ -18,7 +18,7 @@ package winlocal
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/google/osv-scalibr/detector"
 	scalibrfs "github.com/google/osv-scalibr/fs"
@@ -55,5 +55,5 @@ func (Detector) RequiredExtractors() []string { return nil }
 
 // Scan starts the scan.
 func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *inventoryindex.InventoryIndex) ([]*detector.Finding, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+	return nil, errors.New("only supported on Windows")
 }

--- a/extractor/filesystem/containers/containerd/containerd_linux.go
+++ b/extractor/filesystem/containers/containerd/containerd_linux.go
@@ -20,6 +20,7 @@ package containerd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -352,13 +353,13 @@ func snapshotsBucketByDigest(tx *bolt.Tx) ([]string, error) {
 	var snapshotsBucketByDigest []string
 	//  metadata db structure: v1-> snapshots -> <snapshot_digest> -> <snapshot_info_fields>
 	if tx == nil {
-		return snapshotsBucketByDigest, fmt.Errorf("The transaction is nil")
+		return snapshotsBucketByDigest, errors.New("The transaction is nil")
 	}
 	if tx.Bucket([]byte("v1")) == nil {
-		return snapshotsBucketByDigest, fmt.Errorf("Could not find the v1 bucket in the metadata.db file")
+		return snapshotsBucketByDigest, errors.New("Could not find the v1 bucket in the metadata.db file")
 	}
 	if tx.Bucket([]byte("v1")).Bucket([]byte("snapshots")) == nil {
-		return snapshotsBucketByDigest, fmt.Errorf("Could not find the snapshots bucket in the metadata.db file")
+		return snapshotsBucketByDigest, errors.New("Could not find the snapshots bucket in the metadata.db file")
 	}
 	snapshotsMetadataBucket := tx.Bucket([]byte("v1")).Bucket([]byte("snapshots"))
 	err := snapshotsMetadataBucket.ForEach(func(k []byte, v []byte) error {

--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -17,6 +17,7 @@ package filesystem
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -39,7 +40,7 @@ import (
 var (
 	// ErrNotRelativeToScanRoots is returned when one of the file or directory to be retrieved or
 	// skipped is not relative to any of the scan roots.
-	ErrNotRelativeToScanRoots = fmt.Errorf("path not relative to any of the scan roots")
+	ErrNotRelativeToScanRoots = errors.New("path not relative to any of the scan roots")
 )
 
 // Extractor is the filesystem-based inventory extraction plugin, used to extract inventory data
@@ -202,7 +203,7 @@ func InitWalkContext(ctx context.Context, config *Config, absScanRoots []*scalib
 func RunFS(ctx context.Context, config *Config, wc *walkContext) ([]*extractor.Inventory, []*plugin.Status, error) {
 	start := time.Now()
 	if wc == nil || wc.fs == nil {
-		return nil, nil, fmt.Errorf("walk context is nil")
+		return nil, nil, errors.New("walk context is nil")
 	}
 
 	var err error

--- a/extractor/filesystem/filesystem_test.go
+++ b/extractor/filesystem/filesystem_test.go
@@ -445,7 +445,7 @@ func TestRunFS(t *testing.T) {
 			},
 			wantStatus: []*plugin.Status{
 				{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
-					Status: plugin.ScanStatusPartiallySucceeded, FailureReason: fmt.Sprintf("%s: extraction failed", path1),
+					Status: plugin.ScanStatusPartiallySucceeded, FailureReason: path1 + ": extraction failed",
 				}},
 			},
 			wantInodeCount: 6,
@@ -458,7 +458,7 @@ func TestRunFS(t *testing.T) {
 			wantInv: []*extractor.Inventory{},
 			wantStatus: []*plugin.Status{
 				{Name: "ex1", Version: 1, Status: &plugin.ScanStatus{
-					Status: plugin.ScanStatusFailed, FailureReason: fmt.Sprintf("%s: extraction failed", path1),
+					Status: plugin.ScanStatusFailed, FailureReason: path1 + ": extraction failed",
 				}},
 			},
 			wantInodeCount: 6,

--- a/extractor/filesystem/language/dotnet/depsjson/depsjson.go
+++ b/extractor/filesystem/language/dotnet/depsjson/depsjson.go
@@ -18,7 +18,7 @@ package depsjson
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -157,7 +157,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 	// Check if the decoded content is empty (i.e., no libraries)
 	if len(deps.Libraries) == 0 {
 		log.Warn("Empty deps.json file or no libraries found")
-		return nil, fmt.Errorf("empty deps.json file or no libraries found")
+		return nil, errors.New("empty deps.json file or no libraries found")
 	}
 
 	var inventories []*extractor.Inventory

--- a/extractor/filesystem/language/javascript/bunlock/bunlock.go
+++ b/extractor/filesystem/language/javascript/bunlock/bunlock.go
@@ -81,13 +81,13 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 // specified as a tuple in a bun.lock
 func structurePackageDetails(pkg []any) (string, string, string, error) {
 	if len(pkg) == 0 {
-		return "", "", "", fmt.Errorf("empty package tuple")
+		return "", "", "", errors.New("empty package tuple")
 	}
 
 	str, ok := pkg[0].(string)
 
 	if !ok {
-		return "", "", "", fmt.Errorf("first element of package tuple is not a string")
+		return "", "", "", errors.New("first element of package tuple is not a string")
 	}
 
 	str, isScoped := strings.CutPrefix(str, "@")

--- a/extractor/filesystem/language/javascript/yarnlock/yarnlock.go
+++ b/extractor/filesystem/language/javascript/yarnlock/yarnlock.go
@@ -18,6 +18,7 @@ package yarnlock
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -108,7 +109,7 @@ func groupYarnPackageDescriptions(ctx context.Context, scanner *bufio.Scanner) (
 			}
 			current = &packageDescription{header: line}
 		} else if current == nil {
-			return nil, fmt.Errorf("malformed yarn.lock")
+			return nil, errors.New("malformed yarn.lock")
 		} else {
 			current.props = append(current.props, line)
 		}

--- a/extractor/filesystem/language/python/condameta/condameta.go
+++ b/extractor/filesystem/language/python/condameta/condameta.go
@@ -18,6 +18,7 @@ package condameta
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -159,7 +160,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 
 	// Return an empty slice if the package name or version is empty
 	if pkg.Name == "" || pkg.Version == "" {
-		return nil, fmt.Errorf("package name or version is empty")
+		return nil, errors.New("package name or version is empty")
 	}
 
 	inventory := &extractor.Inventory{

--- a/extractor/filesystem/language/rust/cargoauditable/cargoauditable.go
+++ b/extractor/filesystem/language/rust/cargoauditable/cargoauditable.go
@@ -129,7 +129,7 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	reader, ok := input.Reader.(io.ReaderAt)
 	if !ok {
-		return nil, fmt.Errorf("input.Reader is not a ReaderAt")
+		return nil, errors.New("input.Reader is not a ReaderAt")
 	}
 
 	dependencyInfo, err := rustaudit.GetDependencyInfo(reader)

--- a/extractor/filesystem/language/swift/swiftutils/podfilelock.go
+++ b/extractor/filesystem/language/swift/swiftutils/podfilelock.go
@@ -16,6 +16,7 @@
 package swiftutils
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -43,7 +44,7 @@ func ParsePodfileLock(reader io.Reader) ([]Package, error) {
 
 	// Check if the file is empty
 	if len(bytes) == 0 {
-		return nil, fmt.Errorf("file is empty")
+		return nil, errors.New("file is empty")
 	}
 
 	var podfile podfileLock
@@ -62,7 +63,7 @@ func ParsePodfileLock(reader io.Reader) ([]Package, error) {
 		case string:
 			podBlob = v
 		default:
-			return nil, fmt.Errorf("malformed Podfile.lock")
+			return nil, errors.New("malformed Podfile.lock")
 		}
 
 		splits := strings.Split(podBlob, " ")

--- a/extractor/filesystem/os/cos/cos.go
+++ b/extractor/filesystem/os/cos/cos.go
@@ -185,12 +185,12 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 
 func toDistro(m *Metadata) string {
 	if m.OSVersionID != "" {
-		return fmt.Sprintf("cos-%s", m.OSVersionID)
+		return "cos-" + m.OSVersionID
 	}
 
 	if m.OSVersion != "" {
 		log.Warnf("VERSION_ID not set in os-release, fallback to VERSION")
-		return fmt.Sprintf("cos-%s", m.OSVersion)
+		return "cos-" + m.OSVersion
 	}
 	log.Errorf("VERSION and VERSION_ID not set in os-release")
 	return ""

--- a/extractor/filesystem/os/kernel/module/module.go
+++ b/extractor/filesystem/os/kernel/module/module.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"debug/elf"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -175,7 +176,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 	// to identify malicious modules if the author intentionally stripped the module name.
 	section := elfFile.Section(".modinfo")
 	if section == nil {
-		return nil, fmt.Errorf("no .modinfo section found")
+		return nil, errors.New("no .modinfo section found")
 	}
 
 	sectionData, err := section.Data()

--- a/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
+++ b/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
@@ -17,6 +17,7 @@ package vmlinuz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -169,7 +170,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 	}
 
 	if len(magicType) == 0 || magicType[0] != "Linux kernel" {
-		return nil, fmt.Errorf("no match with linux kernel found")
+		return nil, errors.New("no match with linux kernel found")
 	}
 
 	metadata := parseVmlinuzMetadata(magicType)

--- a/extractor/filesystem/os/macapps/macapps.go
+++ b/extractor/filesystem/os/macapps/macapps.go
@@ -17,6 +17,7 @@ package macapps
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -169,7 +170,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) (*extractor.Inv
 	var metadata Metadata
 
 	if !ok {
-		return nil, fmt.Errorf("input.Reader does not support readseeker")
+		return nil, errors.New("input.Reader does not support readseeker")
 	}
 	if string(header) == "bplist00" {
 		// Binary plist

--- a/extractor/standalone/containers/containerd/containerd_linux.go
+++ b/extractor/standalone/containers/containerd/containerd_linux.go
@@ -19,7 +19,7 @@ package containerd
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -148,7 +148,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 	}
 
 	if e.client == nil {
-		return inventory, fmt.Errorf("Containerd API client is not initialized")
+		return inventory, errors.New("Containerd API client is not initialized")
 	}
 
 	ctrMetadata, err := containersFromAPI(ctx, e.client)

--- a/extractor/standalone/containers/containerd/fakeclient/fake_containerd_client.go
+++ b/extractor/standalone/containers/containerd/fakeclient/fake_containerd_client.go
@@ -19,6 +19,7 @@ package fakeclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	containerd "github.com/containerd/containerd"
@@ -135,7 +136,7 @@ func (s *TasksService) List(ctx context.Context, in *tasks.ListTasksRequest, opt
 
 	ns, ok := namespaces.Namespace(ctx)
 	if !ok {
-		return &tasks.ListTasksResponse{Tasks: []*task.Process{}}, fmt.Errorf("no namespace found in context")
+		return &tasks.ListTasksResponse{Tasks: []*task.Process{}}, errors.New("no namespace found in context")
 	}
 
 	ids := s.nssTaskIDs[ns]

--- a/extractor/standalone/windows/dismpatch/dismpatch_dummy.go
+++ b/extractor/standalone/windows/dismpatch/dismpatch_dummy.go
@@ -18,7 +18,7 @@ package dismpatch
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/standalone"
@@ -47,5 +47,5 @@ func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabili
 
 // Extract is a no-op for Linux.
 func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([]*extractor.Inventory, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+	return nil, errors.New("only supported on Windows")
 }

--- a/extractor/standalone/windows/ospackages/ospackages_dummy.go
+++ b/extractor/standalone/windows/ospackages/ospackages_dummy.go
@@ -18,7 +18,7 @@ package ospackages
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"runtime"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -63,7 +63,7 @@ func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabili
 
 // Extract is a no-op for Linux.
 func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([]*extractor.Inventory, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+	return nil, errors.New("only supported on Windows")
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.

--- a/extractor/standalone/windows/regosversion/regosversion_dummy.go
+++ b/extractor/standalone/windows/regosversion/regosversion_dummy.go
@@ -18,7 +18,7 @@ package regosversion
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"runtime"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -63,7 +63,7 @@ func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabili
 
 // Extract is a no-op for non-Windows platforms.
 func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([]*extractor.Inventory, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+	return nil, errors.New("only supported on Windows")
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.

--- a/extractor/standalone/windows/regpatchlevel/regpatchlevel_dummy.go
+++ b/extractor/standalone/windows/regpatchlevel/regpatchlevel_dummy.go
@@ -18,7 +18,7 @@ package regpatchlevel
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"runtime"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -63,7 +63,7 @@ func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabili
 
 // Extract is a no-op for Linux.
 func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([]*extractor.Inventory, error) {
-	return nil, fmt.Errorf("only supported on Windows")
+	return nil, errors.New("only supported on Windows")
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -163,7 +163,7 @@ func (s *ScanStatus) String() string {
 	case ScanStatusPartiallySucceeded:
 		return "PARTIALLY_SUCCEEDED"
 	case ScanStatusFailed:
-		return fmt.Sprintf("FAILED: %s", s.FailureReason)
+		return "FAILED: " + s.FailureReason
 	}
 	return "UNSPECIFIED"
 }

--- a/scalibr.go
+++ b/scalibr.go
@@ -44,8 +44,8 @@ import (
 )
 
 var (
-	errNoScanRoot            = fmt.Errorf("no scan root specified")
-	errFilesWithSeveralRoots = fmt.Errorf("can't extract specific files with several scan roots")
+	errNoScanRoot            = errors.New("no scan root specified")
+	errFilesWithSeveralRoots = errors.New("can't extract specific files with several scan roots")
 )
 
 // Scanner is the main entry point of the scanner.
@@ -263,7 +263,7 @@ func (s Scanner) ScanContainer(ctx context.Context, img *image.Image, config *Sc
 	}
 
 	if len(chainLayers) == 0 {
-		return nil, fmt.Errorf("no chain layers found")
+		return nil, errors.New("no chain layers found")
 	}
 
 	finalChainLayer := chainLayers[len(chainLayers)-1]


### PR DESCRIPTION
This ensures that certain string operators are performed using the fastest method possible, based on [benchmarks](https://github.com/catenacyber/perfsprint/issues/28#issuecomment-2214439134) - while in most cases these are not likely to be the slowest component, since the linter can be enforced and automatically fix it's findings, we shouldn't have to worry over it.

As a bonus, switching to using `errors.New` means we should be able to better lint error messages in the future.

Relates to #274