### PR TITLE
refactor: don't capitalize param names

### DIFF
--- a/detector/list/list.go
+++ b/detector/list/list.go
@@ -72,16 +72,16 @@ var detectorNames = concat(All, InitMap{
 	"all":         vals(All),
 })
 
-func concat(InitMaps ...InitMap) InitMap {
+func concat(initMaps ...InitMap) InitMap {
 	result := InitMap{}
-	for _, m := range InitMaps {
+	for _, m := range initMaps {
 		maps.Copy(result, m)
 	}
 	return result
 }
 
-func vals(InitMap InitMap) []InitFn {
-	return slices.Concat(maps.Values(InitMap)...)
+func vals(initMap InitMap) []InitFn {
+	return slices.Concat(maps.Values(initMap)...)
 }
 
 // FromCapabilities returns all detectors that can run under the specified

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -257,16 +257,16 @@ var (
 
 // LINT.ThenChange(/docs/supported_inventory_types.md)
 
-func concat(InitMaps ...InitMap) InitMap {
+func concat(initMaps ...InitMap) InitMap {
 	result := InitMap{}
-	for _, m := range InitMaps {
+	for _, m := range initMaps {
 		maps.Copy(result, m)
 	}
 	return result
 }
 
-func vals(InitMap InitMap) []InitFn {
-	return slices.Concat(maps.Values(InitMap)...)
+func vals(initMap InitMap) []InitFn {
+	return slices.Concat(maps.Values(initMap)...)
 }
 
 // FromCapabilities returns all extractors that can run under the specified

--- a/extractor/standalone/list/list.go
+++ b/extractor/standalone/list/list.go
@@ -74,16 +74,16 @@ var (
 	})
 )
 
-func concat(InitMaps ...InitMap) InitMap {
+func concat(initMaps ...InitMap) InitMap {
 	result := InitMap{}
-	for _, m := range InitMaps {
+	for _, m := range initMaps {
 		maps.Copy(result, m)
 	}
 	return result
 }
 
-func vals(InitMap InitMap) []InitFn {
-	return slices.Concat(maps.Values(InitMap)...)
+func vals(initMap InitMap) []InitFn {
+	return slices.Concat(maps.Values(initMap)...)
 }
 
 // FromCapabilities returns all extractors that can run under the specified


### PR DESCRIPTION
It's not conventional to capitalize parameter names since capitalization is used to represent if something is public or private, and parameters are always local

This will be enforced by the `gocritic` linter

Relates to #274