### PR TITLE
feat: decide yanked from index API response

### DIFF
--- a/clients/datasource/internal/pypi/pypi.go
+++ b/clients/datasource/internal/pypi/pypi.go
@@ -68,7 +68,8 @@ func (y *Yanked) UnmarshalJSON(data []byte) error {
 	// Try unmarshalling as a boolean
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
-		y.Value = b
+		// If yanked is a boolean, it is always false.
+		y.Value = false
 		return nil
 	}
 

--- a/clients/datasource/internal/pypi/pypi.go
+++ b/clients/datasource/internal/pypi/pypi.go
@@ -68,8 +68,7 @@ func (y *Yanked) UnmarshalJSON(data []byte) error {
 	// Try unmarshalling as a boolean
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
-		// If yanked is a boolean, it is always false.
-		y.Value = false
+		y.Value = b
 		return nil
 	}
 

--- a/clients/datasource/internal/pypi/pypi.go
+++ b/clients/datasource/internal/pypi/pypi.go
@@ -68,7 +68,7 @@ func (y *Yanked) UnmarshalJSON(data []byte) error {
 	// Try unmarshalling as a boolean
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
-		y.Value = b
+		y.Value = false
 		return nil
 	}
 

--- a/clients/datasource/internal/pypi/pypi.go
+++ b/clients/datasource/internal/pypi/pypi.go
@@ -68,6 +68,7 @@ func (y *Yanked) UnmarshalJSON(data []byte) error {
 	// Try unmarshalling as a boolean
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
+		// If yanked is a boolean, it will always be false.
 		y.Value = false
 		return nil
 	}

--- a/clients/datasource/internal/pypi/pypi.go
+++ b/clients/datasource/internal/pypi/pypi.go
@@ -43,9 +43,9 @@ type Digests struct {
 	SHA256 string `json:"sha256"`
 }
 
-// IndexReponse defines the response of Index API.
+// IndexResponse defines the response of Index API.
 // https://docs.pypi.org/api/index-api/
