### PR TITLE
refactor: Pass inventory.Inventory to AfterExtractorRun

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -17,15 +17,10 @@ package detector
 
 import (
 	"context"
-	"fmt"
-	"reflect"
-	"time"
-
 	"github.com/google/osv-scalibr/extractor"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/packageindex"
 	"github.com/google/osv-scalibr/plugin"
-	"github.com/google/osv-scalibr/stats"
 )
 
 // Detector is the interface for a security detector plugin, used to scan for security findings
@@ -132,47 +127,3 @@ type TargetDetails struct {
 }
 
 // LINT.ThenChange(/binary/proto/scan_result.proto)
-
-// Run runs the specified detectors and returns their findings,
-// as well as info about whether the plugin runs completed successfully.
-func Run(ctx context.Context, c stats.Collector, detectors []Detector, scanRoot *scalibrfs.ScanRoot, index *packageindex.PackageIndex) ([]*Finding, []*plugin.Status, error) {
-	findings := []*Finding{}
-	status := []*plugin.Status{}
-	for _, d := range detectors {
-		if ctx.Err() != nil {
-			return nil, nil, ctx.Err()
-		}
-		start := time.Now()
-		results, err := d.Scan(ctx, scanRoot, index)
-		c.AfterDetectorRun(d.Name(), time.Since(start), err)
-		for _, f := range results {
-			f.Detectors = []string{d.Name()}
-		}
-		findings = append(findings, results...)
-		status = append(status, plugin.StatusFromErr(d, false, err))
-	}
-	if err := validateAdvisories(findings); err != nil {
-		return []*Finding{}, status, err
-	}
-	return findings, status, nil
-}
-
-func validateAdvisories(findings []*Finding) error {
-	// Check that findings with the same advisory ID have identical advisories.
-	ids := make(map[AdvisoryID]Advisory)
-	for _, f := range findings {
-		if f.Adv == nil {
-			return fmt.Errorf("finding has no advisory set: %v", f)
-		}
-		if f.Adv.ID == nil {
-			return fmt.Errorf("finding has no advisory ID set: %v", f)
-		}
-		if adv, ok := ids[*f.Adv.ID]; ok {
-			if !reflect.DeepEqual(adv, *f.Adv) {
-				return fmt.Errorf("multiple non-identical advisories with ID %v", f.Adv.ID)
-			}
-		}
-		ids[*f.Adv.ID] = *f.Adv
-	}
-	return nil
-}

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -17,6 +17,7 @@ package detector
 
 import (
 	"context"
+
 	"github.com/google/osv-scalibr/extractor"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/packageindex"

--- a/detector/detector/detectorrunner.go
+++ b/detector/detector/detectorrunner.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package detectorrunner provides a Run function to help with running detectors
+package detectorrunner
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/osv-scalibr/detector"
+	"reflect"
+	"time"
+
+	scalibrfs "github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/packageindex"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/stats"
+)
+
+// LINT.ThenChange(/binary/proto/scan_result.proto)
+
+// Run runs the specified detectors and returns their findings,
+// as well as info about whether the plugin runs completed successfully.
+func Run(ctx context.Context, c stats.Collector, detectors []detector.Detector, scanRoot *scalibrfs.ScanRoot, index *packageindex.PackageIndex) ([]*detector.Finding, []*plugin.Status, error) {
+	findings := []*detector.Finding{}
+	status := []*plugin.Status{}
+	for _, d := range detectors {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+		start := time.Now()
+		results, err := d.Scan(ctx, scanRoot, index)
+		c.AfterDetectorRun(d.Name(), time.Since(start), err)
+		for _, f := range results {
+			f.Detectors = []string{d.Name()}
+		}
+		findings = append(findings, results...)
+		status = append(status, plugin.StatusFromErr(d, false, err))
+	}
+	if err := validateAdvisories(findings); err != nil {
+		return []*detector.Finding{}, status, err
+	}
+	return findings, status, nil
+}
+
+func validateAdvisories(findings []*detector.Finding) error {
+	// Check that findings with the same advisory ID have identical advisories.
+	ids := make(map[detector.AdvisoryID]detector.Advisory)
+	for _, f := range findings {
+		if f.Adv == nil {
+			return fmt.Errorf("finding has no advisory set: %v", f)
+		}
+		if f.Adv.ID == nil {
+			return fmt.Errorf("finding has no advisory ID set: %v", f)
+		}
+		if adv, ok := ids[*f.Adv.ID]; ok {
+			if !reflect.DeepEqual(adv, *f.Adv) {
+				return fmt.Errorf("multiple non-identical advisories with ID %v", f.Adv.ID)
+			}
+		}
+		ids[*f.Adv.ID] = *f.Adv
+	}
+	return nil
+}

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -17,6 +17,7 @@ package detector_test
 import (
 	"context"
 	"errors"
+	detectorrunner "github.com/google/osv-scalibr/detector/detector"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -152,17 +153,17 @@ func TestRun(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			px, _ := packageindex.New([]*extractor.Package{})
 			tmp := t.TempDir()
-			gotFindings, gotStatus, err := detector.Run(
+			gotFindings, gotStatus, err := detectorrunner.Run(
 				context.Background(), stats.NoopCollector{}, tc.det, scalibrfs.RealFSScanRoot(tmp), px,
 			)
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("detector.Run(%v): unexpected error (-want +got):\n%s", tc.det, diff)
+				t.Errorf("detectorrunner.Run(%v): unexpected error (-want +got):\n%s", tc.det, diff)
 			}
 			if diff := cmp.Diff(tc.wantFindings, gotFindings); diff != "" {
-				t.Errorf("detector.Run(%v): unexpected findings (-want +got):\n%s", tc.det, diff)
+				t.Errorf("detectorrunner.Run(%v): unexpected findings (-want +got):\n%s", tc.det, diff)
 			}
 			if diff := cmp.Diff(tc.wantStatus, gotStatus); diff != "" {
-				t.Errorf("detector.Run(%v): unexpected status (-want +got):\n%s", tc.det, diff)
+				t.Errorf("detectorrunner.Run(%v): unexpected status (-want +got):\n%s", tc.det, diff)
 			}
 		})
 	}

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -17,12 +17,12 @@ package detector_test
 import (
 	"context"
 	"errors"
-	detectorrunner "github.com/google/osv-scalibr/detector/detector"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/detector"
+	"github.com/google/osv-scalibr/detector/detectorrunner"
 	"github.com/google/osv-scalibr/extractor"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/packageindex"

--- a/detector/detectorrunner/detectorrunner.go
+++ b/detector/detectorrunner/detectorrunner.go
@@ -18,10 +18,10 @@ package detectorrunner
 import (
 	"context"
 	"fmt"
-	"github.com/google/osv-scalibr/detector"
 	"reflect"
 	"time"
 
+	"github.com/google/osv-scalibr/detector"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/packageindex"
 	"github.com/google/osv-scalibr/plugin"

--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -479,7 +479,12 @@ func (wc *walkContext) runExtractor(ex Extractor, path string) {
 		Info:   info,
 		Reader: rc,
 	})
-	wc.stats.AfterExtractorRun(ex.Name(), time.Since(start), err)
+	wc.stats.AfterExtractorRun(ex.Name(), stats.AfterExtractorStats{
+		Path:      path,
+		Runtime:   time.Since(start),
+		Inventory: &results,
+		Error:     err,
+	})
 
 	if err != nil {
 		addErrToMap(wc.errors, ex.Name(), fmt.Errorf("%s: %w", path, err))

--- a/scalibr.go
+++ b/scalibr.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	detectorrunner "github.com/google/osv-scalibr/detector/detector"
 	"regexp"
 	"slices"
 	"sort"
@@ -248,7 +249,7 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 		return newScanResult(sro)
 	}
 
-	findings, detectorStatus, err := detector.Run(
+	findings, detectorStatus, err := detectorrunner.Run(
 		ctx, config.Stats, config.Detectors, &scalibrfs.ScanRoot{FS: sysroot.FS, Path: sysroot.Path}, px,
 	)
 	sro.Inventory.Findings = append(sro.Inventory.Findings, findings...)

--- a/scalibr.go
+++ b/scalibr.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	detectorrunner "github.com/google/osv-scalibr/detector/detector"
 	"regexp"
 	"slices"
 	"sort"
@@ -31,6 +30,7 @@ import (
 	"github.com/google/osv-scalibr/artifact/image/layerscanning/image"
 	"github.com/google/osv-scalibr/artifact/image/layerscanning/trace"
 	"github.com/google/osv-scalibr/detector"
+	"github.com/google/osv-scalibr/detector/detectorrunner"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/extractor/standalone"
@@ -284,7 +284,7 @@ func (s Scanner) ScanContainer(ctx context.Context, img *image.Image, config *Sc
 	}
 	// Overwrite the scan roots with the chain layer filesystem.
 	config.ScanRoots = []*scalibrfs.ScanRoot{
-		&scalibrfs.ScanRoot{
+		{
 			FS: chainfs,
 		},
 	}

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -26,7 +26,7 @@ import (
 // different metric backends to enable monitoring of Scalibr.
 type Collector interface {
 	AfterInodeVisited(path string)
-	AfterExtractorRun(name string, runtime time.Duration, err error)
+	AfterExtractorRun(pluginName string, extractorstats AfterExtractorStats)
 	AfterDetectorRun(name string, runtime time.Duration, err error)
 	AfterScan(runtime time.Duration, status *plugin.ScanStatus)
 
@@ -60,7 +60,7 @@ type NoopCollector struct{}
 func (c NoopCollector) AfterInodeVisited(path string) {}
 
 // AfterExtractorRun implements Collector by doing nothing.
-func (c NoopCollector) AfterExtractorRun(name string, runtime time.Duration, err error) {}
+func (c NoopCollector) AfterExtractorRun(pluginName string, extractorstats AfterExtractorStats) {}
 
 // AfterDetectorRun implements Collector by doing nothing.
 func (c NoopCollector) AfterDetectorRun(name string, runtime time.Duration, err error) {}

--- a/stats/types.go
+++ b/stats/types.go
@@ -14,6 +14,20 @@
 
 package stats
 
+import (
+	"github.com/google/osv-scalibr/inventory"
+	"time"
+)
+
+// AfterExtractorStats is a struct containing stats about results of the a file extraction run
+type AfterExtractorStats struct {
+	Path    string
+	Runtime time.Duration
+
+	Inventory *inventory.Inventory
+	Error     error
+}
+
 // FileRequiredStats is a struct containing stats about a file that was
 // required or skipped by a plugin.
 type FileRequiredStats struct {

--- a/stats/types.go
+++ b/stats/types.go
@@ -15,8 +15,9 @@
 package stats
 
 import (
-	"github.com/google/osv-scalibr/inventory"
 	"time"
+
+	"github.com/google/osv-scalibr/inventory"
 )
 
 // AfterExtractorStats is a struct containing stats about results of the a file extraction run


### PR DESCRIPTION
This patch allows the AfterExtractor function to get additional access to:
- Path
- Extractor's returned Inventory

And switched AfterExtractor to take a pointer to allow for future additions without making (big) breaking changes. 

Also had to move detector.Run into it's own package, separate from the type definitions to avoid cyclic dependency imports. This makes detector more similar to how extractors are laid out.

This needs to be patched once it's been approved to also update the internal implementation.

