### PR TITLE
test: check for error instance rather than message

### DIFF
--- a/extractor/standalone/windows/dismpatch/dismparser/dism_parser_test.go
+++ b/extractor/standalone/windows/dismpatch/dismparser/dism_parser_test.go
@@ -15,6 +15,7 @@
 package dismparser
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -116,7 +117,7 @@ func TestParseError(t *testing.T) {
 	}
 
 	_, _, err = Parse(string(content))
-	if err == nil || err.Error() != "Could not parse DISM output successfully" {
-		t.Errorf("Parse: Want: %v, Got: %v", "Could not parse DISM output successfully", err)
+	if !errors.Is(err, ErrParsingError) {
+		t.Errorf("Parse: Want: %v, Got: %v", ErrParsingError, err)
 	}
 }


### PR DESCRIPTION
This makes the test less brittle as it no longer cares about the exact wording of the error message