### PR TITLE
refactor: prefer "ID" and "JSON" instead of "Id" and "Json"

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -105,6 +105,8 @@ linters-settings:
         disabled: false
       - name: use-any
         disabled: false
+      - name: var-naming
+        disabled: false
 
 issues:
   max-issues-per-linter: 0

--- a/clients/datasource/internal/pypi/pypi.go
+++ b/clients/datasource/internal/pypi/pypi.go
@@ -15,9 +15,9 @@
 // Package pypi defines the structures to parse PyPI JSON API response.
 package pypi
 
-// JsonResponse defines the response of JSON API.
+// JSONResponse defines the response of JSON API.
 // https://docs.pypi.org/api/json/
-type JsonResponse struct {
+type JSONResponse struct {
 	Info Info  `json:"info"`
 	URLs []URL `json:"urls"`
 }

--- a/clients/datasource/pypi_registry.go
+++ b/clients/datasource/pypi_registry.go
@@ -52,14 +52,14 @@ func NewPyPIRegistryAPIClient(registry string) *PyPIRegistryAPIClient {
 	}
 }
 
-// GetRequiresDist queries the JSON API and returns the requires dist for a specific version.
-func (p *PyPIRegistryAPIClient) GetVersionJson(ctx context.Context, project, version string) (pypi.JsonResponse, error) {
+// GetVersionJSON queries the JSON API and returns the requires dist for a specific version.
+func (p *PyPIRegistryAPIClient) GetVersionJSON(ctx context.Context, project, version string) (pypi.JSONResponse, error) {
 	path, err := url.JoinPath(p.registry, "pypi", project, version, "json")
 	if err != nil {
-		return pypi.JsonResponse{}, err
+		return pypi.JSONResponse{}, err
 	}
 
-	var jsonResp pypi.JsonResponse
+	var jsonResp pypi.JSONResponse
 	err = p.get(ctx, path, false, &jsonResp)
 	return jsonResp, err
 }

--- a/clients/datasource/pypi_registry_test.go
+++ b/clients/datasource/pypi_registry_test.go
@@ -254,11 +254,11 @@ func TestGetVersionJson(t *testing.T) {
 	}
 	`))
 
-	got, err := client.GetVersionJson(context.Background(), "sampleproject", "3.0.0")
+	got, err := client.GetVersionJSON(context.Background(), "sampleproject", "3.0.0")
 	if err != nil {
 		t.Fatalf("failed to get version JSON of PyPI project %s %s: %v", "sampleproject", "3.0.0", err)
 	}
-	want := pypi.JsonResponse{
+	want := pypi.JSONResponse{
 		Info: pypi.Info{
 			RequiresDist: []string{
 				"peppercorn",
@@ -281,6 +281,6 @@ func TestGetVersionJson(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("GetVersionJson(%s, %s) mismatch (-want +got):\n%s", "sampleproject", "3.0.0", diff)
+		t.Errorf("GetVersionJSON(%s, %s) mismatch (-want +got):\n%s", "sampleproject", "3.0.0", diff)
 	}
 }

--- a/clients/resolution/pypi_registry_client.go
+++ b/clients/resolution/pypi_registry_client.go
@@ -41,7 +41,7 @@ func (c *PyPIRegistryClient) Version(ctx context.Context, vk resolve.VersionKey)
 	// Version is not used by the PyPI resolver for now, so here
 	// only returns the VersionKey with yanked or not.
 	// We may need to add more metadata in the future.
-	resp, err := c.api.GetVersionJson(ctx, vk.Name, vk.Version)
+	resp, err := c.api.GetVersionJSON(ctx, vk.Name, vk.Version)
 	if err != nil {
 		return resolve.Version{}, err
 	}
@@ -76,7 +76,7 @@ func (c *PyPIRegistryClient) Versions(ctx context.Context, pk resolve.PackageKey
 			},
 		}
 
-		resp, err := c.api.GetVersionJson(ctx, pk.Name, ver)
+		resp, err := c.api.GetVersionJSON(ctx, pk.Name, ver)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +91,7 @@ func (c *PyPIRegistryClient) Versions(ctx context.Context, pk resolve.PackageKey
 
 // Requirements returns requirements of a version specified by the VersionKey.
 func (c *PyPIRegistryClient) Requirements(ctx context.Context, vk resolve.VersionKey) ([]resolve.RequirementVersion, error) {
-	resp, err := c.api.GetVersionJson(ctx, vk.Name, vk.Version)
+	resp, err := c.api.GetVersionJSON(ctx, vk.Name, vk.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/extractor/standalone/containers/containerd/containerd_test.go
+++ b/extractor/standalone/containers/containerd/containerd_test.go
@@ -38,7 +38,7 @@ func TestExtract(t *testing.T) {
 	tests := []struct {
 		name          string
 		onGoos        []string
-		nssTaskIds    map[string][]string
+		nssTaskIDs    map[string][]string
 		tsks          []*task.Process
 		ctrs          []containerd.Container
 		wantInventory []*extractor.Inventory
@@ -47,7 +47,7 @@ func TestExtract(t *testing.T) {
 		{
 			name:          "valid with no tasks",
 			onGoos:        []string{"linux"},
-			nssTaskIds:    map[string][]string{"default": {}, "k8s.io": {}},
+			nssTaskIDs:    map[string][]string{"default": {}, "k8s.io": {}},
 			tsks:          []*task.Process{},
 			ctrs:          []containerd.Container{},
 			wantInventory: []*extractor.Inventory{},
@@ -55,7 +55,7 @@ func TestExtract(t *testing.T) {
 		{
 			name:       "valid with tasks and rootfs",
 			onGoos:     []string{"linux"},
-			nssTaskIds: map[string][]string{"default": {"123456789"}, "k8s.io": {"567890123"}},
+			nssTaskIDs: map[string][]string{"default": {"123456789"}, "k8s.io": {"567890123"}},
 			tsks:       []*task.Process{{ID: "123456789", ContainerID: "", Pid: 12345}, {ID: "567890123", ContainerID: "", Pid: 5678}},
 			ctrs:       []containerd.Container{fakeclient.NewFakeContainer("123456789", "image1", "digest1", "/run/containerd/io.containerd.runtime.v2.task/default/123456789/rootfs"), fakeclient.NewFakeContainer("567890123", "image2", "digest2", "/run/containerd/io.containerd.runtime.v2.task/k8s.io/567890123/rootfs")},
 			wantInventory: []*extractor.Inventory{
@@ -92,7 +92,7 @@ func TestExtract(t *testing.T) {
 		{
 			name:       "valid with tasks and no rootfs",
 			onGoos:     []string{"linux"},
-			nssTaskIds: map[string][]string{"default": {"123456789"}, "k8s.io": {"567890123"}},
+			nssTaskIDs: map[string][]string{"default": {"123456789"}, "k8s.io": {"567890123"}},
 			tsks:       []*task.Process{{ID: "123456789", ContainerID: "", Pid: 12345}, {ID: "567890123", ContainerID: "", Pid: 5678}},
 			ctrs:       []containerd.Container{fakeclient.NewFakeContainer("123456789", "image1", "digest1", ""), fakeclient.NewFakeContainer("567890123", "image2", "digest2", "")},
 			wantInventory: []*extractor.Inventory{
@@ -129,7 +129,7 @@ func TestExtract(t *testing.T) {
 		{
 			name:       "valid with tasks and relative-path-only rootfs",
 			onGoos:     []string{"linux"},
-			nssTaskIds: map[string][]string{"default": {"123456788"}, "k8s.io": {"567890122"}},
+			nssTaskIDs: map[string][]string{"default": {"123456788"}, "k8s.io": {"567890122"}},
 			tsks:       []*task.Process{{ID: "123456788", ContainerID: "", Pid: 12346}, {ID: "567890122", ContainerID: "", Pid: 5677}},
 			ctrs:       []containerd.Container{fakeclient.NewFakeContainer("123456788", "image1", "digest1", "test/rootfs"), fakeclient.NewFakeContainer("567890122", "image2", "digest2", "test2/rootfs")},
 			wantInventory: []*extractor.Inventory{
@@ -172,7 +172,7 @@ func TestExtract(t *testing.T) {
 			}
 
 			var input *standalone.ScanInput
-			cli, err := fakeclient.NewFakeCtrdClient(context.Background(), tt.nssTaskIds, tt.tsks, tt.ctrs)
+			cli, err := fakeclient.NewFakeCtrdClient(context.Background(), tt.nssTaskIDs, tt.tsks, tt.ctrs)
 			if err != nil {
 				t.Fatalf("NewFakeCtrdClient() error: %v", err)
 			}


### PR DESCRIPTION
This enables the `var-naming` rule within `revive`, which by default mirrors `golint`

Relates to #274