### PR TITLE
chore: enable more `revive` rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -101,9 +101,39 @@ linters-settings:
     analyze-types: true
   revive:
     rules:
+      - name: blank-imports
+        disabled: false
+      - name: context-as-argument
+        disabled: false
+      - name: context-keys-type
+        disabled: false
+      - name: dot-imports
+        disabled: false
+      - name: empty-block
+        disabled: false
+      - name: error-naming
+        disabled: false
+      - name: error-return
+        disabled: false
+      - name: error-strings
+        disabled: false
+      - name: errorf
+        disabled: false
+      - name: exported
+        disabled: false
       - name: indent-error-flow
         disabled: false
-      - name: use-any
+      - name: range
+        disabled: false
+      - name: receiver-naming
+        disabled: false
+      - name: redefines-builtin-id
+        disabled: false
+      - name: superfluous-else
+        disabled: false
+      - name: time-naming
+        disabled: false
+      - name: unreachable-code
         disabled: false
 
 issues:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -119,8 +119,6 @@ linters-settings:
         disabled: false
       - name: errorf
         disabled: false
-      - name: exported
-        disabled: false
       - name: indent-error-flow
         disabled: false
       - name: range


### PR DESCRIPTION
This enables most of the default `revive` rules which we don't have any violations for.

The remaining ones to be enabled which do have violations are:
  - ~`indent-error-flow` (https://github.com/google/osv-scalibr/pull/562)~
  - `exported`
  - `package-name` (https://github.com/google/osv-scalibr/pull/547)
  - `unexported-return`
  - `unused-parameter`
  - `var-declaration`
  - `var-naming` (https://github.com/google/osv-scalibr/pull/563)

Relates to #274