### PR TITLE
fix(mixlock): always return a slice of inventories

### DIFF
--- a/extractor/filesystem/language/elixir/mixlock/mixlock_test.go
+++ b/extractor/filesystem/language/elixir/mixlock/mixlock_test.go
@@ -206,6 +206,7 @@ func TestExtract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/empty",
 			},
+			WantInventory: []*extractor.Inventory{},
 		},
 	}
 

--- a/extractor/filesystem/language/erlang/mixlock/mixlock_test.go
+++ b/extractor/filesystem/language/erlang/mixlock/mixlock_test.go
@@ -75,6 +75,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/empty.lock",
 			},
+			WantInventory: []*extractor.Inventory{},
 		},
 		{
 			Name: "one package",

--- a/extractor/filesystem/language/erlang/mixlock/mixlockutils/mixlockutils.go
+++ b/extractor/filesystem/language/erlang/mixlock/mixlockutils/mixlockutils.go
@@ -46,7 +46,7 @@ type Package struct {
 func ParseMixLockFile(input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
 	scanner := bufio.NewScanner(input.Reader)
 
-	var inventories []*extractor.Inventory
+	inventories := []*extractor.Inventory{}
 
 	for scanner.Scan() {
 		line := scanner.Text()


### PR DESCRIPTION
Intentionally or not, in every other extractor we return an empty slice rather than `nil` for this situation so I think it makes sense that we do so here.