### PR TITLE
Annotate packages from cache directories

### DIFF
--- a/extractor/annotator/annotator.go
+++ b/extractor/annotator/annotator.go
@@ -4,24 +4,22 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//
+// Package annotator add Annotation to inventories
 package annotator
 
 import (
-	"path/filepath"
-	"regexp"
-
 	"github.com/google/osv-scalibr/extractor"
 )
 
-// Annotate adds annotations to the inventory
+// Annotate adds annotations to the packages
 func Annotate(pkgs []*extractor.Package) {
 	for _, pkg := range pkgs {
 		for _, loc := range pkg.Locations {
@@ -30,40 +28,4 @@ func Annotate(pkgs []*extractor.Package) {
 			}
 		}
 	}
-}
-
-// Precompile regex patterns to match cache directories
-var cacheDirPatterns = []*regexp.Regexp{
-	// Linux/Unix-like systems
-	regexp.MustCompile(`^/tmp`),                            // Common temporary storage location
-	regexp.MustCompile(`^/var/cache`),                      // Common system cache directory
-	regexp.MustCompile(`^/home/[^/]+/\.local/share/Trash`), // User-specific cache directory
-	regexp.MustCompile(`^/home/[^/]+/\.cache`),             // User-specific cache directory
-
-	// macOS
-	regexp.MustCompile(`^/Users/[^/]+/Library/Caches`),  // User cache directory
-	regexp.MustCompile(`^/private/tmp`),                 // System temporary files location
-	regexp.MustCompile(`^/System/Volumes/Data/var/tmp`), // System temporary files location
-
-	// Windows
-	regexp.MustCompile(`^C\:/Users/[^/]+/AppData/Local/Temp`), // %LOCALAPPDATA%\Temp on Windows
-	regexp.MustCompile(`^C\:/Windows/Temp`),                   // System temporary files
-}
-
-// IsInsideCacheDir checks if the given path is inside a cache directory.
-func IsInsideCacheDir(path string) bool {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return false
-	}
-
-	absPath = filepath.ToSlash(absPath)
-
-	// Check if the absolute path matches any of the known cache directory patterns
-	for _, pattern := range cacheDirPatterns {
-		if pattern.MatchString(absPath) {
-			return true
-		}
-	}
-	return false
 }

