### PR TITLE
chore: disable `nilnil` and `prealloc` linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,7 +61,6 @@ linters:
     - nolintlint
     - nosprintfhostport
     - perfsprint
-#    - prealloc
     - predeclared
     - promlinter
 #    - protogetter
@@ -91,6 +90,7 @@ linters:
 #    - paralleltest # Parallel tests mixes up log lines of multiple tests in the internal test runner
 #    - tparallel    # Parallel tests mixes up log lines of multiple tests in the internal test runner
 #    - nilnil       # We consider this a valid pattern to use sometimes
+#    - prealloc     # We don't want to preallocate all the time
 
 linters-settings:
   forbidigo:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,7 +57,6 @@ linters:
     - musttag
     - nakedret
     - nilerr
-#    - nilnil
     - noctx
     - nolintlint
     - nosprintfhostport
@@ -91,6 +90,7 @@ linters:
 #    - nlreturn     # Not feasible until it's supported by the internal linter
 #    - paralleltest # Parallel tests mixes up log lines of multiple tests in the internal test runner
 #    - tparallel    # Parallel tests mixes up log lines of multiple tests in the internal test runner
+#    - nilnil       # We consider this a valid pattern to use sometimes
 
 linters-settings:
   forbidigo:


### PR DESCRIPTION
Relates to #274