### PR TITLE
refactor: use `strings.ReplaceAll`

### DIFF
--- a/artifact/image/symlink/symlink.go
+++ b/artifact/image/symlink/symlink.go
@@ -123,7 +123,7 @@ func RemoveObsoleteSymlinks(root string) error {
 //	      relative-symlink.txt -> /root/SQUASHED/dir1/sample.txt
 //	      absolute-symlink.txt -> /root/SQUASHED/dir1/sample.txt
 func ResolveInterLayerSymlinks(root, layerDigest, squashedImageDirectory string) error {
-	layerPath := filepath.Join(root, strings.Replace(layerDigest, ":", "-", -1))
+	layerPath := filepath.Join(root, strings.ReplaceAll(layerDigest, ":", "-"))
 
 	// Walk through each symlink in the layer, convert to absolute symlink, then resolve cross layer
 	// symlinks.

--- a/artifact/image/unpack/unpack.go
+++ b/artifact/image/unpack/unpack.go
@@ -256,7 +256,7 @@ func (u *Unpacker) UnpackLayers(dir string, image v1.Image) ([]string, error) {
 		}
 		layerDigests = append(layerDigests, digest.String())
 
-		layerPath := filepath.Join(dir, strings.Replace(digest.String(), ":", "-", -1))
+		layerPath := filepath.Join(dir, strings.ReplaceAll(digest.String(), ":", "-"))
 		_ = os.Mkdir(layerPath, fs.ModePerm)
 
 		// requiredTargets stores targets that symlinks point to.

--- a/artifact/image/unpack/unpack_test.go
+++ b/artifact/image/unpack/unpack_test.go
@@ -573,7 +573,7 @@ func mustReadSubDirs(t *testing.T, dir string) []digestAndContent {
 		}
 		content := mustReadDir(t, filepath.Join(dir, info.Name()))
 		dc = append(dc, digestAndContent{
-			strings.Replace(info.Name(), "-", ":", -1),
+			strings.ReplaceAll(info.Name(), "-", ":"),
 			content,
 		})
 	}


### PR DESCRIPTION
This makes it easier to understand at a glance what's happening, rather than needing to realize `-1` is being passed to mean "all"

This will be enforced by the `gocritic` linter

Relates to #274