### PR TITLE
fix: always provide a context when making http requests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,7 +58,7 @@ linters:
     - nakedret
     - nilerr
 #    - nilnil
-#    - noctx
+    - noctx
     - nolintlint
     - nosprintfhostport
     - perfsprint


### PR DESCRIPTION
This also enables the `noctx` lint to enforce this in future

Relates to #274