### PR TITLE
refactor: use `regexp.MustCompile` for constant expressions

### DIFF
--- a/extractor/filesystem/language/java/archive/manifest.go
+++ b/extractor/filesystem/language/java/archive/manifest.go
@@ -77,6 +77,10 @@ func parseManifest(f *zip.File) (manifest, error) {
 	}, nil
 }
 
+var (
+	groupIDFinder = regexp.MustCompile(`[a-zA-Z0-9-_.]+`)
+)
+
 // Transforms for manifest fields that need a little work to extract the group
 // ID. Note that we intentionally do not combine this as part of the `keys` in
 // the `getGroupID` function because we want to maintain ordering of the keys to
@@ -94,13 +98,8 @@ var groupIDTransforms = map[string]func(string) string{
 	// And we simply want to extract `org.elasticsearch`, which would be the first
 	// match for the regex.
 	"Implementation-Title": func(s string) string {
-		groupIDRegex, err := regexp.Compile(`[a-zA-Z0-9-_\.]+`)
-		if err != nil {
-			log.Warnf("Error compiling group ID regex: %v", err)
-		}
-
 		// Get the first match for a domain-like string.
-		return groupIDRegex.FindString(s)
+		return groupIDFinder.FindString(s)
 	},
 }
 

--- a/extractor/standalone/windows/dismpatch/dismparser/dism_parser.go
+++ b/extractor/standalone/windows/dismpatch/dismparser/dism_parser.go
@@ -37,25 +37,20 @@ type DismPkg struct {
 	InstallTime     string
 }
 
+var (
+	pkgExpFinder = regexp.MustCompile("entity :(.*)\n*State :(.*)\n*Release Type :(.*)\n*Install Time :(.*)\n*")
+	imgVerFinder = regexp.MustCompile("Image Version: (.*)")
+)
+
 // Parse parses dism output into an array of dismPkgs.
 func Parse(input string) ([]DismPkg, string, error) {
 	pkgs := strings.Split(input, "Package Id")
-
-	pkgExp, err := regexp.Compile("entity :(.*)\n*State :(.*)\n*Release Type :(.*)\n*Install Time :(.*)\n*")
-	if err != nil {
-		return nil, "", err
-	}
-
-	imgExp, err := regexp.Compile("Image Version: (.*)")
-	if err != nil {
-		return nil, "", err
-	}
 
 	imgVersion := ""
 	dismPkgs := []DismPkg{}
 
 	for _, pkg := range pkgs {
-		matches := pkgExp.FindStringSubmatch(pkg)
+		matches := pkgExpFinder.FindStringSubmatch(pkg)
 		if len(matches) > 4 {
 			dismPkg := DismPkg{
 				PackageIdentity: strings.TrimSpace(matches[1]),
@@ -67,7 +62,7 @@ func Parse(input string) ([]DismPkg, string, error) {
 			dismPkgs = append(dismPkgs, dismPkg)
 		} else {
 			// this is the first entry that has the image version
-			matches = imgExp.FindStringSubmatch(pkg)
+			matches = imgVerFinder.FindStringSubmatch(pkg)
 			if len(matches) > 1 {
 				imgVersion = strings.TrimSpace(matches[1])
 			}


### PR DESCRIPTION
Since these are constants, we know that they will always compile and so can simplify our logic by switching to use `regexp.MustCompile`

This will be enforced by the `gocritic` linter

Relates to #274