### PR TITLE
fix: only add registry to Maven client when merging parent pom.xml

### DIFF
--- a/clients/resolution/maven_registry_client.go
+++ b/clients/resolution/maven_registry_client.go
@@ -123,18 +123,18 @@ func (c *MavenRegistryClient) Requirements(ctx context.Context, vk resolve.Versi
 		return nil, err
 	}
 
-	// We should not add registries defined in dependencies pom.xml files.
-	apiWithoutRegistries := c.api.WithoutRegistries()
 	// We need to merge parents for potential dependencies in parents.
 	if err := mavenutil.MergeParents(ctx, proj.Parent, &proj, mavenutil.Options{
-		Client:             apiWithoutRegistries,
+		Client: c.api,
+		// We should not add registries defined in dependencies pom.xml files.
+		AddRegistry:        false,
 		AllowLocal:         false,
 		InitialParentIndex: 1,
 	}); err != nil {
 		return nil, err
 	}
 	proj.ProcessDependencies(func(groupID, artifactID, version maven.String) (maven.DependencyManagement, error) {
-		return mavenutil.GetDependencyManagement(ctx, apiWithoutRegistries, groupID, artifactID, version)
+		return mavenutil.GetDependencyManagement(ctx, c.api, groupID, artifactID, version)
 	})
 
 	reqs := make([]resolve.RequirementVersion, 0, len(proj.Dependencies))

--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
@@ -128,6 +128,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	if err := mavenutil.MergeParents(ctx, project.Parent, &project, mavenutil.Options{
 		Input:              input,
 		Client:             e.mavenClient,
+		AddRegistry:        true,
 		AllowLocal:         true,
 		InitialParentIndex: 1,
 	}); err != nil {

--- a/guidedremediation/internal/manifest/maven/pomxml.go
+++ b/guidedremediation/internal/manifest/maven/pomxml.go
@@ -256,6 +256,7 @@ func (r readWriter) Read(path string, fsys scalibrfs.FS) (manifest.Manifest, err
 	if err := mavenutil.MergeParents(ctx, project.Parent, &project, mavenutil.Options{
 		Input:              &filesystem.ScanInput{FS: fsys, Path: path},
 		Client:             r.MavenRegistryAPIClient,
+		AddRegistry:        true,
 		AllowLocal:         true,
 		InitialParentIndex: 1,
 	}); err != nil {

--- a/internal/mavenutil/maven.go
+++ b/internal/mavenutil/maven.go
@@ -50,6 +50,7 @@ type Options struct {
 	Input  *filesystem.ScanInput
 	Client *datasource.MavenRegistryAPIClient
 
+	AddRegistry        bool
 	AllowLocal         bool
 	InitialParentIndex int
 }
@@ -104,7 +105,7 @@ func MergeParents(ctx context.Context, current maven.Parent, result *maven.Proje
 		if err := result.MergeProfiles("", maven.ActivationOS{}); err != nil {
 			return fmt.Errorf("failed to merge default profiles: %w", err)
 		}
-		if opts.Client != nil && len(proj.Repositories) > 0 {
+		if opts.Client != nil && opts.AddRegistry && len(proj.Repositories) > 0 {
 			for _, repo := range proj.Repositories {
 				if err := opts.Client.AddRegistry(datasource.MavenRegistry{
 					URL:              string(repo.URL),
@@ -215,7 +216,8 @@ func GetDependencyManagement(ctx context.Context, client *datasource.MavenRegist
 	// project with parents merged, so we call MergeParents by passing
 	// an empty project.
 	if err := MergeParents(ctx, root, &result, Options{
-		Client:             client.WithoutRegistries(),
+		Client:             client,
+		AddRegistry:        false,
 		AllowLocal:         false,
 		InitialParentIndex: 0,
 	}); err != nil {


### PR DESCRIPTION
When `mvn` fetches pom.xml for dependencies, it uses the repositories defined in effective pom which is generated by merging parent pom.xml, but not the repositories in remote dependency pom.xml. This does not match the behaviour we have in the Maven client and this PR fixes it by following `mvn`'s behaviour. 