### PR TITLE
chore: enable `use-any` linter (again)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -91,6 +91,8 @@ linters-settings:
         disabled: false
       - name: unreachable-code
         disabled: false
+      - name: use-any
+        disabled: false
       - name: var-naming
         disabled: false
 


### PR DESCRIPTION
I mistakenly removed this in #561

Relates to https://github.com/google/osv-scalibr/issues/274
Relates to #455