### PR TITLE
tests: Yaml based false layers

### DIFF
--- a/artifact/image/layerscanning/testing/fakelayerbuilder/extractor.go
+++ b/artifact/image/layerscanning/testing/fakelayerbuilder/extractor.go
@@ -1,0 +1,75 @@
+package fakelayerbuilder
+
+import (
+	"bufio"
+	"context"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+)
+
+// Extractor extracts FakeTestLayers built from the FakeLayerBuilder
+type FakeTestLayersExtractor struct {
+}
+
+// Name of the extractor.
+func (e FakeTestLayersExtractor) Name() string { return "fake/layerextractor" }
+
+// Version of the extractor.
+func (e FakeTestLayersExtractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e FakeTestLayersExtractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired always returns true, as this is for testing only
+func (e FakeTestLayersExtractor) FileRequired(_ filesystem.FileAPI) bool {
+	return true
+}
+
+// Extract extracts packages from yarn.lock files passed through the scan input.
+func (e FakeTestLayersExtractor) Extract(_ context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+	scanner := bufio.NewScanner(input.Reader)
+	invs := []*extractor.Inventory{}
+
+	for scanner.Scan() {
+		pkgline := scanner.Text()
+		// If no version found, just return "" as version
+		pkg, version, _ := strings.Cut(pkgline, "@")
+
+		invs = append(invs, &extractor.Inventory{
+			Name:      pkg,
+			Version:   version,
+			Locations: []string{input.Path},
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return invs, nil
+}
+
+// ToPURL always returns nil
+func (e FakeTestLayersExtractor) ToPURL(i *extractor.Inventory) *purl.PackageURL {
+	return &purl.PackageURL{
+		Type:    purl.TypeGeneric,
+		Name:    i.Name,
+		Version: i.Version,
+	}
+}
+
+// ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
+func (e FakeTestLayersExtractor) ToCPEs(_ *extractor.Inventory) []string { return []string{} }
+
+// Ecosystem returns no ecosystem as this is a mock for testing
+func (e FakeTestLayersExtractor) Ecosystem(i *extractor.Inventory) string {
+	return ""
+}
+
+var _ filesystem.Extractor = FakeTestLayersExtractor{}

--- a/artifact/image/layerscanning/testing/fakelayerbuilder/fakelayerbuilder.go
+++ b/artifact/image/layerscanning/testing/fakelayerbuilder/fakelayerbuilder.go
@@ -58,6 +58,8 @@ func parseFakeLayerFileFromPath(path string) (FakeTestLayers, error) {
 }
 
 func BuildFakeChainLayersFromPath(t *testing.T, testDir string, layerInfoPath string) []*fakechainlayer.FakeChainLayer {
+	t.Helper()
+
 	layers, err := parseFakeLayerFileFromPath(layerInfoPath)
 	if err != nil {
 		t.Fatalf("Failed to parse fake layer file %q: %q", layerInfoPath, err)

--- a/artifact/image/layerscanning/testing/fakelayerbuilder/fakelayerbuilder.go
+++ b/artifact/image/layerscanning/testing/fakelayerbuilder/fakelayerbuilder.go
@@ -1,0 +1,108 @@
+// fakelayerbuilder uses a yaml file with custom syntax to build up fake layers for testing
+//
+// Example:
+//
+// ```yml
+//
+// layers:
+//
+//	# Add foo.txt lockfile
+//	- files:
+//	    foo.txt:
+//	    	# With the package foo
+//	        - foo
+//	    bar.txt:
+//	        - bar
+//	# Delete the bar lockfile
+//	- files:
+//	    !bar.txt:
+//	- files:
+//	    baz.txt:
+//	        - baz
+//	    # Readd bar
+//	- files:
+//	    bar.txt:
+//	        - bar
+//
+// ```
+package fakelayerbuilder
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/artifact/image/layerscanning/testing/fakechainlayer"
+	"github.com/google/osv-scalibr/artifact/image/layerscanning/testing/fakelayer"
+	"github.com/google/osv-scalibr/artifact/image/whiteout"
+	"github.com/opencontainers/go-digest"
+	"gopkg.in/yaml.v3"
+)
+
+func parseFakeLayerFileFromPath(path string) (FakeTestLayers, error) {
+	layers := FakeTestLayers{}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return FakeTestLayers{}, err
+	}
+
+	err = yaml.Unmarshal(data, &layers)
+	if err != nil {
+		return FakeTestLayers{}, err
+	}
+
+	return layers, nil
+}
+
+func BuildFakeChainLayersFromPath(t *testing.T, testDir string, layerInfoPath string) []*fakechainlayer.FakeChainLayer {
+	layers, err := parseFakeLayerFileFromPath(layerInfoPath)
+	if err != nil {
+		t.Fatalf("Failed to parse fake layer file %q: %q", layerInfoPath, err)
+	}
+
+	output := []*fakechainlayer.FakeChainLayer{}
+
+	// chainLayerContents is edited every loop with the diffs of that layer
+	chainLayerContents := map[string]string{}
+
+	for index, layer := range layers.Layers {
+		diffID := digest.NewDigestFromEncoded(digest.SHA256, fmt.Sprintf("diff-id-%d", index))
+		command := fmt.Sprintf("command-%d", index)
+
+		// Build and edit layer contents
+		layerContents := map[string]string{}
+		for key, file := range layer.Files {
+			if strings.HasPrefix(key, "~") {
+				key = strings.TrimPrefix(key, "~")
+				layerContents[whiteout.ToWhiteout(key)] = ""
+				delete(chainLayerContents, key)
+
+				continue
+			}
+			layerContents[key] = strings.Join(file, "\n")
+			chainLayerContents[key] = layerContents[key]
+		}
+
+		// Create fake layer and chainLayer
+		fakeLayer, err := fakelayer.New(filepath.Join(testDir, fmt.Sprintf("layer-%d", index)), diffID, command, layerContents, false)
+		if err != nil {
+			t.Fatalf("fakelayer.New(%q, %q, %q, %v, %v) failed: %v", testDir, diffID, command, layerContents, false, err)
+		}
+
+		chainLayerContentsClone := make(map[string]string, len(chainLayerContents))
+		for k, v := range chainLayerContents {
+			chainLayerContentsClone[k] = v
+		}
+		chainLayer, err := fakechainlayer.New(filepath.Join(testDir, fmt.Sprintf("chainlayer-%d", index)), index, diffID, command, fakeLayer, chainLayerContentsClone, false)
+		if err != nil {
+			t.Fatalf("fakechainlayer.New(%d, %q, %q, %v, %v) failed: %v", index, diffID, command, layer, chainLayerContentsClone, err)
+		}
+
+		output = append(output, chainLayer)
+	}
+
+	return output
+}

--- a/artifact/image/layerscanning/testing/fakelayerbuilder/models.go
+++ b/artifact/image/layerscanning/testing/fakelayerbuilder/models.go
@@ -1,0 +1,7 @@
+package fakelayerbuilder
+
+type FakeTestLayers struct {
+	Layers []struct {
+		Files map[string][]string `yaml:"files"`
+	} `yaml:"layers"`
+}

--- a/artifact/image/layerscanning/trace/testdata/populatelayers.yml
+++ b/artifact/image/layerscanning/trace/testdata/populatelayers.yml
@@ -1,0 +1,23 @@
+layers:
+  # Add foo.txt lockfile
+  - files:
+      foo.txt:
+        # With the package foo
+        - foo
+      bar.txt:
+        - bar
+  # Delete the bar lockfile
+  - files:
+      ~bar.txt:
+  - files:
+      baz.txt:
+        - baz
+      # Readd bar
+  - files:
+      bar.txt:
+        - bar
+  # Edit the same file in place
+  - files:
+      foo.txt:
+        - foo
+        - foo2


### PR DESCRIPTION
Created a yaml based fake layer definition to make it easier to setup tests, and also added a 5th chain layer to the test to showcase  how easy it is to add new layers.

No existing tests has been changed other than to set change the diff ID index from starting at "diff-1" to start at "diff-0" instead to match Index.

In this PR I avoided removing Inventory from the initial test cases to minimise changes, but it is a possible change in the future to make it easier to define additional test cases.

@mleyvajr100 PTAL!