### PR TITLE
refactor: remove unneeded pointer dereferences

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -225,8 +225,8 @@ func ToCDX(r *scalibr.ScanResult, c CDXConfig) *cyclonedx.BOM {
 		pkg := cyclonedx.Component{
 			BOMRef:  uuid.New().String(),
 			Type:    cyclonedx.ComponentTypeLibrary,
-			Name:    (*i).Name,
-			Version: (*i).Version,
+			Name:    i.Name,
+			Version: i.Version,
 		}
 		if p := ToPURL(i); p != nil {
 			pkg.PackageURL = p.String()
@@ -234,9 +234,9 @@ func ToCDX(r *scalibr.ScanResult, c CDXConfig) *cyclonedx.BOM {
 		if cpes := extractCPEs(i); len(cpes) > 0 {
 			pkg.CPE = cpes[0]
 		}
-		if len((*i).Locations) > 0 {
-			occ := make([]cyclonedx.EvidenceOccurrence, 0, len(((*i).Locations)))
-			for _, loc := range (*i).Locations {
+		if len(i.Locations) > 0 {
+			occ := make([]cyclonedx.EvidenceOccurrence, 0, len((i.Locations)))
+			for _, loc := range i.Locations {
 				occ = append(occ, cyclonedx.EvidenceOccurrence{
 					Location: loc,
 				})


### PR DESCRIPTION
This are not needed, and will later be flagged by the `gocritic` linter

Relates to #274