### PR TITLE
fix: ensure errors are properly wrapped

### DIFF
--- a/artifact/image/image.go
+++ b/artifact/image/image.go
@@ -85,11 +85,11 @@ func V1ImageFromRemoteName(imageName string, imageOptions ...remote.Option) (v1.
 		}
 		descriptor, err := remote.Get(ref, imageOptions...)
 		if err != nil {
-			return nil, fmt.Errorf("couldn’t pull remote image %s: %v", ref, err)
+			return nil, fmt.Errorf("couldn’t pull remote image %s: %w", ref, err)
 		}
 		image, err = descriptor.Image()
 		if err != nil {
-			return nil, fmt.Errorf("couldn’t parse image manifest %s: %v", ref, err)
+			return nil, fmt.Errorf("couldn’t parse image manifest %s: %w", ref, err)
 		}
 	} else {
 		// Pull from a tag.
@@ -99,7 +99,7 @@ func V1ImageFromRemoteName(imageName string, imageOptions ...remote.Option) (v1.
 		}
 		image, err = remote.Image(tag, imageOptions...)
 		if err != nil {
-			return nil, fmt.Errorf("couldn’t pull remote image %s: %v", tag, err)
+			return nil, fmt.Errorf("couldn’t pull remote image %s: %w", tag, err)
 		}
 	}
 	return image, nil
