### PR TITLE
refactor: don't capitalize error messages

### DIFF
--- a/binary/cli/cli.go
+++ b/binary/cli/cli.go
@@ -220,7 +220,7 @@ func validateImagePlatform(imagePlatform string) error {
 	}
 	platformDetails := strings.Split(imagePlatform, "/")
 	if len(platformDetails) < 2 {
-		return fmt.Errorf("Image platform '%s' is invalid. Must be in the form OS/Architecture (e.g. linux/amd64)", imagePlatform)
+		return fmt.Errorf("image platform '%s' is invalid. Must be in the form OS/Architecture (e.g. linux/amd64)", imagePlatform)
 	}
 	return nil
 }
@@ -279,7 +279,7 @@ func validateDetectorDependency(detectors []string, extractors []string, require
 		for _, d := range det {
 			for _, req := range d.RequiredExtractors() {
 				if !exMap[req] {
-					return fmt.Errorf("Extractor %s must be turned on for Detector %s to run", req, d.Name())
+					return fmt.Errorf("extractor %s must be turned on for Detector %s to run", req, d.Name())
 				}
 			}
 		}

--- a/binary/proto/proto.go
+++ b/binary/proto/proto.go
@@ -614,10 +614,10 @@ func qualifiersToProto(qs purl.Qualifiers) []*spb.Qualifier {
 }
 
 // ErrAdvisoryMissing will be returned if the Advisory is not set on a finding.
-var ErrAdvisoryMissing = errors.New("Advisory missing in finding")
+var ErrAdvisoryMissing = errors.New("advisory missing in finding")
 
 // ErrAdvisoryIDMissing will be returned if the Advisory ID is not set on a finding.
-var ErrAdvisoryIDMissing = errors.New("Advisory ID missing in finding")
+var ErrAdvisoryIDMissing = errors.New("advisory ID missing in finding")
 
 func findingToProto(f *detector.Finding) (*spb.Finding, error) {
 	if f.Adv == nil {

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -161,10 +161,10 @@ func validateAdvisories(findings []*Finding) error {
 	ids := make(map[AdvisoryID]Advisory)
 	for _, f := range findings {
 		if f.Adv == nil {
-			return fmt.Errorf("Finding has no advisory set: %v", f)
+			return fmt.Errorf("finding has no advisory set: %v", f)
 		}
 		if f.Adv.ID == nil {
-			return fmt.Errorf("Finding has no advisory ID set: %v", f)
+			return fmt.Errorf("finding has no advisory ID set: %v", f)
 		}
 		if adv, ok := ids[*f.Adv.ID]; ok {
 			if !reflect.DeepEqual(adv, *f.Adv) {

--- a/extractor/filesystem/containers/containerd/containerd_linux.go
+++ b/extractor/filesystem/containers/containerd/containerd_linux.go
@@ -128,13 +128,13 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 	var inventory = []*extractor.Inventory{}
 
 	if input.Info != nil && input.Info.Size() > e.maxMetaDBFileSize {
-		return inventory, fmt.Errorf("Containerd metadb file %s is too large: %d", input.Path, input.Info.Size())
+		return inventory, fmt.Errorf("containerd metadb file %s is too large: %d", input.Path, input.Info.Size())
 	}
 	// Timeout is added to make sure Scalibr does not hand if the metadb file is open by another process.
 	// This will still allow to handle the snapshot of a machine.
 	metaDB, err := bolt.Open(filepath.Join(input.Root, input.Path), 0444, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
-		return inventory, fmt.Errorf("Could not read the containerd metadb file: %w", err)
+		return inventory, fmt.Errorf("could not read the containerd metadb file: %w", err)
 	}
 
 	defer metaDB.Close()
@@ -145,7 +145,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		fullMetadataDBPath := filepath.Join(input.Root, snapshotterMetadataDBPath)
 		snapshotsMetadata, err = snapshotsMetadataFromDB(fullMetadataDBPath, e.maxMetaDBFileSize, "overlayfs")
 		if err != nil {
-			return inventory, fmt.Errorf("Could not collect snapshots metadata from DB: %w", err)
+			return inventory, fmt.Errorf("could not collect snapshots metadata from DB: %w", err)
 		}
 	}
 
@@ -174,7 +174,7 @@ func fileSizeCheck(filepath string, maxFileSize int64) (err error) {
 		return err
 	}
 	if fileInfo.Size() > maxFileSize {
-		return fmt.Errorf("File %s is too large: %d", filepath, fileInfo.Size())
+		return fmt.Errorf("file %s is too large: %d", filepath, fileInfo.Size())
 	}
 	return nil
 }
@@ -323,18 +323,18 @@ func snapshotsMetadataFromDB(fullMetadataDBPath string, maxMetaDBFileSize int64,
 	// Check if the file is valid to be opened, and make sure it's not too large.
 	err := fileSizeCheck(fullMetadataDBPath, maxMetaDBFileSize)
 	if err != nil {
-		return nil, fmt.Errorf("Could not read the containerd metadb file: %w", err)
+		return nil, fmt.Errorf("could not read the containerd metadb file: %w", err)
 	}
 
 	metadataDB, err := bolt.Open(fullMetadataDBPath, 0444, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
-		return nil, fmt.Errorf("Could not read the containerd metadb file: %w", err)
+		return nil, fmt.Errorf("could not read the containerd metadb file: %w", err)
 	}
 	defer metadataDB.Close()
 	err = metadataDB.View(func(tx *bolt.Tx) error {
 		snapshotsBucketByDigest, err := snapshotsBucketByDigest(tx)
 		if err != nil {
-			return fmt.Errorf("Not able to grab the names of the snapshot buckets: %w", err)
+			return fmt.Errorf("not able to grab the names of the snapshot buckets: %w", err)
 		}
 		// Store the important info of the snapshots into snapshotMetadata struct.
 		snapshotsMetadata = snapshotMetadataFromSnapshotsBuckets(tx, snapshotsBucketByDigest, snapshotsMetadata, fileSystemDriver)
@@ -354,13 +354,13 @@ func snapshotsBucketByDigest(tx *bolt.Tx) ([]string, error) {
 	var snapshotsBucketByDigest []string
 	//  metadata db structure: v1-> snapshots -> <snapshot_digest> -> <snapshot_info_fields>
 	if tx == nil {
-		return snapshotsBucketByDigest, errors.New("The transaction is nil")
+		return snapshotsBucketByDigest, errors.New("the transaction is nil")
 	}
 	if tx.Bucket([]byte("v1")) == nil {
-		return snapshotsBucketByDigest, errors.New("Could not find the v1 bucket in the metadata.db file")
+		return snapshotsBucketByDigest, errors.New("could not find the v1 bucket in the metadata.db file")
 	}
 	if tx.Bucket([]byte("v1")).Bucket([]byte("snapshots")) == nil {
-		return snapshotsBucketByDigest, errors.New("Could not find the snapshots bucket in the metadata.db file")
+		return snapshotsBucketByDigest, errors.New("could not find the snapshots bucket in the metadata.db file")
 	}
 	snapshotsMetadataBucket := tx.Bucket([]byte("v1")).Bucket([]byte("snapshots"))
 	err := snapshotsMetadataBucket.ForEach(func(k []byte, v []byte) error {

--- a/extractor/filesystem/language/python/wheelegg/wheelegg.go
+++ b/extractor/filesystem/language/python/wheelegg/wheelegg.go
@@ -210,7 +210,7 @@ func (e Extractor) extractZip(ctx context.Context, input *filesystem.ScanInput) 
 func (e Extractor) openAndExtract(f *zip.File, input *filesystem.ScanInput) (*extractor.Inventory, error) {
 	r, err := f.Open()
 	if err != nil {
-		return nil, fmt.Errorf("On %q: Open(%s): %w", input.Path, f.Name, err)
+		return nil, fmt.Errorf("on %q: Open(%s): %w", input.Path, f.Name, err)
 	}
 	defer r.Close()
 

--- a/extractor/filesystem/os/dpkg/dpkg.go
+++ b/extractor/filesystem/os/dpkg/dpkg.go
@@ -286,7 +286,7 @@ func parseSourceNameVersion(source string) (string, string, error) {
 	// Format is either "name" or "name (version)"
 	if idx := strings.Index(source, " ("); idx != -1 {
 		if !strings.HasSuffix(source, ")") {
-			return "", "", fmt.Errorf("Invalid DPKG Source field: %q", source)
+			return "", "", fmt.Errorf("invalid DPKG Source field: %q", source)
 		}
 		n := source[:idx]
 		v := source[idx+2 : len(source)-1]

--- a/extractor/filesystem/os/macapps/macapps.go
+++ b/extractor/filesystem/os/macapps/macapps.go
@@ -147,7 +147,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		})
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Mac OS Application.extract(%s): %w", input.Path, err)
+		return nil, fmt.Errorf("macOS Application.extract(%s): %w", input.Path, err)
 	}
 	if i == nil {
 		return []*extractor.Inventory{}, nil

--- a/extractor/standalone/containers/containerd/containerd_linux.go
+++ b/extractor/standalone/containers/containerd/containerd_linux.go
@@ -148,7 +148,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) ([
 	}
 
 	if e.client == nil {
-		return inventory, errors.New("Containerd API client is not initialized")
+		return inventory, errors.New("containerd API client is not initialized")
 	}
 
 	ctrMetadata, err := containersFromAPI(ctx, e.client)

--- a/extractor/standalone/windows/dismpatch/dismparser/dism_parser.go
+++ b/extractor/standalone/windows/dismpatch/dismparser/dism_parser.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// ErrParsingError indicates an error while parsing the DISM output.
-	ErrParsingError = errors.New("Could not parse DISM output successfully")
+	ErrParsingError = errors.New("could not parse DISM output successfully")
 
 	versionRegexp = regexp.MustCompile(`~(\d+\.\d+\.\d+\.\d+)$`)
 )


### PR DESCRIPTION
Go convention is that error messages shouldn't be capitalized or end with punctuation as they might get chained

This will later be enforced by the `stylecheck` linter

Relates to #274