### PR TITLE
chore: enable `staticcheck` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -72,7 +72,7 @@ linters:
     - sloglint
     - spancheck
     - sqlclosecheck
-#    - staticcheck
+    - staticcheck
 #    - stylecheck
     - tagalign
     - tenv


### PR DESCRIPTION
#539 addressed the only violation, so we can now enable this

Relates to #274