### PR TITLE
fix(guided remediation): data race in override strategy

### DIFF
--- a/guidedremediation/internal/strategy/override/override.go
+++ b/guidedremediation/internal/strategy/override/override.go
@@ -235,7 +235,10 @@ func getVersionsGreater(ctx context.Context, cl resolve.Client, vk resolve.Versi
 
 		return sv.Compare(a.Version, b.Version)
 	}
-	slices.SortFunc(versions, cmpFunc)
+	if !slices.IsSortedFunc(versions, cmpFunc) {
+		versions = slices.Clone(versions)
+		slices.SortFunc(versions, cmpFunc)
+	}
 	// Find the index of the next higher version
 	offset, vkFound := slices.BinarySearchFunc(versions, resolve.Version{VersionKey: vk}, cmpFunc)
 	if vkFound { // if the given version somehow doesn't exist, offset will already be at the next higher version


### PR DESCRIPTION
The override strategy was sorting (i.e. modifying) the versions list returned by `client.Versions()`, which might be shared between goroutines.

Changed it to clone the slice if it needs to be sorted.