### PR TITLE
chore: disable `nlreturn` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,7 +58,6 @@ linters:
     - nakedret
     - nilerr
 #    - nilnil
-#    - nlreturn
 #    - noctx
     - nolintlint
 #    - nosprintfhostport
@@ -89,6 +88,7 @@ linters:
     - zerologlint
   disable-all: true
 #  disable:
+#    - nlreturn     # Not feasible until it's supported by the internal linter
 #    - paralleltest # Parallel tests mixes up log lines of multiple tests in the internal test runner
 #    - tparallel    # Parallel tests mixes up log lines of multiple tests in the internal test runner
 


### PR DESCRIPTION
[We've decided to disable this linter for now](https://github.com/google/osv-scalibr/pull/525#issuecomment-2702397088) as it's likely going to be very annoying without the internal linter enforcing it

Relates to #274