### PR TITLE
fix: return after encountering an error when trying to talk to DAG

### DIFF
--- a/detector/cve/cve202011978/cve202011978.go
+++ b/detector/cve/cve202011978/cve202011978.go
@@ -392,6 +392,7 @@ func triggerAndWaitForDAG(ctx context.Context, airflowIP string, airflowServerPo
 		res, err := http.DefaultClient.Do(req)
 		if err != nil {
 			log.Infof("failed to get task status: %v", err)
+			return false
 		}
 
 		var statusBody map[string]any


### PR DESCRIPTION
I'm pretty sure this is technically a bug, though it might not actually be causing problems as `res` might still not be `nil` in which case I'd expect the JSON decode straight afterwards to fail and return, rather than a panic.

Regardless though I think this should still be returning