### PR TITLE
refactor: remove unneeded random seeding, as `Seed` is now already randomized since Go v1.20

### DIFF
--- a/detector/cve/cve20236019/cve20236019.go
+++ b/detector/cve/cve20236019/cve20236019.go
@@ -225,8 +225,6 @@ func fileExists(filesys scalibrfs.FS, path string) bool {
 
 // Generate a random string of the given length
 func generateRandomString(length int) string {
-	rand.Seed(time.Now().UnixNano())
-
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	bytes := make([]byte, length)
 	for i := range length {


### PR DESCRIPTION
Even if we feel this is needed, the method itself is deprecated in favor of creating a local generator with a specific seed