### PR TITLE
refactor: remove unneeded `else` blocks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -101,6 +101,8 @@ linters-settings:
     analyze-types: true
   revive:
     rules:
+      - name: indent-error-flow
+        disabled: false
       - name: use-any
         disabled: false
 

--- a/detector/cve/cve20242912/cve20242912.go
+++ b/detector/cve/cve20242912/cve20242912.go
@@ -196,9 +196,9 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, ix *in
 	if !isVulnVersion {
 		log.Infof("Version not vulnerable: %q", bentomlVersion)
 		return nil, nil
-	} else {
-		log.Infof("Version is potentially vulnerable: %q", bentomlVersion)
 	}
+
+	log.Infof("Version is potentially vulnerable: %q", bentomlVersion)
 
 	if !CheckAccessibility(ctx, bentomlServerIP, bentomlServerPort) {
 		log.Infof("BentoML server not accessible")

--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -270,9 +270,9 @@ func readLine(scanner *bufio.Scanner, builder *strings.Builder) string {
 		builder.WriteString(l[:len(l)-1])
 		scanner.Scan()
 		return readLine(scanner, builder)
-	} else {
-		builder.WriteString(l)
 	}
+
+	builder.WriteString(l)
 
 	return builder.String()
 }

--- a/extractor/filesystem/os/rpm/rpm_linux.go
+++ b/extractor/filesystem/os/rpm/rpm_linux.go
@@ -331,7 +331,6 @@ func (Extractor) Ecosystem(i *extractor.Inventory) string {
 		return "Red Hat"
 	} else if m.OSID == "rocky" {
 		return "Rocky Linux"
-	} else {
-		return ""
 	}
+	return ""
 }


### PR DESCRIPTION
This helps makes code more readable by avoiding unneeded indenting

Relates to #274