### PR TITLE
chore: enable `errorlint` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,6 @@ linters:
     - cyclop
     - depguard
     - err113
-    - errorlint        # TODO(#274): work on enabling this
     - exhaustive       # TODO(#274): work on enabling this
     - exhaustruct
     - exptostd         # TODO(#274): work on enabling this


### PR DESCRIPTION
Relates to #274