### PR TITLE
fix: return empty version if version cannot be identified in pomxml

### DIFF
--- a/extractor/filesystem/language/java/pomxml/pomxml.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml.go
@@ -49,7 +49,7 @@ func parseResolvedVersion(version maven.String) string {
 	// First capture group will always exist, but might be empty, therefore the slice will always
 	// have a length of 2.
 	if results == nil || results[1] == "" {
-		return "0"
+		return ""
 	}
 
 	return results[1]

--- a/extractor/filesystem/language/java/pomxml/pomxml_test.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml_test.go
@@ -300,8 +300,8 @@ func TestExtractor_Extract(t *testing.T) {
 					},
 				},
 				{
-					Name:      "org.frank:frank",
-					Version:   "0", // Version is not available in the local pom.xml.
+					Name: "org.frank:frank",
+					// Version is not available in the local pom.xml.
 					Locations: []string{"testdata/with-parent.xml"},
 					Metadata: &javalockfile.Metadata{
 						ArtifactID:   "frank",


### PR DESCRIPTION
Previously, version zero is returned if a dependency version cannot be identified in pom.xml, this is misleading and this PR leaves the version to be empty if it cannot be identified. 