@@ -120,7 +120,7 @@ func NewFromRemoteName(imageName string, imageOptions ...remote.Option) (scalibr
 func NewFromImage(image v1.Image) (scalibrfs.FS, error) {
 	outDir, err := os.MkdirTemp(os.TempDir(), "scalibr-container-")
 	if err != nil {
-		return nil, fmt.Errorf("couldn’t create tmp dir for image: %v", err)
+		return nil, fmt.Errorf("couldn’t create tmp dir for image: %w", err)
 	}
 	// Squash the image's final layer into a directory.
 	cfg := &unpack.UnpackerConfig{

--- a/artifact/image/layerscanning/image/image_test.go
+++ b/artifact/image/layerscanning/image/image_test.go
@@ -1087,7 +1087,7 @@ func constructImage(ctx context.Context, version, fakePackageName string) (*v1.I
 		return io.NopCloser(bytes.NewBuffer(buf.Bytes())), nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to create layer: %v", err)
+		return nil, fmt.Errorf("unable to create layer: %w", err)
 	}
 	image, err := mutate.AppendLayers(empty.Image, layer)
 	return &image, err

--- a/artifact/image/tar/tar.go
+++ b/artifact/image/tar/tar.go
@@ -43,7 +43,7 @@ func SaveToTarball(path string, image v1.Image) error {
 
 	if _, err := io.Copy(f, r); err != nil {
 		if strings.Contains(err.Error(), "invalid tar header") {
-			return fmt.Errorf("failed to copy image tar to %q: %v", path, err)
+			return fmt.Errorf("failed to copy image tar to %q: %w", path, err)
 		}
 		return fmt.Errorf("failed to copy image tar to %q: %w", path, err)
 	}

--- a/extractor/filesystem/containers/containerd/containerd_linux.go
+++ b/extractor/filesystem/containers/containerd/containerd_linux.go
@@ -134,7 +134,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	// This will still allow to handle the snapshot of a machine.
 	metaDB, err := bolt.Open(filepath.Join(input.Root, input.Path), 0444, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
-		return inventory, fmt.Errorf("Could not read the containerd metadb file: %v", err)
+		return inventory, fmt.Errorf("Could not read the containerd metadb file: %w", err)
 	}
 
 	defer metaDB.Close()
@@ -145,7 +145,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		fullMetadataDBPath := filepath.Join(input.Root, snapshotterMetadataDBPath)
 		snapshotsMetadata, err = snapshotsMetadataFromDB(fullMetadataDBPath, e.maxMetaDBFileSize, "overlayfs")
 		if err != nil {
-			return inventory, fmt.Errorf("Could not collect snapshots metadata from DB: %v", err)
+			return inventory, fmt.Errorf("Could not collect snapshots metadata from DB: %w", err)
 		}
 	}
 
@@ -323,18 +323,18 @@ func snapshotsMetadataFromDB(fullMetadataDBPath string, maxMetaDBFileSize int64,
 	// Check if the file is valid to be opened, and make sure it's not too large.
 	err := fileSizeCheck(fullMetadataDBPath, maxMetaDBFileSize)
 	if err != nil {
-		return nil, fmt.Errorf("Could not read the containerd metadb file: %v", err)
+		return nil, fmt.Errorf("Could not read the containerd metadb file: %w", err)
 	}
 
 	metadataDB, err := bolt.Open(fullMetadataDBPath, 0444, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
-		return nil, fmt.Errorf("Could not read the containerd metadb file: %v", err)
+		return nil, fmt.Errorf("Could not read the containerd metadb file: %w", err)
 	}
 	defer metadataDB.Close()
 	err = metadataDB.View(func(tx *bolt.Tx) error {
 		snapshotsBucketByDigest, err := snapshotsBucketByDigest(tx)
 		if err != nil {
-			return fmt.Errorf("Not able to grab the names of the snapshot buckets: %v", err)
+			return fmt.Errorf("Not able to grab the names of the snapshot buckets: %w", err)
 		}
 		// Store the important info of the snapshots into snapshotMetadata struct.
 		snapshotsMetadata = snapshotMetadataFromSnapshotsBuckets(tx, snapshotsBucketByDigest, snapshotsMetadata, fileSystemDriver)

--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -379,14 +379,14 @@ func (wc *walkContext) shouldSkipDir(path string) bool {
 func (wc *walkContext) runExtractor(ex Extractor, path string) {
 	rc, err := wc.fs.Open(path)
 	if err != nil {
-		addErrToMap(wc.errors, ex.Name(), fmt.Errorf("Open(%s): %v", path, err))
+		addErrToMap(wc.errors, ex.Name(), fmt.Errorf("Open(%s): %w", path, err))
 		return
 	}
 	defer rc.Close()
 
 	info, err := rc.Stat()
 	if err != nil {
-		addErrToMap(wc.errors, ex.Name(), fmt.Errorf("stat(%s): %v", path, err))
+		addErrToMap(wc.errors, ex.Name(), fmt.Errorf("stat(%s): %w", path, err))
 		return
 	}
 

--- a/extractor/filesystem/language/haskell/cabal/cabal.go
+++ b/extractor/filesystem/language/haskell/cabal/cabal.go
@@ -150,7 +150,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for s.Scan() {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return pkgs, fmt.Errorf("%s halted at %q because of context error: %v", e.Name(), input.Path, err)
+			return pkgs, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
 		}
 
 		line := s.Text()

--- a/extractor/filesystem/language/haskell/stacklock/stacklock.go
+++ b/extractor/filesystem/language/haskell/stacklock/stacklock.go
@@ -150,7 +150,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for s.Scan() {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return pkgs, fmt.Errorf("%s halted at %q because of context error: %v", e.Name(), input.Path, err)
+			return pkgs, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
 		}
 
 		line := strings.TrimSpace(s.Text())

--- a/extractor/filesystem/language/python/setup/setup.go
+++ b/extractor/filesystem/language/python/setup/setup.go
@@ -151,7 +151,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for s.Scan() {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return pkgs, fmt.Errorf("%s halted at %q because of context error: %v", e.Name(), input.Path, err)
+			return pkgs, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
 		}
 
 		line := s.Text()

--- a/extractor/filesystem/language/rust/cargotoml/cargotoml.go
+++ b/extractor/filesystem/language/rust/cargotoml/cargotoml.go
@@ -156,7 +156,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 
 	for name, dependency := range parsedTomlFile.Dependencies {
 		if err := ctx.Err(); err != nil {
-			return packages, fmt.Errorf("%s halted at %q because of context error: %v", e.Name(), input.Path, err)
+			return packages, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
 		}
 
 		var srcCode *extractor.SourceCodeIdentifier

--- a/extractor/filesystem/os/apk/apk.go
+++ b/extractor/filesystem/os/apk/apk.go
@@ -176,7 +176,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 
 	for eof := false; !eof; {
 		if err := ctx.Err(); err != nil {
-			return nil, fmt.Errorf("%s halted at %q because of context error: %v", e.Name(), input.Path, err)
+			return nil, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
 		}
 
 		record, err := parseSingleApkRecord(scanner)

--- a/extractor/filesystem/os/cos/cos.go
+++ b/extractor/filesystem/os/cos/cos.go
@@ -153,7 +153,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 	dec := json.NewDecoder(input.Reader)
 	var packages cosPackageInfo
 	if err := dec.Decode(&packages); err != nil {
-		err := fmt.Errorf("failed to json decode %q: %v", input.Path, err)
+		err := fmt.Errorf("failed to json decode %q: %w", input.Path, err)
 		log.Debugf(err.Error())
 		// TODO(b/281023532): We should not mark the overall SCALIBR scan as failed if we can't parse a file.
 		return nil, fmt.Errorf("%w", err)

--- a/extractor/filesystem/os/dpkg/dpkg.go
+++ b/extractor/filesystem/os/dpkg/dpkg.go
@@ -182,7 +182,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for eof := false; !eof; {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return pkgs, fmt.Errorf("%s halted at %q because of context error: %v", e.Name(), input.Path, err)
+			return pkgs, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
 		}
 
 		h, err := rd.ReadMIMEHeader()

--- a/extractor/filesystem/os/flatpak/flatpak.go
+++ b/extractor/filesystem/os/flatpak/flatpak.go
@@ -178,7 +178,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) (*extractor.Inv
 	var f Metainfo
 	err = xml.NewDecoder(input.Reader).Decode(&f)
 	if err != nil {
-		return nil, fmt.Errorf("failed to xml decode: %v", err)
+		return nil, fmt.Errorf("failed to xml decode: %w", err)
 	}
 
 	pkgName := ""

--- a/extractor/filesystem/os/kernel/module/module.go
+++ b/extractor/filesystem/os/kernel/module/module.go
@@ -169,7 +169,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 	}
 	elfFile, err := elf.NewFile(readerAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse ELF file: %v", err)
+		return nil, fmt.Errorf("failed to parse ELF file: %w", err)
 	}
 
 	// Note that it's possible to strip section names from the binary so we might not be able
@@ -181,7 +181,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 
 	sectionData, err := section.Data()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read .modinfo section: %v", err)
+		return nil, fmt.Errorf("failed to read .modinfo section: %w", err)
 	}
 
 	var metadata Metadata

--- a/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
+++ b/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
@@ -166,7 +166,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 
 	magicType, err := magic.GetType(r)
 	if err != nil {
-		return nil, fmt.Errorf("error determining magic type: %s", err)
+		return nil, fmt.Errorf("error determining magic type: %w", err)
 	}
 
 	if len(magicType) == 0 || magicType[0] != "Linux kernel" {

--- a/extractor/filesystem/os/nix/nix.go
+++ b/extractor/filesystem/os/nix/nix.go
@@ -97,7 +97,7 @@ var packageStoreUnstableRegex = regexp.MustCompile(`^([a-zA-Z0-9]{32})-([a-zA-Z0
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	// Check for cancellation or timeout.
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("%s halted at %q because of context error: %v", e.Name(), input.Path, err)
+		return nil, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
 	}
 
 	m, err := osrelease.GetOSRelease(input.FS)

--- a/extractor/filesystem/os/pacman/pacman.go
+++ b/extractor/filesystem/os/pacman/pacman.go
@@ -161,7 +161,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for s.Scan() {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return pkgs, fmt.Errorf("%s halted at %q because of context error: %v", e.Name(), input.Path, err)
+			return pkgs, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
 		}
 
 		line := s.Text()
@@ -184,7 +184,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 				log.Warnf("Reached EOF for desc file in %v", input.Path)
 				break
 			}
-			return pkgs, fmt.Errorf("%s halted at %q: %v", e.Name(), input.Path, err)
+			return pkgs, fmt.Errorf("%s halted at %q: %w", e.Name(), input.Path, err)
 		}
 	}
 

--- a/extractor/filesystem/os/snap/snap.go
+++ b/extractor/filesystem/os/snap/snap.go
@@ -163,7 +163,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.I
 	snap := snap{}
 	dec := yaml.NewDecoder(input.Reader)
 	if err := dec.Decode(&snap); err != nil {
-		return nil, fmt.Errorf("failed to yaml decode %q: %v", input.Path, err)
+		return nil, fmt.Errorf("failed to yaml decode %q: %w", input.Path, err)
 	}
 
 	if snap.Name == "" {


### PR DESCRIPTION
By using `%w` errors can later be unwrapped with `errors.Unwrap`, allowing them to be checked with `errors.Is` and `errors.As`.

This will later be enforced by `errorlint`