### PR TITLE
ci: ensure that `go.sum` is tidy

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: fernandrone/linelint@7907a5dca0c28ea7dd05c6d8d8cacded713aca11 # v0.0.6
+  tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+
+      - run: go mod tidy -diff
   lint:
     strategy:
       fail-fast: false


### PR DESCRIPTION
`go mod tidy -diff` will return a non-zero exit code if there are changes, allowing it to be used in CI to enforce our `go.sum` is tidy

Relates to #455