### PR TITLE
chore: ensure that `any` is used instead of `interface{}`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -67,7 +67,7 @@ linters:
     - promlinter
 #    - protogetter
     - reassign
-#    - revive
+    - revive
     - rowserrcheck
     - sloglint
     - spancheck
@@ -99,6 +99,10 @@ linters-settings:
       - p: ^testing.T.Parallel$
         pkg: ^testing$
     analyze-types: true
+  revive:
+    rules:
+      - name: use-any
+        disabled: false
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
This mirrors an internal linter, so unsurprisingly we've not got any actual violations.

Note that by configuring `revive` at all we override its default rules, some of which we'll want enabled long-term

Relates to #455
Relates to #274