### PR TITLE
refactor: merge `if` with its `else` parent

### DIFF
--- a/guidedremediation/internal/vulns/vulns.go
+++ b/guidedremediation/internal/vulns/vulns.go
@@ -108,11 +108,9 @@ func IsAffected(vuln *osvschema.Vulnerability, inv *extractor.Inventory) bool {
 				if e.Introduced != "" || e.LastAffected != "" {
 					return true
 				}
-			} else {
 				// Version is between events, only match if previous event is Introduced
-				if idx != 0 && events[idx-1].Introduced != "" {
-					return true
-				}
+			} else if idx != 0 && events[idx-1].Introduced != "" {
+				return true
 			}
 		}
 	}


### PR DESCRIPTION
Since we're already in an `else` branch, we can avoid a level of intention by using `else if`.

This will be later enforced by the `gocritic` linter

Relates to #274