### PR TITLE
fix(gomod): prefer version specified by `toolchain` directive when present

### DIFF
--- a/extractor/filesystem/language/golang/gomod/gomod.go
+++ b/extractor/filesystem/language/golang/gomod/gomod.go
@@ -131,9 +131,11 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 
 	// Give the toolchain version priority, if present
 	if parsedLockfile.Toolchain != nil && parsedLockfile.Toolchain.Name != "" {
+		version, _, _ := strings.Cut(parsedLockfile.Toolchain.Name, "-")
+
 		packages[mapKey{name: "stdlib"}] = &extractor.Inventory{
 			Name:      "stdlib",
-			Version:   strings.TrimPrefix(parsedLockfile.Toolchain.Name, "go"),
+			Version:   strings.TrimPrefix(version, "go"),
 			Locations: []string{input.Path},
 		}
 	}

--- a/extractor/filesystem/language/golang/gomod/gomod.go
+++ b/extractor/filesystem/language/golang/gomod/gomod.go
@@ -133,7 +133,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	if parsedLockfile.Toolchain != nil && parsedLockfile.Toolchain.Name != "" {
 		packages[mapKey{name: "stdlib"}] = &extractor.Inventory{
 			Name:      "stdlib",
-			Version:   parsedLockfile.Toolchain.Name,
+			Version:   strings.TrimPrefix(parsedLockfile.Toolchain.Name, "go"),
 			Locations: []string{input.Path},
 		}
 	}

--- a/extractor/filesystem/language/golang/gomod/gomod.go
+++ b/extractor/filesystem/language/golang/gomod/gomod.go
@@ -129,6 +129,15 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		}
 	}
 
+	// Give the toolchain version priority, if present
+	if parsedLockfile.Toolchain != nil && parsedLockfile.Toolchain.Name != "" {
+		packages[mapKey{name: "stdlib"}] = &extractor.Inventory{
+			Name:      "stdlib",
+			Version:   parsedLockfile.Toolchain.Name,
+			Locations: []string{input.Path},
+		}
+	}
+
 	// The map values might have changed after replacement so we need to run another
 	// deduplication pass.
 	dedupedPs := map[mapKey]*extractor.Inventory{}

--- a/extractor/filesystem/language/golang/gomod/gomod_test.go
+++ b/extractor/filesystem/language/golang/gomod/gomod_test.go
@@ -133,7 +133,7 @@ func TestExtractor_Extract(t *testing.T) {
 				},
 				{
 					Name:      "stdlib",
-					Version:   "go1.23.6",
+					Version:   "1.23.6",
 					Locations: []string{"testdata/toolchain.mod"},
 				},
 			},

--- a/extractor/filesystem/language/golang/gomod/gomod_test.go
+++ b/extractor/filesystem/language/golang/gomod/gomod_test.go
@@ -121,6 +121,24 @@ func TestExtractor_Extract(t *testing.T) {
 			},
 		},
 		{
+			Name: "toolchain",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/toolchain.mod",
+			},
+			WantInventory: []*extractor.Inventory{
+				{
+					Name:      "github.com/BurntSushi/toml",
+					Version:   "1.0.0",
+					Locations: []string{"testdata/toolchain.mod"},
+				},
+				{
+					Name:      "stdlib",
+					Version:   "go1.23.6",
+					Locations: []string{"testdata/toolchain.mod"},
+				},
+			},
+		},
+		{
 			Name: "indirect packages",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/indirect-packages.mod",

--- a/extractor/filesystem/language/golang/gomod/gomod_test.go
+++ b/extractor/filesystem/language/golang/gomod/gomod_test.go
@@ -139,6 +139,24 @@ func TestExtractor_Extract(t *testing.T) {
 			},
 		},
 		{
+			Name: "toolchain with suffix",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/toolchain-with-suffix.mod",
+			},
+			WantInventory: []*extractor.Inventory{
+				{
+					Name:      "github.com/BurntSushi/toml",
+					Version:   "1.0.0",
+					Locations: []string{"testdata/toolchain-with-suffix.mod"},
+				},
+				{
+					Name:      "stdlib",
+					Version:   "1.23.6",
+					Locations: []string{"testdata/toolchain-with-suffix.mod"},
+				},
+			},
+		},
+		{
 			Name: "indirect packages",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/indirect-packages.mod",

--- a/extractor/filesystem/language/golang/gomod/testdata/toolchain-with-suffix.mod
+++ b/extractor/filesystem/language/golang/gomod/testdata/toolchain-with-suffix.mod
@@ -1,0 +1,9 @@
+module my-library
+
+go 1.23.5
+
+toolchain go1.23.6-xyz
+
+require (
+	github.com/BurntSushi/toml v1.0.0
+)

--- a/extractor/filesystem/language/golang/gomod/testdata/toolchain.mod
+++ b/extractor/filesystem/language/golang/gomod/testdata/toolchain.mod
@@ -1,0 +1,9 @@
+module my-library
+
+go 1.23.5
+
+toolchain go1.23.6
+
+require (
+	github.com/BurntSushi/toml v1.0.0
+)


### PR DESCRIPTION
Unlike with `go`, the `toolchain` directive holds the name of an actual toolchain which is prefixed with `go` and can have a suffix - when comparing, [these should be ignored](https://go.dev/doc/toolchain#name):

> Toolchains are compared by comparing the version V embedded in the name (dropping the initial go and discarding off any suffix beginning with -)

~However, I'm not sure if that's an extractor-level concern - if it's not, then I think we'll need to include a custom version comparator for `semantic` to handle that, and ensure comparators elsewhere like osv.dev account for this.~

Resolves https://github.com/google/osv-scanner/issues/1606