### PR TITLE
refactor: rename `OSVToDepsDevSystem` to match opposite utility function

### DIFF
--- a/guidedremediation/internal/util/util.go
+++ b/guidedremediation/internal/util/util.go
@@ -39,7 +39,7 @@ func DepsDevToOSVEcosystem(sys resolve.System) osvschema.Ecosystem {
 
 // OSVToDepsDevEcosystem converts an osvschema.Ecosystem into a deps.dev resolve.System.
 // Unknown / invalid Ecosystems become `resolve.UnknownEcosystem`.
-func OSVToDepsDevSystem(sys osvschema.Ecosystem) resolve.System {
+func OSVToDepsDevEcosystem(sys osvschema.Ecosystem) resolve.System {
 	switch sys {
 	case osvschema.EcosystemMaven:
 		return resolve.Maven

--- a/guidedremediation/internal/vulns/vulns.go
+++ b/guidedremediation/internal/vulns/vulns.go
@@ -52,7 +52,7 @@ func (e mockExtractor) Version() int                                 { return 0 
 
 // IsAffected returns true if the Vulnerability applies to the package version of the Inventory.
 func IsAffected(vuln *osvschema.Vulnerability, inv *extractor.Inventory) bool {
-	resolveSys := util.OSVToDepsDevSystem(osvschema.Ecosystem(inv.Ecosystem()))
+	resolveSys := util.OSVToDepsDevEcosystem(osvschema.Ecosystem(inv.Ecosystem()))
 	if resolveSys == resolve.UnknownSystem {
 		return false
 	}


### PR DESCRIPTION
I'm pretty sure this was the intended name given both the function comment and that its counterpart is `DepsDevToOSVEcosystem`