### PR TITLE
fix: Don't panic when extracting CDX with no components

### DIFF
--- a/extractor/filesystem/sbom/cdx/cdx.go
+++ b/extractor/filesystem/sbom/cdx/cdx.go
@@ -124,7 +124,7 @@ func enumerateComponents(components []cyclonedx.Component, results *[]*extractor
 func (e Extractor) convertCdxBomToInventory(cdxBom *cyclonedx.BOM, path string) ([]*extractor.Inventory, error) {
 	results := []*extractor.Inventory{}
 
-	if cdxBom == nil {
+	if cdxBom == nil || cdxBom.Components == nil {
 		return results, nil
 	}
 

--- a/extractor/filesystem/sbom/cdx/cdx_test.go
+++ b/extractor/filesystem/sbom/cdx/cdx_test.go
@@ -108,6 +108,11 @@ func TestExtract(t *testing.T) {
 		wantInventory []*extractor.Inventory
 	}{
 		{
+			name:          "minimal.cdx.json",
+			path:          "testdata/minimal.cdx.json",
+			wantInventory: []*extractor.Inventory{},
+		},
+		{
 			name: "sbom.cdx.json",
 			path: "testdata/sbom.cdx.json",
 			wantInventory: []*extractor.Inventory{

--- a/extractor/filesystem/sbom/cdx/testdata/minimal.cdx.json
+++ b/extractor/filesystem/sbom/cdx/testdata/minimal.cdx.json
@@ -1,0 +1,41 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-03-24T18:02:51Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "author": "CycloneDX",
+          "name": "cyclonedx-gradle-plugin",
+          "version": "2.2.0"
+        }
+      ],
+      "services": []
+    },
+    "component": {
+      "type": "library",
+      "bom-ref": "pkg:maven/com.example.group/fooBar@1.2.3?project_path=%3A",
+      "group": "com.example.group",
+      "name": "fooBar",
+      "version": "1.2.3",
+      "purl": "pkg:maven/com.example.group/fooBar@1.2.3?project_path=%3A",
+      "modified": false,
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/znsio/specmatic-gradle-plugin.git"
+        }
+      ]
+    },
+    "licenses": []
+  },
+  "dependencies": [
+    {
+      "ref": "pkg:maven/com.example.group/fooBar@1.2.3?project_path=%3A",
+      "dependsOn": []
+    }
+  ]
+}

--- a/extractor/filesystem/sbom/spdx/spdx_test.go
+++ b/extractor/filesystem/sbom/spdx/spdx_test.go
@@ -103,6 +103,11 @@ func TestExtract(t *testing.T) {
 		wantInventory []*extractor.Inventory
 	}{
 		{
+			name:          "minimal.spdx.json",
+			path:          "testdata/minimal.spdx.json",
+			wantInventory: []*extractor.Inventory{},
+		},
+		{
 			name: "sbom.spdx.json",
 			path: "testdata/sbom.spdx.json",
 			wantInventory: []*extractor.Inventory{

--- a/extractor/filesystem/sbom/spdx/testdata/minimal.spdx.json
+++ b/extractor/filesystem/sbom/spdx/testdata/minimal.spdx.json
@@ -1,0 +1,16 @@
+{
+  "SPDXID" : "SPDXRef-DOCUMENT",
+  "spdxVersion" : "SPDX-2.3",
+  "creationInfo" : {
+    "created" : "2023-04-28T15:44:16Z",
+    "creators" : [ "Person: John Doe" ],
+    "licenseListVersion" : "3.18"
+  },
+  "name" : "examplesbom",
+  "dataLicense" : "CC0-1.0",
+  "documentNamespace" : "http://example.org/documents/examplesbom-1.0.1",
+  "documentDescribes": [
+    "SPDXRef-nginx",
+    "SPDXRef-openssl"
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/google/osv-scanner/issues/1744

Because cdxBom.Components is a pointer to a slice, it's dereferenced before being passed to a for loop, causing it to panic when the component does not exist. Add an extra check here to prevent this. 

https://github.com/google/osv-scalibr/blob/b93cd317ad98c8677ae54bb2016a01c9759cb667/extractor/filesystem/sbom/cdx/cdx.go#L112-L120

Also added the file from the issue as a test case, and added a similarly empty SPDX test case as well just to be sure.