### PR TITLE
ci: run linter on `macos-latest`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,11 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,7 +30,11 @@ jobs:
           args: --timeout=5m
   # TODO(#346): we're exploring if only-new-issues will help reduce friction in PRs
   lint-just-new:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Because the linter involves compiling files, it won't lint files that are excluded due to `go:build` directives, so we really should be running the linter across all three OSs - currently running on Windows works but has a number of errors mostly around imports that I suspect are due to file path and line ending differences, but macOS works fine so we might as well start running on that