-type IndexReponse struct {
+type IndexResponse struct {
 	Name     string   `json:"name"`
 	Files    []File   `json:"files"`
 	Versions []string `json:"versions"`
@@ -57,7 +57,8 @@ type File struct {
 	Yanked Yanked `json:"yanked"`
 }
 
-// Custom type to represent the field that can be false or a string
+// Yanked represents the yanked field in the index response.
+// This can either be false or a string representing the yanked reason.
 type Yanked struct {
 	Value bool
 }

--- a/clients/datasource/internal/pypi/pypi.go
+++ b/clients/datasource/internal/pypi/pypi.go
@@ -68,8 +68,7 @@ func (y *Yanked) UnmarshalJSON(data []byte) error {
 	// Try unmarshalling as a boolean
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
-		// If yanked is a boolean, it will always be false.
-		y.Value = false
+		y.Value = b
 		return nil
 	}
 

--- a/clients/datasource/internal/pypi/pypi_test.go
+++ b/clients/datasource/internal/pypi/pypi_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pypi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestYankedUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		want    Yanked
+		wantErr bool
+	}{
+		{
+			name: "boolean false",
+			json: `false`,
+			want: Yanked{Value: false},
+		},
+		{
+			name: "boolean true",
+			json: `true`,
+			want: Yanked{Value: true},
+		},
+		{
+			name: "string reason",
+			json: `"security issue"`,
+			want: Yanked{Value: true},
+		},
+		{
+			name:    "invalid type",
+			json:    `123`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got Yanked
+			err := json.Unmarshal([]byte(tt.json), &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("UnmarshalJSON() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/clients/datasource/pypi_registry.go
+++ b/clients/datasource/pypi_registry.go
@@ -68,10 +68,10 @@ func (p *PyPIRegistryAPIClient) GetVersionJSON(ctx context.Context, project, ver
 }
 
 // GetVersions queries the Index API and returns the list of versions.
-func (p *PyPIRegistryAPIClient) GetIndex(ctx context.Context, project string) (pypi.IndexReponse, error) {
+func (p *PyPIRegistryAPIClient) GetIndex(ctx context.Context, project string) (pypi.IndexResponse, error) {
 	path, err := url.JoinPath(p.registry, "simple", project)
 	if err != nil {
-		return pypi.IndexReponse{}, err
+		return pypi.IndexResponse{}, err
 	}
 
 	// The Index API requires an ending slash.
@@ -79,7 +79,7 @@ func (p *PyPIRegistryAPIClient) GetIndex(ctx context.Context, project string) (p
 		path += "/"
 	}
 
-	var indexResp pypi.IndexReponse
+	var indexResp pypi.IndexResponse
 	err = p.get(ctx, path, true, &indexResp)
 	return indexResp, err
 }

--- a/clients/datasource/pypi_registry.go
+++ b/clients/datasource/pypi_registry.go
@@ -67,7 +67,7 @@ func (p *PyPIRegistryAPIClient) GetVersionJSON(ctx context.Context, project, ver
 	return jsonResp, err
 }
 
-// GetVersions queries the Index API and returns the list of versions.
+// GetIndex queries the Index API and returns the list of versions.
 func (p *PyPIRegistryAPIClient) GetIndex(ctx context.Context, project string) (pypi.IndexResponse, error) {
 	path, err := url.JoinPath(p.registry, "simple", project)
 	if err != nil {

--- a/clients/datasource/pypi_registry.go
+++ b/clients/datasource/pypi_registry.go
@@ -55,7 +55,7 @@ func NewPyPIRegistryAPIClient(registry string) *PyPIRegistryAPIClient {
 	}
 }
 
-// GetVersionJSON queries the JSON API and returns the requires dist for a specific version.
+// GetVersionJSON queries the JSON API and returns the JSON response for the specified version.
 func (p *PyPIRegistryAPIClient) GetVersionJSON(ctx context.Context, project, version string) (pypi.JSONResponse, error) {
 	path, err := url.JoinPath(p.registry, "pypi", project, version, "json")
 	if err != nil {
@@ -68,15 +68,7 @@ func (p *PyPIRegistryAPIClient) GetVersionJSON(ctx context.Context, project, ver
 }
 
 // GetVersions queries the Index API and returns the list of versions.
-func (p *PyPIRegistryAPIClient) GetVersions(ctx context.Context, project string) ([]string, error) {
-	resp, err := p.getIndex(ctx, project)
-	if err != nil {
-		return nil, err
-	}
-	return resp.Versions, nil
-}
-
-func (p *PyPIRegistryAPIClient) getIndex(ctx context.Context, project string) (pypi.IndexReponse, error) {
+func (p *PyPIRegistryAPIClient) GetIndex(ctx context.Context, project string) (pypi.IndexReponse, error) {
 	path, err := url.JoinPath(p.registry, "simple", project)
 	if err != nil {
 		return pypi.IndexReponse{}, err

--- a/clients/datasource/pypi_registry_test.go
+++ b/clients/datasource/pypi_registry_test.go
@@ -115,6 +115,10 @@ func TestGetVersions(t *testing.T) {
 			"upload-time": "2024-03-20T13:00:31.245327Z",
 			"url": "https://files.pythonhosted.org/packages/81/bd/c97d94e2b96f03d1c50bc9de04130e014eda89322ba604923e0c251eb02e/beautifulsoup4-4.13.0b2.tar.gz",
 			"yanked": false
+		  },
+		  {
+			"filename": "beautifulsoup4-4.14.tar.gz",
+			"yanked": "yanked"
 		  }
 		],
 		"meta": {
@@ -126,23 +130,37 @@ func TestGetVersions(t *testing.T) {
 		  "4.0.1",
 		  "4.0.2",
 		  "4.12.3",
-		  "4.13.0b2"
+		  "4.13.0b2",
+		  "4.14"
 		]
   }
 	`))
 
-	got, err := client.GetVersions(context.Background(), "beautifulsoup4")
+	got, err := client.GetIndex(context.Background(), "beautifulsoup4")
 	if err != nil {
 		t.Fatalf("failed to get versions of PyPI project %s: %v", "beautifulsoup4", err)
 	}
-	want := []string{
-		"4.0.1",
-		"4.0.2",
-		"4.12.3",
-		"4.13.0b2",
+	want := pypi.IndexReponse{
+		Name: "beautifulsoup4",
+		Files: []pypi.File{
+			{Name: "beautifulsoup4-4.0.1.tar.gz"},
+			{Name: "beautifulsoup4-4.0.2.tar.gz"},
+			{Name: "beautifulsoup4-4.12.3-py3-none-any.whl"},
+			{Name: "beautifulsoup4-4.12.3.tar.gz"},
+			{Name: "beautifulsoup4-4.13.0b2-py3-none-any.whl"},
+			{Name: "beautifulsoup4-4.13.0b2.tar.gz"},
+			{Name: "beautifulsoup4-4.14.tar.gz", Yanked: pypi.Yanked{Value: true}},
+		},
+		Versions: []string{
+			"4.0.1",
+			"4.0.2",
+			"4.12.3",
+			"4.13.0b2",
+			"4.14",
+		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("GetVersions(%s) mismatch (-want +got):\n%s", "beautifulsoup4", diff)
+		t.Errorf("GetIndex(%s) mismatch (-want +got):\n%s", "beautifulsoup4", diff)
 	}
 }
 

--- a/clients/datasource/pypi_registry_test.go
+++ b/clients/datasource/pypi_registry_test.go
@@ -140,7 +140,7 @@ func TestGetVersions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get versions of PyPI project %s: %v", "beautifulsoup4", err)
 	}
-	want := pypi.IndexReponse{
+	want := pypi.IndexResponse{
 		Name: "beautifulsoup4",
 		Files: []pypi.File{
 			{Name: "beautifulsoup4-4.0.1.tar.gz"},

--- a/clients/resolution/pypi_registry_client.go
+++ b/clients/resolution/pypi_registry_client.go
@@ -16,6 +16,7 @@ package resolution
 
 import (
 	"context"
+	"path/filepath"
 	"slices"
 
 	"deps.dev/util/pypi"
@@ -24,6 +25,7 @@ import (
 	"deps.dev/util/resolve/version"
 	"deps.dev/util/semver"
 	"github.com/google/osv-scalibr/clients/datasource"
+	"github.com/google/osv-scalibr/log"
 )
 
 // PyPIRegistryClient is a client to fetch data from PyPI registry.
@@ -56,18 +58,42 @@ func (c *PyPIRegistryClient) Version(ctx context.Context, vk resolve.VersionKey)
 
 // Versions returns all the available versions of the package specified by the given PackageKey.
 func (c *PyPIRegistryClient) Versions(ctx context.Context, pk resolve.PackageKey) ([]resolve.Version, error) {
-	vers, err := c.api.GetVersions(ctx, pk.Name)
+	resp, err := c.api.GetIndex(ctx, pk.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	slices.SortFunc(vers, func(a, b string) int { return semver.PyPI.Compare(a, b) })
+	slices.SortFunc(resp.Versions, func(a, b string) int { return semver.PyPI.Compare(a, b) })
 
 	var yanked version.AttrSet
 	yanked.SetAttr(version.Blocked, "")
 
+	yankedVersions := make(map[string]bool)
+	for _, file := range resp.Files {
+		var v string
+		switch filepath.Ext(file.Name) {
+		case ".gz":
+			_, v, err = pypi.SdistVersion(resp.Name, file.Name)
+			if err != nil {
+				log.Errorf("failed to extract version from sdist file name %s: %v", file.Name, err)
+				continue
+			}
+		case ".whl":
+			info, err := pypi.ParseWheelName(file.Name)
+			if err != nil {
+				log.Errorf("failed to parse wheel name %s: %v", file.Name, err)
+				continue
+			}
+			v = info.Version
+		}
+		if file.Yanked.Value {
+			// If a file is yanked, assume this version is yanked.
+			yankedVersions[v] = true
+		}
+	}
+
 	var versions []resolve.Version
-	for _, ver := range vers {
+	for _, ver := range resp.Versions {
 		v := resolve.Version{
 			VersionKey: resolve.VersionKey{
 				PackageKey:  pk,
@@ -75,12 +101,7 @@ func (c *PyPIRegistryClient) Versions(ctx context.Context, pk resolve.PackageKey
 				VersionType: resolve.Concrete,
 			},
 		}
-
-		resp, err := c.api.GetVersionJSON(ctx, pk.Name, ver)
-		if err != nil {
-			return nil, err
-		}
-		if resp.Info.Yanked {
+		if yankedVersions[ver] {
 			v.AttrSet = yanked
 		}
 		versions = append(versions, v)

--- a/clients/resolution/pypi_registry_client_test.go
+++ b/clients/resolution/pypi_registry_client_test.go
@@ -116,6 +116,10 @@ func TestVersions(t *testing.T) {
 			"upload-time": "2024-03-20T13:00:31.245327Z",
 			"url": "https://files.pythonhosted.org/packages/81/bd/c97d94e2b96f03d1c50bc9de04130e014eda89322ba604923e0c251eb02e/beautifulsoup4-4.13.0b2.tar.gz",
 			"yanked": false
+		  },
+		  {
+			"filename": "beautifulsoup4-4.14.tar.gz",
+			"yanked": "yanked"
 		  }
 		],
 		"meta": {
@@ -127,31 +131,11 @@ func TestVersions(t *testing.T) {
 		  "4.0.1",
 		  "4.0.2",
 		  "4.12.3",
-		  "4.13.0b2"
+		  "4.13.0b2",
+		  "4.14"
 		]
   }
 	`))
-	srv.SetResponse(t, "pypi/beautifulsoup4/4.0.1/json", []byte(`{
-		"info": {
-			"yanked": true
-		}
-	}`))
-	srv.SetResponse(t, "pypi/beautifulsoup4/4.0.2/json", []byte(`{
-		"info": {
-			"yanked": false
-		}
-	}`))
-	srv.SetResponse(t, "pypi/beautifulsoup4/4.12.3/json", []byte(`
-  {
-		"info": {
-			"yanked": false
-		}
-	}`))
-	srv.SetResponse(t, "pypi/beautifulsoup4/4.13.0b2/json", []byte(`{
-		"info": {
-			"yanked": false
-		}
-	}`))
 
 	pk := resolve.PackageKey{
 		System: resolve.PyPI,
@@ -162,6 +146,7 @@ func TestVersions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get versions %v: %v", pk, err)
 	}
+
 	var yanked version.AttrSet
 	yanked.SetAttr(version.Blocked, "")
 	want := []resolve.Version{
@@ -171,7 +156,6 @@ func TestVersions(t *testing.T) {
 				Version:     "4.0.1",
 				VersionType: resolve.Concrete,
 			},
-			AttrSet: yanked,
 		},
 		{
 			VersionKey: resolve.VersionKey{
@@ -194,9 +178,22 @@ func TestVersions(t *testing.T) {
 				VersionType: resolve.Concrete,
 			},
 		},
+		{
+			VersionKey: resolve.VersionKey{
+				PackageKey:  pk,
+				Version:     "4.14",
+				VersionType: resolve.Concrete,
+			},
+			AttrSet: yanked,
+		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Versions(%v) mismatch (-want +got):\n%s", pk, diff)
+		t.Fatalf("Versions(%v) mismatch (-want +got):\n%s", pk, diff)
+	}
+	for i, v := range got {
+		if !v.AttrSet.Equal(want[i].AttrSet) {
+			t.Errorf("AttrSet for package %s version %s mismatch", v.Name, v.Version)
+		}
 	}
 }
 


### PR DESCRIPTION
Previously to decide whether a version is yanked or not, we fetch all version JSONs, however this slows down the dependency resolution.

In this PR, instead, we parse the index API response and decide whether a version is yanked or not by checking each file in the list.