### PR TITLE
chore: ensure that all packages have comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -121,6 +121,8 @@ linters-settings:
         disabled: false
       - name: indent-error-flow
         disabled: false
+      - name: package-comments
+        disabled: false
       - name: range
         disabled: false
       - name: receiver-naming
@@ -137,6 +139,8 @@ linters-settings:
         disabled: false
 
 issues:
+  include:
+    - EXC0015 # revive package-comments
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-rules:

--- a/detector/weakcredentials/winlocal/winlocal_dummy.go
+++ b/detector/weakcredentials/winlocal/winlocal_dummy.go
@@ -14,6 +14,7 @@
 
 //go:build !windows
 
+// Package winlocal implements a weak passwords detector for local accounts on Windows.
 package winlocal
 
 import (

--- a/extractor/standalone/windows/dismpatch/dismpatch_dummy.go
+++ b/extractor/standalone/windows/dismpatch/dismpatch_dummy.go
@@ -14,6 +14,7 @@
 
 //go:build !windows
 
+// Package dismpatch extract patch level from the DISM command line tool.
 package dismpatch
 
 import (

--- a/extractor/standalone/windows/ospackages/ospackages_dummy.go
+++ b/extractor/standalone/windows/ospackages/ospackages_dummy.go
@@ -14,6 +14,7 @@
 
 //go:build !windows
 
+// Package ospackages extracts installed softwares on Windows.
 package ospackages
 
 import (

--- a/extractor/standalone/windows/regosversion/regosversion_dummy.go
+++ b/extractor/standalone/windows/regosversion/regosversion_dummy.go
@@ -14,6 +14,7 @@
 
 //go:build !windows
 
+// Package regosversion extracts the OS version (build, major, minor release) from the registry.
 package regosversion
 
 import (

--- a/extractor/standalone/windows/regpatchlevel/regpatchlevel_dummy.go
+++ b/extractor/standalone/windows/regpatchlevel/regpatchlevel_dummy.go
@@ -14,6 +14,7 @@
 
 //go:build !windows
 
+// Package regpatchlevel extract patch level from the Windows registry.
 package regpatchlevel
 
 import (


### PR DESCRIPTION
This mirrors an internal linter, though this linter requires that the package comment be in a file that is not ignored e.g. due to `go:build` conditions, meaning it considers a few packages as missing comments as they're in a Windows-only file.

Currently, I've addressed that by copying the comment into a non-Windows file without removing the previous comment, though we might want to discuss what convention we actually follow - I think there's at least two possible ones to consider:
  1. always put the comment in all files in a `go:build` "set" i.e. `xyz_dummy.go` and `xyz_windows.go` (downside being we're having to maintain the comment twice)
  2. always put the package comment in a file that is never ignored when possible (possible downside is that often that can be a file holding utilities rather than the actual meat of the package, and if there isn't such a file then we'd have to do 1. anyway)

Relates to #455
Relates to #274