--- a/extractor/annotator/annotator.go
+++ b/extractor/annotator/annotator.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 // Package annotator add Annotation to inventories
+// TODO(b/400910349): Migrate into a separate plugin type
 package annotator
 
 import (

--- a/extractor/annotator/annotator.go
+++ b/extractor/annotator/annotator.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotator
+
+import (
+	"path/filepath"
+	"regexp"
+
+	"github.com/google/osv-scalibr/extractor"
+)
+
+// Annotate adds annotations to the inventory
+func Annotate(pkgs []*extractor.Package) {
+	for _, pkg := range pkgs {
+		for _, loc := range pkg.Locations {
+			if IsInsideCacheDir(loc) {
+				pkg.Annotations = append(pkg.Annotations, extractor.InsideCacheDir)
+			}
+		}
+	}
+}
+
+// Precompile regex patterns to match cache directories
+var cacheDirPatterns = []*regexp.Regexp{
+	// Linux/Unix-like systems
+	regexp.MustCompile(`^/tmp`),                            // Common temporary storage location
+	regexp.MustCompile(`^/var/cache`),                      // Common system cache directory
+	regexp.MustCompile(`^/home/[^/]+/\.local/share/Trash`), // User-specific cache directory
+	regexp.MustCompile(`^/home/[^/]+/\.cache`),             // User-specific cache directory
+
+	// macOS
+	regexp.MustCompile(`^/Users/[^/]+/Library/Caches`),  // User cache directory
+	regexp.MustCompile(`^/private/tmp`),                 // System temporary files location
+	regexp.MustCompile(`^/System/Volumes/Data/var/tmp`), // System temporary files location
+
+	// Windows
+	regexp.MustCompile(`^C\:/Users/[^/]+/AppData/Local/Temp`), // %LOCALAPPDATA%\Temp on Windows
+	regexp.MustCompile(`^C\:/Windows/Temp`),                   // System temporary files
+}
+
+// IsInsideCacheDir checks if the given path is inside a cache directory.
+func IsInsideCacheDir(path string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+
+	absPath = filepath.ToSlash(absPath)
+
+	// Check if the absolute path matches any of the known cache directory patterns
+	for _, pattern := range cacheDirPatterns {
+		if pattern.MatchString(absPath) {
+			return true
+		}
+	}
+	return false
+}

--- a/extractor/annotator/cachedir.go
+++ b/extractor/annotator/cachedir.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotator
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/osv-scalibr/log"
+)
+
+type matcher func(string) bool
+
+// patterns to match cache directories
+var cacheDirMatchers = []matcher{
+	// Linux/Unix-like systems
+	func(s string) bool { return strings.HasPrefix(s, "/tmp") },
+	func(s string) bool { return strings.HasPrefix(s, "/var/cache") },
+	regexp.MustCompile(`^/home/[^/]+/\.local/share/Trash`).MatchString,
+	regexp.MustCompile(`^/home/[^/]+/\.cache`).MatchString,
+
+	// macOS
+	regexp.MustCompile(`^/Users/[^/]+/Library/Caches`).MatchString,
+	func(s string) bool { return strings.HasPrefix(s, "/private/tmp") },
+	func(s string) bool { return strings.HasPrefix(s, "/System/Volumes/Data/var/tmp") },
+
+	// Windows
+	regexp.MustCompile(`^C\:/Users/[^/]+/AppData/Local/Temp`).MatchString,
+	func(s string) bool { return strings.HasPrefix(s, "C:/Windows/Temp") },
+}
+
+// IsInsideCacheDir checks if the given path is inside a cache directory.
+func IsInsideCacheDir(path string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+
+	log.Info(absPath)
+
+	absPath = filepath.ToSlash(absPath)
+
+	// Check if the absolute path matches any of the known cache directory patterns
+	for _, match := range cacheDirMatchers {
+		if match(absPath) {
+			return true
+		}
+	}
+	return false
+}

--- a/extractor/annotator/cachedir.go
+++ b/extractor/annotator/cachedir.go
@@ -18,8 +18,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	"github.com/google/osv-scalibr/log"
 )
 
 type matcher func(string) bool
