### PR TITLE
fix: CDX extractor should be extracting nested components

### DIFF
--- a/extractor/filesystem/sbom/cdx/cdx_test.go
+++ b/extractor/filesystem/sbom/cdx/cdx_test.go
@@ -130,6 +130,36 @@ func TestExtract(t *testing.T) {
 			},
 		},
 		{
+			name: "sbom-with-nested-comps.cdx.json",
+			path: "testdata/sbom-with-nested-comps.cdx.json",
+			wantInventory: []*extractor.Inventory{
+				{
+					Name:    "Nginx",
+					Version: "1.21.1",
+					Metadata: &cdx.Metadata{
+						CPEs: []string{"cpe:2.3:a:nginx:nginx:1.21.1"},
+					},
+					Locations: []string{"testdata/sbom-with-nested-comps.cdx.json"},
+				},
+				{
+					Name:    "openssl",
+					Version: "1.1.1",
+					Metadata: &cdx.Metadata{
+						PURL: purlFromString(t, "pkg:generic/openssl@1.1.1"),
+					},
+					Locations: []string{"testdata/sbom-with-nested-comps.cdx.json"},
+				},
+				{
+					Name:    "rustls",
+					Version: "0.23.13",
+					Metadata: &cdx.Metadata{
+						PURL: purlFromString(t, "pkg:cargo/rustls@0.23.13"),
+					},
+					Locations: []string{"testdata/sbom-with-nested-comps.cdx.json"},
+				},
+			},
+		},
+		{
 			name: "sbom.cdx.xml",
 			path: "testdata/sbom.cdx.xml",
 			wantInventory: []*extractor.Inventory{

--- a/extractor/filesystem/sbom/cdx/testdata/sbom-with-nested-comps.cdx.json
+++ b/extractor/filesystem/sbom/cdx/testdata/sbom-with-nested-comps.cdx.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "openssl-1.1.1",
+      "type": "library",
+      "name": "openssl",
+      "version": "1.1.1",
+      "purl": "pkg:generic/openssl@1.1.1"
+    },
+    {
+      "bom-ref": "nginx-1.21.1",
+      "type": "application",
+      "name": "Nginx",
+      "version": "1.21.1",
+      "cpe": "cpe:2.3:a:nginx:nginx:1.21.1",
+      "components": [
+        {
+          "type": "library",
+          "bom-ref": "rustls@0.23.13",
+          "name": "rustls",
+          "version": "0.23.13",
+          "purl": "pkg:cargo/rustls@0.23.13"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/google/osv-scanner/issues/1717

This adds support for extracting nested components. 

The new test file is indented with 2 spaces to follow the set editorconfig, but the other json files for this extractor are indented with 4. We'll have to do a pass to unify the indentation on all the test files at some point.  