### PR TITLE
refactor: remove unneeded slice expressions

### DIFF
--- a/artifact/image/layerscanning/image/image_test.go
+++ b/artifact/image/layerscanning/image/image_test.go
@@ -773,7 +773,7 @@ func compareChainLayerEntries(t *testing.T, gotChainLayer image.ChainLayer, want
 				t.Fatalf("ReadAll(%v) returned error: %v", filepathContentPair.filepath, err)
 			}
 
-			gotContent := string(contentBytes[:])
+			gotContent := string(contentBytes)
 			if diff := cmp.Diff(gotContent, filepathContentPair.content); diff != "" {
 				t.Errorf("Open(%v) returned incorrect content: got \"%s\", want \"%s\"", filepathContentPair.filepath, gotContent, filepathContentPair.content)
 			}

--- a/detector/govulncheck/binary/binary.go
+++ b/detector/govulncheck/binary/binary.go
@@ -154,7 +154,7 @@ func parseVulnsFromOutput(out *bytes.Buffer, binaryPath string) ([]*detector.Fin
 		extra := ""
 		affected, err := json.Marshal(osv.Affected)
 		if err == nil {
-			extra = fmt.Sprintf("Vulnerable dependencies for binary %s: %s", binaryPath, string(affected[:]))
+			extra = fmt.Sprintf("Vulnerable dependencies for binary %s: %s", binaryPath, string(affected))
 		} else {
 			log.Warnf("error serializing affected software: %w", err)
 		}


### PR DESCRIPTION
This are not needed, and will later be flagged by the `gocritic` linter

Relates to #274