### PR TITLE
fix: layer tracing logic after optimisation

### DIFF
--- a/artifact/image/layerscanning/trace/trace.go
+++ b/artifact/image/layerscanning/trace/trace.go
@@ -136,7 +136,6 @@ func PopulateLayerDetails(ctx context.Context, inventory []*extractor.Inventory,
 				if err != nil {
 					break
 				}
-
 			} else {
 				// If none of the files from the inventory are present in the underlying layer, then there
 				// will be no difference in the extracted inventory from oldChainLayer, so extraction can be

--- a/artifact/image/layerscanning/trace/trace.go
+++ b/artifact/image/layerscanning/trace/trace.go
@@ -103,6 +103,7 @@ func PopulateLayerDetails(ctx context.Context, inventory []*extractor.Inventory,
 
 		var foundOrigin bool
 		fileLocation := inv.Locations[0]
+		lastScannedLayerIndex := len(chainLayers) - 1
 
 		// Go backwards through the chain layers and find the first layer where the inventory is not
 		// present. Such layer is the layer in which the inventory was introduced. If the inventory is
@@ -135,6 +136,7 @@ func PopulateLayerDetails(ctx context.Context, inventory []*extractor.Inventory,
 				if err != nil {
 					break
 				}
+
 			} else {
 				// If none of the files from the inventory are present in the underlying layer, then there
 				// will be no difference in the extracted inventory from oldChainLayer, so extraction can be
@@ -154,12 +156,15 @@ func PopulateLayerDetails(ctx context.Context, inventory []*extractor.Inventory,
 				}
 			}
 
-			// If the inventory is not present in the old layer, then it was introduced in layer i+1.
+			// If the inventory is not present in the old layer, then it was introduced in the previous layer we actually scanned
 			if !foundPackage {
-				layerDetails = chainLayerDetailsList[i+1]
+				layerDetails = chainLayerDetailsList[lastScannedLayerIndex]
 				foundOrigin = true
 				break
 			}
+
+			// This is now the latest scanned layer
+			lastScannedLayerIndex = i
 		}
 
 		// If the inventory is present in every layer, then it means it was introduced in the first


### PR DESCRIPTION
The previous layer is no longer always the layer that we last read and found the package in layer tracing. We keep track of the actual last layer scanned, and use that as the origin layer index when the package cannot be found.

Ideally we also add some unit test cases to catch this.

Tested this change in osv-scanner and it seems to fix the issue.