### PR TITLE
fix(requirements): actually check if line is a global option

### DIFF
--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -222,7 +222,7 @@ func extractFromPath(reader io.Reader, path string) ([]*extractor.Inventory, pat
 			extraPaths = append(extraPaths, p)
 		}
 
-		if strings.HasPrefix("-", l) {
+		if strings.HasPrefix(l, "-") {
 			// Global options other than -r are not implemented.
 			// https://pip.pypa.io/en/stable/reference/requirements-file-format/#global-options
 			// TODO(b/286213823): Implement metric


### PR DESCRIPTION
Because this params are the wrong way round we currently check if `-` is prefixed with the line, which will never be true - this doesn't result in any actual issue right now because even though we can parse a version out depending on the string (e.g. if someone does something nonsensical like `-ipkg == 1.0.0`), because of the `-` the package name will never be considered valid.

However, in a future where we started capturing metrics those'd end up being incorrect, and right now we're wasting cycles parsing lines that will never be valid package.

This was caught by the `gocritic` linter