### PR TITLE
fix: ensure return types of public methods are themselves public

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -92,6 +92,8 @@ linters:
           disabled: false
         - name: time-naming
           disabled: false
+        - name: unexported-return
+          disabled: false
         - name: unreachable-code
           disabled: false
         - name: use-any

--- a/artifact/image/layerscanning/image/image_test.go
+++ b/artifact/image/layerscanning/image/image_test.go
@@ -1294,12 +1294,12 @@ func TestFS(t *testing.T) {
 					{
 						fileNodeTree: func() *RootNode {
 							root := NewNode(DefaultMaxSymlinkDepth)
-							_ = root.Insert("/", &virtualFile{
+							_ = root.Insert("/", &VirtualFile{
 								virtualPath: "/",
 								isWhiteout:  false,
 								mode:        fs.ModeDir | dirPermission,
 							})
-							_ = root.Insert("/foo.txt", &virtualFile{
+							_ = root.Insert("/foo.txt", &VirtualFile{
 								virtualPath: "/foo.txt",
 								mode:        filePermission,
 							})
@@ -1323,12 +1323,12 @@ func TestFS(t *testing.T) {
 					{
 						fileNodeTree: func() *RootNode {
 							root := NewNode(DefaultMaxSymlinkDepth)
-							_ = root.Insert("/", &virtualFile{
+							_ = root.Insert("/", &VirtualFile{
 								virtualPath: "/",
 								isWhiteout:  false,
 								mode:        fs.ModeDir | dirPermission,
 							})
-							_ = root.Insert("/foo.txt", &virtualFile{
+							_ = root.Insert("/foo.txt", &VirtualFile{
 								virtualPath: "/foo.txt",
 								mode:        filePermission,
 							})
@@ -1343,16 +1343,16 @@ func TestFS(t *testing.T) {
 					{
 						fileNodeTree: func() *RootNode {
 							root := NewNode(DefaultMaxSymlinkDepth)
-							_ = root.Insert("/", &virtualFile{
+							_ = root.Insert("/", &VirtualFile{
 								virtualPath: "/",
 								isWhiteout:  false,
 								mode:        fs.ModeDir | dirPermission,
 							})
-							_ = root.Insert("/foo.txt", &virtualFile{
+							_ = root.Insert("/foo.txt", &VirtualFile{
 								virtualPath: "/foo.txt",
 								mode:        filePermission,
 							})
-							_ = root.Insert("/bar.txt", &virtualFile{
+							_ = root.Insert("/bar.txt", &VirtualFile{
 								virtualPath: "/bar.txt",
 								mode:        filePermission,
 							})

--- a/artifact/image/layerscanning/image/layer.go
+++ b/artifact/image/layerscanning/image/layer.go
@@ -195,9 +195,9 @@ func (chainfs *FS) EvalSymlink(path string) (string, error) {
 	return vf.virtualPath, nil
 }
 
-// getVirtualFile returns the virtualFile object for the given path. The virtualFile object stores
+// getVirtualFile returns the VirtualFile object for the given path. The VirtualFile object stores
 // metadata on the virtual file and where it is located on the real filesystem.
-func (chainfs *FS) getVirtualFile(path string) (*virtualFile, error) {
+func (chainfs *FS) getVirtualFile(path string) (*VirtualFile, error) {
 	if chainfs.tree == nil {
 		return nil, fs.ErrNotExist
 	}
@@ -207,7 +207,7 @@ func (chainfs *FS) getVirtualFile(path string) (*virtualFile, error) {
 
 // getVirtualFileChildren returns the direct virtual file children of the given path. This helper
 // function is used to implement the fs.ReadDirFS interface.
-func (chainfs *FS) getVirtualFileChildren(path string) ([]*virtualFile, error) {
+func (chainfs *FS) getVirtualFileChildren(path string) ([]*VirtualFile, error) {
 	if chainfs.tree == nil {
 		return nil, fs.ErrNotExist
 	}

--- a/artifact/image/layerscanning/image/layer_test.go
+++ b/artifact/image/layerscanning/image/layer_test.go
@@ -66,7 +66,7 @@ func TestConvertV1Layer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotLayer := convertV1Layer(tc.v1Layer, tc.command, tc.isEmpty, DefaultMaxSymlinkDepth)
 
-			if diff := cmp.Diff(gotLayer, tc.wantLayer, cmp.AllowUnexported(Layer{}, fakev1layer.FakeV1Layer{}, virtualFile{}, Node{})); tc.wantLayer != nil && diff != "" {
+			if diff := cmp.Diff(gotLayer, tc.wantLayer, cmp.AllowUnexported(Layer{}, fakev1layer.FakeV1Layer{}, VirtualFile{}, Node{})); tc.wantLayer != nil && diff != "" {
 				t.Errorf("convertV1Layer(%v, %v, %v) returned layer: %v, want layer: %v", tc.v1Layer, tc.command, tc.isEmpty, gotLayer, tc.wantLayer)
 			}
 		})
@@ -74,12 +74,12 @@ func TestConvertV1Layer(t *testing.T) {
 }
 
 func TestChainLayerFS(t *testing.T) {
-	root := &virtualFile{
+	root := &VirtualFile{
 		virtualPath: "/",
 		isWhiteout:  false,
 		mode:        fs.ModeDir | dirPermission,
 	}
-	file1 := &virtualFile{
+	file1 := &VirtualFile{
 		virtualPath: "/file1",
 		isWhiteout:  false,
 		mode:        filePermission,
@@ -151,7 +151,7 @@ func TestChainFSOpen(t *testing.T) {
 		name            string
 		chainfs         FS
 		path            string
-		wantVirtualFile *virtualFile
+		wantVirtualFile *VirtualFile
 		wantErr         error
 	}{
 		{
@@ -172,7 +172,7 @@ func TestChainFSOpen(t *testing.T) {
 			name:    "open root from filled tree",
 			chainfs: populatedChainFS,
 			path:    "/",
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/",
 				isWhiteout:  false,
 				mode:        fs.ModeDir | dirPermission,
@@ -182,7 +182,7 @@ func TestChainFSOpen(t *testing.T) {
 			name:    "open directory from filled tree",
 			chainfs: populatedChainFS,
 			path:    "/dir1",
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir1",
 				isWhiteout:  false,
 				mode:        fs.ModeDir | dirPermission,
@@ -192,7 +192,7 @@ func TestChainFSOpen(t *testing.T) {
 			name:    "open file from filled tree",
 			chainfs: populatedChainFS,
 			path:    "/baz",
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/baz",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -202,7 +202,7 @@ func TestChainFSOpen(t *testing.T) {
 			name:    "open non-root file from filled tree",
 			chainfs: populatedChainFS,
 			path:    "/dir1/foo",
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir1/foo",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -212,7 +212,7 @@ func TestChainFSOpen(t *testing.T) {
 			name:    "open file with .. in path",
 			chainfs: populatedChainFS,
 			path:    "/dir1/../dir2/bar",
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -222,7 +222,7 @@ func TestChainFSOpen(t *testing.T) {
 			name:    "open file with .. outside of root (This should get normalized to root)",
 			chainfs: populatedChainFS,
 			path:    "../../dir2/bar",
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -233,7 +233,7 @@ func TestChainFSOpen(t *testing.T) {
 			chainfs: populatedChainFS,
 			path:    "/symlink1",
 			// The node the symlink points to is expected.
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -244,7 +244,7 @@ func TestChainFSOpen(t *testing.T) {
 			chainfs: populatedChainFS,
 			path:    "/symlink2",
 			// The node the symlink points to is expected.
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -255,7 +255,7 @@ func TestChainFSOpen(t *testing.T) {
 			chainfs: populatedChainFS,
 			path:    "/symlink-relative-1",
 			// The node the symlink points to is expected.
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -266,7 +266,7 @@ func TestChainFSOpen(t *testing.T) {
 			chainfs: populatedChainFS,
 			path:    "/dir2/symlink-relative-2",
 			// The node the symlink points to is expected.
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -277,7 +277,7 @@ func TestChainFSOpen(t *testing.T) {
 			chainfs: populatedChainFS,
 			path:    "/dir2/symlink-relative-3",
 			// The node the symlink points to is expected.
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -288,7 +288,7 @@ func TestChainFSOpen(t *testing.T) {
 			chainfs: populatedChainFS,
 			path:    "/symlink-to-dir/bar",
 			// "/symlink-dir" resolves to "/dir1", so we should get the virtual file with path "/dir1/foo"
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -299,7 +299,7 @@ func TestChainFSOpen(t *testing.T) {
 			chainfs: populatedChainFS,
 			path:    "/symlink-to-dir-nested/bar",
 			// "/symlink-dir" resolves to "/dir1", so we should get the virtual file with path "/dir1/foo"
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -310,7 +310,7 @@ func TestChainFSOpen(t *testing.T) {
 			chainfs: populatedChainFS,
 			path:    "/symlink-into-nested-dir-symlink",
 			// "/symlink-dir" resolves to "/dir1", so we should get the virtual file with path "/dir1/foo"
-			wantVirtualFile: &virtualFile{
+			wantVirtualFile: &VirtualFile{
 				virtualPath: "/dir2/bar",
 				isWhiteout:  false,
 				mode:        filePermission,
@@ -357,7 +357,7 @@ func TestChainFSOpen(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(gotFile, tc.wantVirtualFile, cmp.AllowUnexported(virtualFile{})); tc.wantVirtualFile != nil && diff != "" {
+			if diff := cmp.Diff(gotFile, tc.wantVirtualFile, cmp.AllowUnexported(VirtualFile{})); tc.wantVirtualFile != nil && diff != "" {
 				t.Errorf("Open(%v) returned file: %v, want file: %v", tc.path, gotFile, tc.wantVirtualFile)
 			}
 		})
@@ -463,7 +463,7 @@ func TestChainFSReadDir(t *testing.T) {
 		name             string
 		chainfs          FS
 		path             string
-		wantVirtualFiles []*virtualFile
+		wantVirtualFiles []*VirtualFile
 		wantErr          error
 	}{
 		{
@@ -478,7 +478,7 @@ func TestChainFSReadDir(t *testing.T) {
 			name:             "root directory",
 			chainfs:          setUpEmptyChainFS(t),
 			path:             "/",
-			wantVirtualFiles: []*virtualFile{},
+			wantVirtualFiles: []*VirtualFile{},
 		},
 		{
 			name:    "non-root directory in empty tree",
@@ -491,7 +491,7 @@ func TestChainFSReadDir(t *testing.T) {
 			chainfs: populatedChainFS,
 			path:    "/",
 			// wh.foobar is a whiteout file and should not be returned.
-			wantVirtualFiles: []*virtualFile{
+			wantVirtualFiles: []*VirtualFile{
 				{
 					virtualPath: "/dir1",
 					isWhiteout:  false,
@@ -585,7 +585,7 @@ func TestChainFSReadDir(t *testing.T) {
 			name:    "read non-root directory from filled tree",
 			chainfs: populatedChainFS,
 			path:    "/dir1",
-			wantVirtualFiles: []*virtualFile{
+			wantVirtualFiles: []*VirtualFile{
 				{
 					virtualPath: "/dir1/foo",
 					isWhiteout:  false,
@@ -603,7 +603,7 @@ func TestChainFSReadDir(t *testing.T) {
 			name:    "read symlink from filled tree",
 			chainfs: populatedChainFS,
 			path:    "/symlink-to-dir",
-			wantVirtualFiles: []*virtualFile{
+			wantVirtualFiles: []*VirtualFile{
 				{
 					virtualPath: "/dir2/bar",
 					isWhiteout:  false,
@@ -696,123 +696,123 @@ func setUpChainFS(t *testing.T, maxSymlinkDepth int) FS {
 		tree: NewNode(maxSymlinkDepth),
 	}
 
-	vfsMap := map[string]*virtualFile{
+	vfsMap := map[string]*VirtualFile{
 		// Layer 1 files / directories
-		"/": &virtualFile{
+		"/": &VirtualFile{
 			virtualPath: "/",
 			isWhiteout:  false,
 			mode:        fs.ModeDir | dirPermission,
 		},
-		"/dir1": &virtualFile{
+		"/dir1": &VirtualFile{
 			virtualPath: "/dir1",
 			isWhiteout:  false,
 			mode:        fs.ModeDir | dirPermission,
 		},
-		"/baz": &virtualFile{
+		"/baz": &VirtualFile{
 			virtualPath: "/baz",
 			isWhiteout:  false,
 			mode:        filePermission,
 		},
 		// Layer 2 files / directories
-		"/dir1/foo": &virtualFile{
+		"/dir1/foo": &VirtualFile{
 			virtualPath: "/dir1/foo",
 			isWhiteout:  false,
 			mode:        filePermission,
 		},
-		"/dir2": &virtualFile{
+		"/dir2": &VirtualFile{
 			virtualPath: "/dir2",
 			isWhiteout:  false,
 			mode:        fs.ModeDir | dirPermission,
 		},
-		"/dir2/bar": &virtualFile{
+		"/dir2/bar": &VirtualFile{
 			virtualPath: "/dir2/bar",
 			isWhiteout:  false,
 			mode:        filePermission,
 		},
-		"/wh.foobar": &virtualFile{
+		"/wh.foobar": &VirtualFile{
 			virtualPath: "/wh.foobar",
 			isWhiteout:  true,
 			mode:        filePermission,
 		},
-		"/symlink1": &virtualFile{
+		"/symlink1": &VirtualFile{
 			virtualPath: "/symlink1",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/dir2/bar",
 		},
-		"/symlink2": &virtualFile{
+		"/symlink2": &VirtualFile{
 			virtualPath: "/symlink2",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/symlink1",
 		},
-		"/symlink3": &virtualFile{
+		"/symlink3": &VirtualFile{
 			virtualPath: "/symlink3",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/symlink2",
 		},
-		"/symlink4": &virtualFile{
+		"/symlink4": &VirtualFile{
 			virtualPath: "/symlink4",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/symlink3",
 		},
-		"/symlink-relative-1": &virtualFile{
+		"/symlink-relative-1": &VirtualFile{
 			virtualPath: "/symlink-relative-1",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "./dir2/bar",
 		},
-		"/dir2/symlink-relative-2": &virtualFile{
+		"/dir2/symlink-relative-2": &VirtualFile{
 			virtualPath: "/dir2/symlink-relative-2",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "./bar",
 		},
-		"/dir2/symlink-relative-3": &virtualFile{
+		"/dir2/symlink-relative-3": &VirtualFile{
 			virtualPath: "/dir2/symlink-relative-3",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "../symlink-relative-1",
 		},
-		"/symlink-to-dir-nested": &virtualFile{
+		"/symlink-to-dir-nested": &VirtualFile{
 			virtualPath: "/symlink-to-dir-nested",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/symlink-to-dir",
 		},
-		"/symlink-into-nested-dir-symlink": &virtualFile{
+		"/symlink-into-nested-dir-symlink": &VirtualFile{
 			virtualPath: "/symlink-into-nested-dir-symlink",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/symlink-to-dir-nested/bar",
 		},
-		"/symlink-to-dir": &virtualFile{
+		"/symlink-to-dir": &VirtualFile{
 			virtualPath: "/symlink-to-dir",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/dir2",
 		},
-		"/symlink-to-nonexistent-file": &virtualFile{
+		"/symlink-to-nonexistent-file": &VirtualFile{
 			virtualPath: "/symlink-to-nonexistent-file",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/nonexistent-file",
 		},
-		"/symlink-cycle1": &virtualFile{
+		"/symlink-cycle1": &VirtualFile{
 			virtualPath: "/symlink-cycle1",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/symlink-cycle2",
 		},
-		"/symlink-cycle2": &virtualFile{
+		"/symlink-cycle2": &VirtualFile{
 			virtualPath: "/symlink-cycle2",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,
 			targetPath:  "/symlink-cycle3",
 		},
-		"/symlink-cycle3": &virtualFile{
+		"/symlink-cycle3": &VirtualFile{
 			virtualPath: "/symlink-cycle3",
 			isWhiteout:  false,
 			mode:        fs.ModeSymlink,

--- a/artifact/image/layerscanning/image/pathtree_test.go
+++ b/artifact/image/layerscanning/image/pathtree_test.go
@@ -35,16 +35,16 @@ func testTree(t *testing.T) *RootNode {
 	t.Helper()
 
 	tree := NewNode(DefaultMaxSymlinkDepth)
-	assertNoError(t, tree.Insert("/", &virtualFile{virtualPath: "/", mode: fs.ModeDir}))
-	assertNoError(t, tree.Insert("/a", &virtualFile{virtualPath: "/a", mode: fs.ModeDir}))
-	assertNoError(t, tree.Insert("/a/b", &virtualFile{virtualPath: "/a/b", mode: fs.ModeDir}))
-	assertNoError(t, tree.Insert("/a/b/c", &virtualFile{virtualPath: "/a/b/c", mode: fs.ModeDir}))
-	assertNoError(t, tree.Insert("/a/b/d", &virtualFile{virtualPath: "/a/b/d", mode: fs.ModeDir}))
-	assertNoError(t, tree.Insert("/a/b/d/f", &virtualFile{virtualPath: "/a/b/d/f", mode: fs.ModeDir}))
-	assertNoError(t, tree.Insert("/a/e", &virtualFile{virtualPath: "/a/e", mode: fs.ModeDir}))
-	assertNoError(t, tree.Insert("/a/e/f", &virtualFile{virtualPath: "/a/e/f", mode: fs.ModeDir}))
-	assertNoError(t, tree.Insert("/a/g", &virtualFile{virtualPath: "/a/g", mode: fs.ModeDir}))
-	assertNoError(t, tree.Insert("/x/y/z", &virtualFile{virtualPath: "/x/y/z", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/", &VirtualFile{virtualPath: "/", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/a", &VirtualFile{virtualPath: "/a", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/a/b", &VirtualFile{virtualPath: "/a/b", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/a/b/c", &VirtualFile{virtualPath: "/a/b/c", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/a/b/d", &VirtualFile{virtualPath: "/a/b/d", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/a/b/d/f", &VirtualFile{virtualPath: "/a/b/d/f", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/a/e", &VirtualFile{virtualPath: "/a/e", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/a/e/f", &VirtualFile{virtualPath: "/a/e/f", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/a/g", &VirtualFile{virtualPath: "/a/g", mode: fs.ModeDir}))
+	assertNoError(t, tree.Insert("/x/y/z", &VirtualFile{virtualPath: "/x/y/z", mode: fs.ModeDir}))
 
 	return tree
 }
@@ -54,30 +54,30 @@ func TestNode_Insert_Error(t *testing.T) {
 		name string
 		tree *RootNode
 		key  string
-		val  *virtualFile
+		val  *VirtualFile
 	}{
 		{
 			name: "duplicate node",
 			tree: func() *RootNode {
 				tree := NewNode(DefaultMaxSymlinkDepth)
-				_ = tree.Insert("/a", &virtualFile{virtualPath: "/a", mode: fs.ModeDir})
+				_ = tree.Insert("/a", &VirtualFile{virtualPath: "/a", mode: fs.ModeDir})
 
 				return tree
 			}(),
 			key: "/a",
-			val: &virtualFile{virtualPath: "/a", mode: fs.ModeDir},
+			val: &VirtualFile{virtualPath: "/a", mode: fs.ModeDir},
 		},
 		{
 			name: "duplicate node in subtree",
 			tree: func() *RootNode {
 				tree := NewNode(DefaultMaxSymlinkDepth)
-				_ = tree.Insert("/a", &virtualFile{virtualPath: "/a", mode: fs.ModeDir})
-				_ = tree.Insert("/a/b", &virtualFile{virtualPath: "/a/b", mode: fs.ModeDir})
+				_ = tree.Insert("/a", &VirtualFile{virtualPath: "/a", mode: fs.ModeDir})
+				_ = tree.Insert("/a/b", &VirtualFile{virtualPath: "/a/b", mode: fs.ModeDir})
 
 				return tree
 			}(),
 			key: "/a/b",
-			val: &virtualFile{virtualPath: "/a/b", mode: fs.ModeDir},
+			val: &VirtualFile{virtualPath: "/a/b", mode: fs.ModeDir},
 		},
 	}
 	for _, tt := range tests {
@@ -95,7 +95,7 @@ func TestNode_Get(t *testing.T) {
 		name    string
 		tree    *RootNode
 		key     string
-		want    *virtualFile
+		want    *VirtualFile
 		wantErr error
 	}{
 		{
@@ -109,18 +109,18 @@ func TestNode_Get(t *testing.T) {
 			name: "single node",
 			tree: func() *RootNode {
 				tree := NewNode(DefaultMaxSymlinkDepth)
-				_ = tree.Insert("/a", &virtualFile{virtualPath: "/a", mode: fs.ModeDir})
+				_ = tree.Insert("/a", &VirtualFile{virtualPath: "/a", mode: fs.ModeDir})
 
 				return tree
 			}(),
 			key:  "/a",
-			want: &virtualFile{virtualPath: "/a", mode: fs.ModeDir},
+			want: &VirtualFile{virtualPath: "/a", mode: fs.ModeDir},
 		},
 		{
 			name: "nonexistent node in single node tree",
 			tree: func() *RootNode {
 				tree := NewNode(DefaultMaxSymlinkDepth)
-				_ = tree.Insert("/a", &virtualFile{virtualPath: "/a", mode: fs.ModeDir})
+				_ = tree.Insert("/a", &VirtualFile{virtualPath: "/a", mode: fs.ModeDir})
 
 				return tree
 			}(),
@@ -132,13 +132,13 @@ func TestNode_Get(t *testing.T) {
 			name: "root node",
 			tree: testTree(t),
 			key:  "/",
-			want: &virtualFile{virtualPath: "/", mode: fs.ModeDir},
+			want: &VirtualFile{virtualPath: "/", mode: fs.ModeDir},
 		},
 		{
 			name: "multiple nodes",
 			tree: testTree(t),
 			key:  "/a/b/c",
-			want: &virtualFile{virtualPath: "/a/b/c", mode: fs.ModeDir},
+			want: &VirtualFile{virtualPath: "/a/b/c", mode: fs.ModeDir},
 		},
 		{
 			name:    "nonexistent node",
@@ -154,7 +154,7 @@ func TestNode_Get(t *testing.T) {
 			if errDiff := cmp.Diff(err, tt.wantErr, cmpopts.EquateErrors()); errDiff != "" {
 				t.Errorf("Node.Get() err diff (-want +got):\n%s", errDiff)
 			}
-			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(virtualFile{})); diff != "" {
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(VirtualFile{})); diff != "" {
 				t.Errorf("Node.Get() (-want +got): %v", diff)
 			}
 		})
@@ -166,7 +166,7 @@ func TestNode_GetChildren(t *testing.T) {
 		name    string
 		tree    *RootNode
 		key     string
-		want    []*virtualFile
+		want    []*VirtualFile
 		wantErr error
 	}{
 		{
@@ -180,19 +180,19 @@ func TestNode_GetChildren(t *testing.T) {
 			name: "single node no children",
 			tree: func() *RootNode {
 				tree := NewNode(DefaultMaxSymlinkDepth)
-				_ = tree.Insert("/a", &virtualFile{virtualPath: "/a", mode: fs.ModeDir})
+				_ = tree.Insert("/a", &VirtualFile{virtualPath: "/a", mode: fs.ModeDir})
 
 				return tree
 			}(),
 			key:  "/a",
-			want: []*virtualFile{},
+			want: []*VirtualFile{},
 		},
 		{
 			name: "root node",
 			tree: testTree(t),
 			key:  "/",
 			// /x is not included since value is nil.
-			want: []*virtualFile{
+			want: []*VirtualFile{
 				{virtualPath: "/a", mode: fs.ModeDir},
 			},
 		},
@@ -200,7 +200,7 @@ func TestNode_GetChildren(t *testing.T) {
 			name: "multiple nodes with children",
 			tree: testTree(t),
 			key:  "/a/b",
-			want: []*virtualFile{
+			want: []*VirtualFile{
 				{virtualPath: "/a/b/c", mode: fs.ModeDir},
 				{virtualPath: "/a/b/d", mode: fs.ModeDir},
 			},
@@ -219,7 +219,7 @@ func TestNode_GetChildren(t *testing.T) {
 			if errDiff := cmp.Diff(err, tt.wantErr, cmpopts.EquateErrors()); errDiff != "" {
 				t.Errorf("Node.Get() err diff (-want +got):\n%s", errDiff)
 			}
-			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(virtualFile{}), cmpopts.SortSlices(func(a, b *virtualFile) bool {
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(VirtualFile{}), cmpopts.SortSlices(func(a, b *VirtualFile) bool {
 				return strings.Compare(a.virtualPath, b.virtualPath) < 0
 			})); diff != "" {
 				t.Errorf("Node.GetChildren() (-want +got): %v", diff)
@@ -250,7 +250,7 @@ func TestNode_Walk(t *testing.T) {
 			name: "single node",
 			tree: func() *RootNode {
 				tree := NewNode(DefaultMaxSymlinkDepth)
-				_ = tree.Insert("/a", &virtualFile{virtualPath: "/a", mode: fs.ModeDir})
+				_ = tree.Insert("/a", &VirtualFile{virtualPath: "/a", mode: fs.ModeDir})
 
 				return tree
 			}(),
@@ -279,7 +279,7 @@ func TestNode_Walk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := []keyValue{}
-			err := tt.tree.Walk(func(p string, vf *virtualFile) error {
+			err := tt.tree.Walk(func(p string, vf *VirtualFile) error {
 				got = append(got, keyValue{key: p, val: vf.virtualPath})
 				return nil
 			})

--- a/artifact/image/layerscanning/image/virtual_file.go
+++ b/artifact/image/layerscanning/image/virtual_file.go
@@ -27,17 +27,17 @@ var (
 	errCannotReadVirtualFile      = errors.New("cannot read file")
 )
 
-// virtualFile represents a file in a virtual filesystem.
-type virtualFile struct {
+// VirtualFile represents a file in a virtual filesystem.
+type VirtualFile struct {
 	// reader provides `Read()`, `Seek()`, `ReadAt()` and `Size()` operations on
 	// the content of this file similar to `io.SectionReader`.
 	// The file can still be read after closing as closing only resets the cursor.
 	// If the file is a directory, operations succeed with 0 byte reads.
 	reader *io.SectionReader
 
-	// isWhiteout is true if the virtualFile represents a whiteout file
+	// isWhiteout is true if the VirtualFile represents a whiteout file
 	isWhiteout bool
-	// virtualPath is the path of the virtualFile in the virtual filesystem.
+	// virtualPath is the path of the VirtualFile in the virtual filesystem.
 	virtualPath string
 	// targetPath is reserved for symlinks. It is the path that the symlink points to.
 	targetPath string
@@ -52,8 +52,8 @@ type virtualFile struct {
 // fs.File METHODS
 // ========================================================
 
-// validateVirtualFile validates that the virtualFile is in a valid state to be read from.
-func validateVirtualFile(f *virtualFile) error {
+// validateVirtualFile validates that the VirtualFile is in a valid state to be read from.
+func validateVirtualFile(f *VirtualFile) error {
 	if f.isWhiteout {
 		return fs.ErrNotExist
 	}
@@ -68,40 +68,40 @@ func validateVirtualFile(f *virtualFile) error {
 	return nil
 }
 
-// Stat returns the virtualFile itself since it implements the fs.FileInfo interface.
-func (f *virtualFile) Stat() (fs.FileInfo, error) {
+// Stat returns the VirtualFile itself since it implements the fs.FileInfo interface.
+func (f *VirtualFile) Stat() (fs.FileInfo, error) {
 	if f.isWhiteout {
 		return nil, fs.ErrNotExist
 	}
 	return f, nil
 }
 
-// Read reads the real file contents referred to by the virtualFile.
-func (f *virtualFile) Read(b []byte) (n int, err error) {
+// Read reads the real file contents referred to by the VirtualFile.
+func (f *VirtualFile) Read(b []byte) (n int, err error) {
 	if err := validateVirtualFile(f); err != nil {
 		return 0, err
 	}
 	return f.reader.Read(b)
 }
 
-// ReadAt reads the real file contents referred to by the virtualFile at a specific offset.
-func (f *virtualFile) ReadAt(b []byte, off int64) (n int, err error) {
+// ReadAt reads the real file contents referred to by the VirtualFile at a specific offset.
+func (f *VirtualFile) ReadAt(b []byte, off int64) (n int, err error) {
 	if err := validateVirtualFile(f); err != nil {
 		return 0, err
 	}
 	return f.reader.ReadAt(b, off)
 }
 
-// Seek sets the read cursor of the file contents represented by the virtualFile.
-func (f *virtualFile) Seek(offset int64, whence int) (n int64, err error) {
+// Seek sets the read cursor of the file contents represented by the VirtualFile.
+func (f *VirtualFile) Seek(offset int64, whence int) (n int64, err error) {
 	if err := validateVirtualFile(f); err != nil {
 		return 0, err
 	}
 	return f.reader.Seek(offset, whence)
 }
 
-// Close resets the read cursor of the file contents represented by the virtualFile.
-func (f *virtualFile) Close() error {
+// Close resets the read cursor of the file contents represented by the VirtualFile.
+func (f *VirtualFile) Close() error {
 	// Don't do anything for directories.
 	if f.IsDir() {
 		return nil
@@ -118,43 +118,48 @@ func (f *virtualFile) Close() error {
 // fs.DirEntry METHODS
 // ========================================================
 
-// Name returns the name of the virtualFile. Name is also used to implement the fs.FileInfo interface.
-func (f *virtualFile) Name() string {
+// Name returns the name of the VirtualFile. Name is also used to implement the fs.FileInfo interface.
+func (f *VirtualFile) Name() string {
 	_, filename := path.Split(f.virtualPath)
 	return filename
 }
 
-// IsDir returns whether the virtualFile represents a directory. IsDir is also used to implement the
+// IsDir returns whether the VirtualFile represents a directory. IsDir is also used to implement the
 // fs.FileInfo interface.
-func (f *virtualFile) IsDir() bool {
+func (f *VirtualFile) IsDir() bool {
 	return f.Type().IsDir()
 }
 
-// Type returns the file type of file represented by the virtualFile.
-func (f *virtualFile) Type() fs.FileMode {
+// Type returns the file type of file represented by the VirtualFile.
+func (f *VirtualFile) Type() fs.FileMode {
 	return f.mode
 }
 
-// Info returns the FileInfo of the file represented by the virtualFile.
-func (f *virtualFile) Info() (fs.FileInfo, error) {
+// Info returns the FileInfo of the file represented by the VirtualFile.
+func (f *VirtualFile) Info() (fs.FileInfo, error) {
 	return f.Stat()
 }
 
 // ========================================================
 // fs.FileInfo METHODS
 // ========================================================
-func (f *virtualFile) Size() int64 {
+
+// Size returns the size of the file.
+func (f *VirtualFile) Size() int64 {
 	return f.size
 }
 
-func (f *virtualFile) Mode() fs.FileMode {
+// Mode returns the mode of the file.
+func (f *VirtualFile) Mode() fs.FileMode {
 	return f.mode
 }
 
-func (f *virtualFile) ModTime() time.Time {
+// ModTime returns the modification time of the file.
+func (f *VirtualFile) ModTime() time.Time {
 	return f.modTime
 }
 
-func (f *virtualFile) Sys() any {
+// Sys is an implementation of FileInfo.Sys() that returns nothing (nil).
+func (f *VirtualFile) Sys() any {
 	return nil
 }

--- a/artifact/image/layerscanning/image/virtual_file_test.go
+++ b/artifact/image/layerscanning/image/virtual_file_test.go
@@ -27,39 +27,39 @@ import (
 )
 
 var (
-	rootDirectory = &virtualFile{
+	rootDirectory = &VirtualFile{
 		virtualPath: "/",
 		isWhiteout:  false,
 		mode:        fs.ModeDir | dirPermission,
 	}
-	rootFile = &virtualFile{
+	rootFile = &VirtualFile{
 		virtualPath: "/bar",
 		isWhiteout:  false,
 		mode:        filePermission,
 	}
-	nonRootDirectory = &virtualFile{
+	nonRootDirectory = &VirtualFile{
 		virtualPath: "/dir1/dir2",
 		isWhiteout:  false,
 		mode:        fs.ModeDir | dirPermission,
 	}
-	nonRootFile = &virtualFile{
+	nonRootFile = &VirtualFile{
 		virtualPath: "/dir1/foo",
 		isWhiteout:  false,
 		mode:        filePermission,
 	}
 )
 
-// TODO: b/377551664 - Add tests for the Stat method for the virtualFile type.
+// TODO: b/377551664 - Add tests for the Stat method for the VirtualFile type.
 func TestStat(t *testing.T) {
 	baseTime := time.Now()
-	regularVirtualFile := &virtualFile{
+	regularVirtualFile := &VirtualFile{
 		virtualPath: "/bar",
 		isWhiteout:  false,
 		mode:        filePermission,
 		size:        1,
 		modTime:     baseTime,
 	}
-	symlinkVirtualFile := &virtualFile{
+	symlinkVirtualFile := &VirtualFile{
 		virtualPath: "/symlink-to-bar",
 		targetPath:  "/bar",
 		isWhiteout:  false,
@@ -67,7 +67,7 @@ func TestStat(t *testing.T) {
 		size:        1,
 		modTime:     baseTime,
 	}
-	whiteoutVirtualFile := &virtualFile{
+	whiteoutVirtualFile := &VirtualFile{
 		virtualPath: "/bar",
 		isWhiteout:  true,
 		mode:        filePermission,
@@ -82,7 +82,7 @@ func TestStat(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		node     *virtualFile
+		node     *VirtualFile
 		wantInfo info
 		wantErr  error
 	}{
@@ -129,7 +129,7 @@ func TestStat(t *testing.T) {
 				modTime: gotVirtualFile.ModTime(),
 			}
 			if diff := cmp.Diff(tc.wantInfo, gotInfo, cmp.AllowUnexported(info{})); diff != "" {
-				t.Errorf("Stat(%v) returned unexpected virtualFile (-want +got): %v", tc.node, diff)
+				t.Errorf("Stat(%v) returned unexpected VirtualFile (-want +got): %v", tc.node, diff)
 			}
 		})
 	}
@@ -144,40 +144,40 @@ func TestRead(t *testing.T) {
 	fuzzSize := int64(len([]byte("fuzz")))
 	fooSize := int64(len([]byte("foo")))
 
-	barVirtualFile := &virtualFile{
+	barVirtualFile := &VirtualFile{
 		virtualPath: "/bar",
 		isWhiteout:  false,
 		mode:        filePermission,
 		size:        barSize,
 		reader:      io.NewSectionReader(contentBlob, 0, barSize),
 	}
-	fuzzVirtualFile := &virtualFile{
+	fuzzVirtualFile := &VirtualFile{
 		virtualPath: "/fuzz",
 		isWhiteout:  false,
 		mode:        filePermission,
 		size:        fuzzSize,
 		reader:      io.NewSectionReader(contentBlob, barSize, fuzzSize),
 	}
-	nonRootFooVirtualFile := &virtualFile{
+	nonRootFooVirtualFile := &VirtualFile{
 		virtualPath: "/dir1/foo",
 		isWhiteout:  false,
 		mode:        filePermission,
 		size:        fooSize,
 		reader:      io.NewSectionReader(contentBlob, barSize+fuzzSize, fooSize),
 	}
-	whiteoutVirtualFile := &virtualFile{
+	whiteoutVirtualFile := &VirtualFile{
 		virtualPath: "/dir1/abc",
 		isWhiteout:  true,
 		mode:        filePermission,
 	}
-	dirVirtualFile := &virtualFile{
+	dirVirtualFile := &VirtualFile{
 		virtualPath: "/dir1",
 		isWhiteout:  false,
 		mode:        fs.ModeDir | dirPermission,
 	}
 	tests := []struct {
 		name     string
-		vf       *virtualFile
+		vf       *VirtualFile
 		want     string
 		wantSize int64
 		wantErr  bool
@@ -244,40 +244,40 @@ func TestReadAt(t *testing.T) {
 	fuzzSize := int64(len([]byte("fuzz")))
 	fooSize := int64(len([]byte("foo")))
 
-	barVirtualFile := &virtualFile{
+	barVirtualFile := &VirtualFile{
 		virtualPath: "/bar",
 		isWhiteout:  false,
 		mode:        filePermission,
 		size:        barSize,
 		reader:      io.NewSectionReader(contentBlob, 0, barSize),
 	}
-	fuzzVirtualFile := &virtualFile{
+	fuzzVirtualFile := &VirtualFile{
 		virtualPath: "/fuzz",
 		isWhiteout:  false,
 		mode:        filePermission,
 		size:        fuzzSize,
 		reader:      io.NewSectionReader(contentBlob, barSize, fuzzSize),
 	}
-	nonRootFooVirtualFile := &virtualFile{
+	nonRootFooVirtualFile := &VirtualFile{
 		virtualPath: "/dir1/foo",
 		isWhiteout:  false,
 		mode:        filePermission,
 		size:        fooSize,
 		reader:      io.NewSectionReader(contentBlob, barSize+fuzzSize, fooSize),
 	}
-	whiteoutVirtualFile := &virtualFile{
+	whiteoutVirtualFile := &VirtualFile{
 		virtualPath: "/dir1/abc",
 		isWhiteout:  true,
 		mode:        filePermission,
 	}
-	dirVirtualFile := &virtualFile{
+	dirVirtualFile := &VirtualFile{
 		virtualPath: "/dir1",
 		isWhiteout:  false,
 		mode:        fs.ModeDir | dirPermission,
 	}
 	tests := []struct {
 		name    string
-		vf      *virtualFile
+		vf      *VirtualFile
 		offset  int64
 		want    string
 		wantErr error
@@ -367,7 +367,7 @@ func TestSeek(t *testing.T) {
 	defer os.Remove(contentBlob.Name())
 
 	fooSize := int64(len([]byte("foo")))
-	virtualFile := &virtualFile{
+	virtualFile := &VirtualFile{
 		virtualPath: "/foo",
 		isWhiteout:  false,
 		mode:        filePermission,
@@ -441,7 +441,7 @@ func TestClose(t *testing.T) {
 
 	fooSize := int64(len([]byte("foo")))
 
-	vf := &virtualFile{
+	vf := &VirtualFile{
 		virtualPath: "/foo",
 		isWhiteout:  false,
 		mode:        filePermission,
@@ -451,7 +451,7 @@ func TestClose(t *testing.T) {
 
 	tests := []struct {
 		name string
-		vf   *virtualFile
+		vf   *VirtualFile
 	}{
 		{
 			name: "close root file",
@@ -480,14 +480,14 @@ func TestReadingAfterClose(t *testing.T) {
 	fooSize := int64(len([]byte("foo")))
 	barSize := int64(len([]byte("bar")))
 
-	fooVirtualFile := &virtualFile{
+	fooVirtualFile := &VirtualFile{
 		virtualPath: "/foo",
 		isWhiteout:  false,
 		mode:        filePermission,
 		size:        fooSize,
 		reader:      io.NewSectionReader(contentBlob, 0, fooSize),
 	}
-	barVirtualFile := &virtualFile{
+	barVirtualFile := &VirtualFile{
 		virtualPath: "/bar",
 		isWhiteout:  false,
 		mode:        filePermission,
@@ -497,7 +497,7 @@ func TestReadingAfterClose(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		vf      *virtualFile
+		vf      *VirtualFile
 		want    string
 		wantErr bool
 	}{
@@ -542,7 +542,7 @@ func TestReadingAfterClose(t *testing.T) {
 func TestName(t *testing.T) {
 	tests := []struct {
 		name string
-		node *virtualFile
+		node *VirtualFile
 		want string
 	}{
 		{
@@ -580,7 +580,7 @@ func TestName(t *testing.T) {
 func TestIsDir(t *testing.T) {
 	tests := []struct {
 		name string
-		node *virtualFile
+		node *VirtualFile
 		want bool
 	}{
 		{
@@ -617,7 +617,7 @@ func TestIsDir(t *testing.T) {
 func TestType(t *testing.T) {
 	tests := []struct {
 		name string
-		node *virtualFile
+		node *VirtualFile
 		want fs.FileMode
 	}{
 		{

--- a/testing/fakedetector/fake_detector.go
+++ b/testing/fakedetector/fake_detector.go
@@ -31,9 +31,9 @@ var (
 	)
 )
 
-// fakeDetector is an Detector implementation to be used in tests.
+// FakeDetector is a Detector implementation to be used in tests.
 // It returns a predefined Finding or error.
-type fakeDetector struct {
+type FakeDetector struct {
 	DetName       string
 	DetVersion    int
 	ReqExtractors []string
@@ -42,70 +42,70 @@ type fakeDetector struct {
 }
 
 // New creates an empty new fake detector.
-func New() *fakeDetector {
-	return &fakeDetector{}
+func New() *FakeDetector {
+	return &FakeDetector{}
 }
 
 // Name returns the detector's name.
-func (fd *fakeDetector) Name() string { return fd.DetName }
+func (fd *FakeDetector) Name() string { return fd.DetName }
 
 // Version returns the detector's version.
-func (fd *fakeDetector) Version() int { return fd.DetVersion }
+func (fd *FakeDetector) Version() int { return fd.DetVersion }
 
 // Requirements returns the detector's requirements.
-func (fd *fakeDetector) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+func (fd *FakeDetector) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
 
 // RequiredExtractors returns a list of Extractors that this Detector requires.
-func (fd *fakeDetector) RequiredExtractors() []string { return fd.ReqExtractors }
+func (fd *FakeDetector) RequiredExtractors() []string { return fd.ReqExtractors }
 
 // DetectedFinding returns generic vulnerability information about what is detected.
-func (fd *fakeDetector) DetectedFinding() inventory.Finding {
+func (fd *FakeDetector) DetectedFinding() inventory.Finding {
 	return inventory.Finding{}
 }
 
 // Scan always returns the same predefined finding or error.
-func (fd *fakeDetector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, px *packageindex.PackageIndex) (inventory.Finding, error) {
+func (fd *FakeDetector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, px *packageindex.PackageIndex) (inventory.Finding, error) {
 	return fd.Findings, fd.Err
 }
 
 // WithName sets the fake detector's name.
-func (fd *fakeDetector) WithName(name string) *fakeDetector {
-	newDet := copier.Copy(fd).(*fakeDetector)
+func (fd *FakeDetector) WithName(name string) *FakeDetector {
+	newDet := copier.Copy(fd).(*FakeDetector)
 	newDet.DetName = name
 	return newDet
 }
 
 // WithVersion sets the fake detector's version.
-func (fd *fakeDetector) WithVersion(version int) *fakeDetector {
-	newDet := copier.Copy(fd).(*fakeDetector)
+func (fd *FakeDetector) WithVersion(version int) *FakeDetector {
+	newDet := copier.Copy(fd).(*FakeDetector)
 	newDet.DetVersion = version
 	return newDet
 }
 
 // WithRequiredExtractors sets the fake detector's required extractors.
-func (fd *fakeDetector) WithRequiredExtractors(extractors ...string) *fakeDetector {
-	newDet := copier.Copy(fd).(*fakeDetector)
+func (fd *FakeDetector) WithRequiredExtractors(extractors ...string) *FakeDetector {
+	newDet := copier.Copy(fd).(*FakeDetector)
 	newDet.ReqExtractors = extractors
 	return newDet
 }
 
 // WithPackageVuln sets the fake detector's package vulnerability that is returned when Scan() is called.
-func (fd *fakeDetector) WithPackageVuln(vuln *inventory.PackageVuln) *fakeDetector {
-	newDet := copier.Copy(fd).(*fakeDetector)
+func (fd *FakeDetector) WithPackageVuln(vuln *inventory.PackageVuln) *FakeDetector {
+	newDet := copier.Copy(fd).(*FakeDetector)
 	newDet.Findings.PackageVulns = []*inventory.PackageVuln{vuln}
 	return newDet
 }
 
 // WithGenericFinding sets the fake detector's generic finding that is returned when Scan() is called.
-func (fd *fakeDetector) WithGenericFinding(finding *inventory.GenericFinding) *fakeDetector {
-	newDet := copier.Copy(fd).(*fakeDetector)
+func (fd *FakeDetector) WithGenericFinding(finding *inventory.GenericFinding) *FakeDetector {
+	newDet := copier.Copy(fd).(*FakeDetector)
 	newDet.Findings.GenericFindings = []*inventory.GenericFinding{finding}
 	return newDet
 }
 
 // WithErr sets the fake detector's error that is returned when Scan() is called.
-func (fd *fakeDetector) WithErr(err error) *fakeDetector {
-	newDet := copier.Copy(fd).(*fakeDetector)
+func (fd *FakeDetector) WithErr(err error) *FakeDetector {
+	newDet := copier.Copy(fd).(*FakeDetector)
 	newDet.Err = err
 	return newDet
 }


### PR DESCRIPTION
While not impossible to use, having an unexpected return type on a public method can make it unwieldy

Relates to #274