### PR TITLE
refactor: use `+=` operator to add suffix to string

### DIFF
--- a/artifact/image/whiteout/whiteout.go
+++ b/artifact/image/whiteout/whiteout.go
@@ -84,7 +84,7 @@ func ToPath(p string) string {
 	nonWhitoutPath := path.Join(dir, file)
 
 	if dir != "" && file == "" {
-		nonWhitoutPath = nonWhitoutPath + "/"
+		nonWhitoutPath += "/"
 	}
 
 	return nonWhitoutPath


### PR DESCRIPTION
This is enforced by the `gocritic` linter, and is consistent with the rest of the codebase

Relates to #274