@@ -48,8 +46,6 @@ func IsInsideCacheDir(path string) bool {
 	if err != nil {
 		return false
 	}
-
-	log.Info(absPath)
 
 	absPath = filepath.ToSlash(absPath)
 

--- a/extractor/annotator/cachedir.go
+++ b/extractor/annotator/cachedir.go
@@ -22,22 +22,29 @@ import (
 
 type matcher func(string) bool
 
+var (
+	linuxTrashPattern = regexp.MustCompile(`home/[^/]+/\.local/share/Trash/`)
+	linuxCachePattern = regexp.MustCompile(`home/[^/]+/\.cache/`)
+	macosCachePattern = regexp.MustCompile(`Users/[^/]+/Library/Caches/`)
+	windowsTmpPattern = regexp.MustCompile(`Users/[^/]+/AppData/Local/Temp/`)
+)
+
 // patterns to match cache directories
 var cacheDirMatchers = []matcher{
 	// Linux/Unix-like systems
-	func(s string) bool { return strings.HasPrefix(s, "/tmp") },
-	func(s string) bool { return strings.HasPrefix(s, "/var/cache") },
-	regexp.MustCompile(`^/home/[^/]+/\.local/share/Trash`).MatchString,
-	regexp.MustCompile(`^/home/[^/]+/\.cache`).MatchString,
+	func(s string) bool { return strings.Contains(s, "tmp/") },
+	func(s string) bool { return strings.Contains(s, "var/cache/") },
+	linuxTrashPattern.MatchString,
+	linuxCachePattern.MatchString,
 
 	// macOS
-	regexp.MustCompile(`^/Users/[^/]+/Library/Caches`).MatchString,
-	func(s string) bool { return strings.HasPrefix(s, "/private/tmp") },
-	func(s string) bool { return strings.HasPrefix(s, "/System/Volumes/Data/var/tmp") },
+	macosCachePattern.MatchString,
+	func(s string) bool { return strings.Contains(s, "private/tmp/") },
+	func(s string) bool { return strings.Contains(s, "System/Volumes/Data/var/tmp/") },
 
 	// Windows
-	regexp.MustCompile(`^C\:/Users/[^/]+/AppData/Local/Temp`).MatchString,
-	func(s string) bool { return strings.HasPrefix(s, "C:/Windows/Temp") },
+	windowsTmpPattern.MatchString,
+	func(s string) bool { return strings.Contains(s, "Windows/Temp/") },
 }
 
 // IsInsideCacheDir checks if the given path is inside a cache directory.

--- a/extractor/annotator/cachedir_test.go
+++ b/extractor/annotator/cachedir_test.go
@@ -1,0 +1,53 @@
+package annotator
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsInsideCacheDir(t *testing.T) {
+	// Define test cases with different platform-specific paths
+	testCases := []struct {
+		inputPath string
+		separator rune // defaulting to '/'
+		want      bool
+	}{
+		// Linux/Unix
+		{inputPath: "/tmp/somefile", want: true},
+		{inputPath: "/var/cache/apt/archives", want: true},
+		{inputPath: "/home/user/.local/share/Trash/files/file.txt", want: true},
+		{inputPath: "/home/user/.cache/thumbnails", want: true},
+		{inputPath: "/home/user/projects/code", want: false},
+
+		// macOS
+		{inputPath: "/Users/username/Library/Caches/com.apple.Safari", want: true},
+		{inputPath: "/private/tmp/mytmpfile", want: true},
+		{inputPath: "/System/Volumes/Data/var/tmp/file", want: true},
+		{inputPath: "/Users/username/Documents", want: false},
+
+		// Windows
+		{inputPath: "C:\\Users\\testuser\\AppData\\Local\\Temp\\tempfile.txt", separator: '\\', want: true},
+		{inputPath: "C:\\Windows\\Temp\\log.txt", separator: '\\', want: true},
+		{inputPath: "C:\\Program Files\\MyApp", separator: '\\', want: false},
+
+		// Edge cases
+		{inputPath: "", want: false},
+		{inputPath: "some/relative/path", want: false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.inputPath, func(t *testing.T) {
+			if tt.separator == 0 {
+				tt.separator = '/'
+			}
+
+			if os.PathSeparator != tt.separator {
+				t.Skipf("Skipping IsInsideCacheDir(%q)", tt.inputPath)
+			}
+			got := IsInsideCacheDir(tt.inputPath)
+			if got != tt.want {
+				t.Errorf("IsInsideCacheDir(%q) = %v; want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}

--- a/extractor/annotator/cachedir_test.go
+++ b/extractor/annotator/cachedir_test.go
@@ -22,7 +22,8 @@ func TestIsInsideCacheDir(t *testing.T) {
 		// macOS
 		{inputPath: "/Users/username/Library/Caches/com.apple.Safari", want: true},
 		{inputPath: "/private/tmp/mytmpfile", want: true},
-		{inputPath: "/System/Volumes/Data/var/tmp/file", want: true},
+		{inputPath: "/System/Volumes/Data/private/var/tmp/file", want: true},
+		{inputPath: "/System/Volumes/Data/private/tmp/file", want: true},
 		{inputPath: "/Users/username/Documents", want: false},
 
 		// Windows

--- a/scalibr.go
+++ b/scalibr.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/osv-scalibr/artifact/image/layerscanning/trace"
 	"github.com/google/osv-scalibr/detector"
 	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/annotator"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/extractor/standalone"
 	"github.com/google/osv-scalibr/inventory"
@@ -237,6 +238,9 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 
 	sro.Inventory.Append(standaloneInv)
 	sro.ExtractorStatus = append(sro.ExtractorStatus, standaloneStatus...)
+
+	// add annotations to the pkgs
+	annotator.Annotate(sro.Inventory.Packages)
 
 	px, err := packageindex.New(sro.Inventory.Packages)
 	if err != nil {


### PR DESCRIPTION
This PRs contains the annotator package implementation, which adds annotations to the packages extracted from `scalibr`.

The implementation is pretty rough and minimal, feel free to leave suggestion on different ways to structure the code.

