### PR TITLE
refactor: remove unneeded zero-value initializations on `var` variables

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -93,6 +93,8 @@ linters:
           disabled: false
         - name: use-any
           disabled: false
+        - name: var-declaration
+          disabled: false
         - name: var-naming
           disabled: false
     staticcheck:

--- a/detector/govulncheck/binary/binary.go
+++ b/detector/govulncheck/binary/binary.go
@@ -76,7 +76,7 @@ func (Detector) RequiredExtractors() []string {
 func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, px *packageindex.PackageIndex) (inventory.Finding, error) {
 	result := inventory.Finding{}
 	scanned := make(map[string]bool)
-	var allErrs error = nil
+	var allErrs error
 	for _, p := range px.GetAllOfType(purl.TypeGolang) {
 		// We only look at Go binaries (no source code).
 		if !slices.Contains(p.Plugins, gobinary.Name) {

--- a/extractor/filesystem/language/python/wheelegg/wheelegg_test.go
+++ b/extractor/filesystem/language/python/wheelegg/wheelegg_test.go
@@ -489,7 +489,7 @@ func TestExtractEggWithoutSize(t *testing.T) {
 
 	// Set FileInfo to nil, which does not allow input.info.Size(). This is required for unzipping the
 	// egg file.
-	var info fs.FileInfo = nil
+	var info fs.FileInfo
 
 	input := &filesystem.ScanInput{FS: scalibrfs.DirFS("."), Path: path, Info: info, Reader: r}
 	e := wheelegg.Extractor{}

--- a/extractor/filesystem/secrets/secrets.go
+++ b/extractor/filesystem/secrets/secrets.go
@@ -54,7 +54,7 @@ var (
 		".yaml":      true,
 	}
 
-	defaultEngine *veles.DetectionEngine = nil
+	defaultEngine *veles.DetectionEngine
 )
 
 func init() { //nolint:gochecknoinits


### PR DESCRIPTION
Relates to #561
Relates to #274