### PR TITLE
fix: only add repositories in pomxml when client is not nil

### DIFF
--- a/extractor/filesystem/language/java/pomxml/testdata/parent/pom.xml
+++ b/extractor/filesystem/language/java/pomxml/testdata/parent/pom.xml
@@ -18,4 +18,11 @@
       <version>4.0.0</version>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2/</url>
+    </repository>
+  </repositories>
 </project>

--- a/internal/mavenutil/maven.go
+++ b/internal/mavenutil/maven.go
@@ -104,14 +104,16 @@ func MergeParents(ctx context.Context, current maven.Parent, result *maven.Proje
 		if err := result.MergeProfiles("", maven.ActivationOS{}); err != nil {
 			return fmt.Errorf("failed to merge default profiles: %w", err)
 		}
-		for _, repo := range proj.Repositories {
-			if err := opts.Client.AddRegistry(datasource.MavenRegistry{
-				URL:              string(repo.URL),
-				ID:               string(repo.ID),
-				ReleasesEnabled:  repo.Releases.Enabled.Boolean(),
-				SnapshotsEnabled: repo.Snapshots.Enabled.Boolean(),
-			}); err != nil {
-				return fmt.Errorf("failed to add registry %s: %w", repo.URL, err)
+		if opts.Client != nil && len(proj.Repositories) > 0 {
+			for _, repo := range proj.Repositories {
+				if err := opts.Client.AddRegistry(datasource.MavenRegistry{
+					URL:              string(repo.URL),
+					ID:               string(repo.ID),
+					ReleasesEnabled:  repo.Releases.Enabled.Boolean(),
+					SnapshotsEnabled: repo.Snapshots.Enabled.Boolean(),
+				}); err != nil {
+					return fmt.Errorf("failed to add registry %s: %w", repo.URL, err)
+				}
 			}
 		}
 		result.MergeParent(proj)


### PR DESCRIPTION
`MergeParents` is called in pomxml extractor which does not require network access so Maven registry client is `nil`.
However, when there are repositories defined in a pom.xml, it still tries to add the information which causes `nil` pointer error.

This PR fixes this issue by checking if the client is nil before adding repository information. 