### PR TITLE
fix: update `deps.dev/util/resolve`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.4
 require (
 	deps.dev/api/v3 v3.0.0-20250307021655-d811e36f9cad
 	deps.dev/util/maven v0.0.0-20250307021655-d811e36f9cad
-	deps.dev/util/resolve v0.0.0-20250307021655-d811e36f9cad
+	deps.dev/util/resolve v0.0.0-20250310223405-f4cf91c9e684
 	deps.dev/util/semver v0.0.0-20250307021655-d811e36f9cad
 	github.com/BurntSushi/toml v1.3.2
 	github.com/CycloneDX/cyclonedx-go v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ deps.dev/api/v3 v3.0.0-20250307021655-d811e36f9cad h1:eBGvlhIacSTSCIyylfzAo0tEBU
 deps.dev/api/v3 v3.0.0-20250307021655-d811e36f9cad/go.mod h1:o6PwfRErnKxbT8Sdij64ZMiTqMNxPsYwfymiyjXPh7A=
 deps.dev/util/maven v0.0.0-20250307021655-d811e36f9cad h1:ei3Dw2a5LRHnFN7sqr7JYQUs7ByGcrM933pDMiJ/lkg=
 deps.dev/util/maven v0.0.0-20250307021655-d811e36f9cad/go.mod h1:eGrXziwI7scSGrwIj+5EBHtTeSxAZD/yi8Hb3nFXesA=
-deps.dev/util/resolve v0.0.0-20250307021655-d811e36f9cad h1:xwvDpiWS4G32xrJ/V+9K7sysodQtu85f98BS2lm4M+0=
-deps.dev/util/resolve v0.0.0-20250307021655-d811e36f9cad/go.mod h1:gjq1md9qho9B7kc6kJHpKnEnMSr1PQuRrpX3XE66cJo=
+deps.dev/util/resolve v0.0.0-20250310223405-f4cf91c9e684 h1:108cMu5nB8Xc5kmoMDORmGm3rwS9x4IH10rUvCu3NBU=
+deps.dev/util/resolve v0.0.0-20250310223405-f4cf91c9e684/go.mod h1:y8YIleznCUaoZGI9XKQrVNrNd8gcVuPzvAJ7BBcJo5Q=
 deps.dev/util/semver v0.0.0-20250307021655-d811e36f9cad h1:uRcYzknOHTHsOaqyJCNu0ptaKqr6kn1BnUiGZivJEMo=
 deps.dev/util/semver v0.0.0-20250307021655-d811e36f9cad/go.mod h1:jjJweVqtuMQ7Q4zlTQ/kCHpboojkRvpMYlhy/c93DVU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=


### PR DESCRIPTION
This resolves an issue when running `go list` (which IDEs use in particular) due to an invalid reference being introduced upstream: https://github.com/google/deps.dev/pull/203