### PR TITLE
chore: enable `unparam` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,7 +46,6 @@ linters:
     - tenv             # Deprecated
     - testpackage
     - tparallel        # Parallel tests mixes up log lines of multiple tests in the internal test runner
-    - unparam          # TODO(#274): work on enabling this
     - usetesting       # TODO(#274): work on enabling this
     - varnamelen
     - wrapcheck

--- a/artifact/image/layerscanning/image/image.go
+++ b/artifact/image/layerscanning/image/image.go
@@ -260,10 +260,7 @@ func FromV1Image(v1Image v1.Image, config *Config) (*Image, error) {
 	}
 
 	// Remove any unnecessary file nodes from the chain layers based on the configured requirer.
-	bytesRemoved, err := removeUnnecessaryFileNodes(chainLayers, config.Requirer, config.MaxSymlinkDepth)
-	if err != nil {
-		return outputImage, fmt.Errorf("failed to remove unnecessary file nodes: %w", err)
-	}
+	bytesRemoved := removeUnnecessaryFileNodes(chainLayers, config.Requirer, config.MaxSymlinkDepth)
 	outputImage.size -= bytesRemoved
 
 	return outputImage, nil
@@ -300,10 +297,10 @@ func isNodeRequired(node *fileNode, requirer require.FileRequirer) bool {
 // removeUnnecessaryFileNodes removes any file nodes from the chain layers that are not required by
 // the requirer. Symlink nodes are accounted for by preserving target nodes if the symlink node is
 // required.
-func removeUnnecessaryFileNodes(chainLayers []*chainLayer, requirer require.FileRequirer, symlinkDepth int) (int64, error) {
+func removeUnnecessaryFileNodes(chainLayers []*chainLayer, requirer require.FileRequirer, symlinkDepth int) int64 {
 	// If there are no chain layers, then there are no nodes to remove.
 	if len(chainLayers) == 0 {
-		return 0, nil
+		return 0
 	}
 
 	// Prune only the final chain layer since SCALIBR scans the last layer.
@@ -358,7 +355,7 @@ func removeUnnecessaryFileNodes(chainLayers []*chainLayer, requirer require.File
 			bytesRemoved += node.Size()
 		}
 	}
-	return bytesRemoved, nil
+	return bytesRemoved
 }
 
 // addRootDirectoryToChainLayers adds the root ("\"") directory to each chain layer.

--- a/artifact/image/layerscanning/image/image_test.go
+++ b/artifact/image/layerscanning/image/image_test.go
@@ -16,7 +16,6 @@ package image
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -636,8 +635,7 @@ func TestFromTarball(t *testing.T) {
 //  4. Devise a pathtree that will return an error when inserting a path. Make sure that Load()
 //     returns an error.
 func TestFromV1Image(t *testing.T) {
-	ctx := context.Background()
-	fakeImage, err := constructImage(ctx, "1.0", "fake-package-name")
+	fakeImage, err := constructImage("1.0", "fake-package-name")
 	if err != nil {
 		t.Fatalf("Failed to construct image: %v", err)
 	}
@@ -1062,7 +1060,7 @@ func TestInitializeChainLayers(t *testing.T) {
 //
 // Put them in a single tarball to make a single layer and put that layer in an empty image to
 // make the minimal image that will work.
-func constructImage(ctx context.Context, version, fakePackageName string) (*v1.Image, error) {
+func constructImage(version, fakePackageName string) (*v1.Image, error) {
 	// The file containing the fake package version.
 	statusContents := fmt.Sprintf("Package: %s\nVersion: %s\nStatus: install ok installed", fakePackageName, version)
 

--- a/extractor/filesystem/containers/containerd/containerd_test.go
+++ b/extractor/filesystem/containers/containerd/containerd_test.go
@@ -285,6 +285,7 @@ func TestExtract(t *testing.T) {
 	}
 }
 
+//nolint:unparam
 func createFileFromTestData(t *testing.T, root string, subPath string, fileName string, testDataFilePath string) {
 	t.Helper()
 	_ = os.MkdirAll(filepath.Join(root, subPath), 0755)

--- a/guidedremediation/guidedremediation.go
+++ b/guidedremediation/guidedremediation.go
@@ -277,6 +277,7 @@ func readWriterForManifest(manifestPath string, registry string) (manifest.ReadW
 	return nil, fmt.Errorf("unsupported manifest: %q", baseName)
 }
 
+//nolint:unparam // TODO(#454): implement pending
 func readWriterForLockfile(lockfilePath string) (lockfile.ReadWriter, error) {
 	baseName := filepath.Base(lockfilePath)
 	// TODO(#454): package-lock.json when in-place strategy is migrated.


### PR DESCRIPTION
This linter checks for unused functions and parameters, and parameters that have only a single value which is why I've introduced a private global variable in the `containerd` test; that feels a little weird, but I think it's slightly better than having a linter disable comment given it's internal test code.

I've already addressed the main two classes of violations this linter caught in the codebase, so the actual net win for enabling this is the sum of this + these PRs:
  * https://github.com/google/osv-scalibr/pull/520
  * https://github.com/google/osv-scalibr/pull/519
  * https://github.com/google/osv-scalibr/pull/500

There was one new violation that slipped through after #520 was landed, which I've also addressed here

Relates to #274
