### PR TITLE
fix: do not put locations in one string for requirements extractor

### DIFF
--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -183,7 +183,7 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 		extraPaths = append(extraPaths, newPaths...)
 		for _, p := range newPKG {
 			// Note the path through which we refer to this requirements.txt file.
-			p.Locations = []string{initPath, p.Locations[0]}
+			p.Locations = []string{initPath, filepath.ToSlash(p.Locations[0])}
 		}
 		pkgs = append(pkgs, newPKG...)
 	}

--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -183,7 +183,7 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 		extraPaths = append(extraPaths, newPaths...)
 		for _, p := range newPKG {
 			// Note the path through which we refer to this requirements.txt file.
-			p.Locations[0] = initPath + ":" + filepath.ToSlash(p.Locations[0])
+			p.Locations = []string{initPath, p.Locations[0]}
 		}
 		pkgs = append(pkgs, newPKG...)
 	}

--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -183,7 +183,7 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 		extraPaths = append(extraPaths, newPaths...)
 		for _, p := range newPKG {
 			// Note the path through which we refer to this requirements.txt file.
-			p.Locations = []string{initPath, filepath.ToSlash(p.Locations[0])}
+			p.Locations = append([]string{initPath}, p.Locations...)
 		}
 		pkgs = append(pkgs, newPKG...)
 	}
@@ -249,7 +249,7 @@ func extractFromPath(reader io.Reader, path string) ([]*extractor.Package, pathQ
 		pkgs = append(pkgs, &extractor.Package{
 			Name:      name,
 			Version:   version,
-			Locations: []string{path},
+			Locations: []string{filepath.ToSlash(path)},
 			Metadata: &Metadata{
 				HashCheckingModeValues: hashOptions,
 				VersionComparator:      comp,

--- a/extractor/filesystem/language/python/requirements/requirements_test.go
+++ b/extractor/filesystem/language/python/requirements/requirements_test.go
@@ -221,7 +221,7 @@ func TestExtract(t *testing.T) {
 				{
 					Name:      "transitive-req",
 					Version:   "1",
-					Locations: []string{"testdata/example.txt:testdata/other-requirements.txt"},
+					Locations: []string{"testdata/example.txt", "testdata/other-requirements.txt"},
 					Metadata:  &requirements.Metadata{Requirement: "transitive-req==1"},
 				},
 			},


### PR DESCRIPTION
Previously, all locations are put into one singe string with `:` as the separator, however we would like the slice of locations instead. This PR fixes this by appending the initial path to the head of the location slice.