### PR TITLE
feat: update the default registry of Maven client if ID matches

### DIFF
--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -69,10 +69,12 @@ type MavenRegistry struct {
 // NewMavenRegistryAPIClient returns a new MavenRegistryAPIClient.
 func NewMavenRegistryAPIClient(registry MavenRegistry) (*MavenRegistryAPIClient, error) {
 	if registry.URL == "" {
+		registry.ID = "central"
 		registry.URL = mavenCentral
 	}
 	if registry.ID == "" {
-		registry.ID = "central"
+		// Gives the default registry an ID so it is not overwritten by registry without an ID in pom.xml.
+		registry.ID = "default"
 	}
 	u, err := url.Parse(registry.URL)
 	if err != nil {

--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -69,8 +69,8 @@ type MavenRegistry struct {
 // NewMavenRegistryAPIClient returns a new MavenRegistryAPIClient.
 func NewMavenRegistryAPIClient(registry MavenRegistry) (*MavenRegistryAPIClient, error) {
 	if registry.URL == "" {
-		registry.ID = "central"
 		registry.URL = mavenCentral
+		registry.ID = "central"
 	}
 	if registry.ID == "" {
 		// Gives the default registry an ID so it is not overwritten by registry without an ID in pom.xml.

--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -70,6 +70,8 @@ type MavenRegistry struct {
 func NewMavenRegistryAPIClient(registry MavenRegistry) (*MavenRegistryAPIClient, error) {
 	if registry.URL == "" {
 		registry.URL = mavenCentral
+	}
+	if registry.ID == "" {
 		registry.ID = "central"
 	}
 	u, err := url.Parse(registry.URL)
@@ -103,6 +105,10 @@ func (m *MavenRegistryAPIClient) WithoutRegistries() *MavenRegistryAPIClient {
 
 // AddRegistry adds the given registry to the list of registries if it has not been added.
 func (m *MavenRegistryAPIClient) AddRegistry(registry MavenRegistry) error {
+	if registry.ID == m.defaultRegistry.ID {
+		return m.updateDefaultRegistry(registry)
+	}
+
 	for _, reg := range m.registries {
 		if reg.ID == registry.ID {
 			return nil
@@ -117,6 +123,16 @@ func (m *MavenRegistryAPIClient) AddRegistry(registry MavenRegistry) error {
 	registry.Parsed = u
 	m.registries = append(m.registries, registry)
 
+	return nil
+}
+
+func (m *MavenRegistryAPIClient) updateDefaultRegistry(registry MavenRegistry) error {
+	u, err := url.Parse(registry.URL)
+	if err != nil {
+		return err
+	}
+	registry.Parsed = u
+	m.defaultRegistry = registry
 	return nil
 }
 

--- a/clients/datasource/maven_registry_test.go
+++ b/clients/datasource/maven_registry_test.go
@@ -115,7 +115,7 @@ func TestMultipleRegistry(t *testing.T) {
 	    <release>3.0.0</release>
 	    <versions>
 	      <version>2.0.0</version>
-		  <version>3.0.0</version>
+		    <version>3.0.0</version>
 	    </versions>
 	  </versioning>
 	</metadata>
@@ -148,7 +148,7 @@ func TestMultipleRegistry(t *testing.T) {
 	    <release>2.0.0</release>
 	    <versions>
 	      <version>1.0.0</version>
-		  <version>2.0.0</version>
+		    <version>2.0.0</version>
 	    </versions>
 	  </versioning>
 	</metadata>
@@ -188,6 +188,73 @@ func TestMultipleRegistry(t *testing.T) {
 		t.Fatalf("failed to get versions for Maven package %s:%s: %v", "org.example", "x.y.z", err)
 	}
 	wantVersions := []maven.String{"1.0.0", "2.0.0", "3.0.0"}
+	if !reflect.DeepEqual(gotVersions, wantVersions) {
+		t.Errorf("GetVersions(%s, %s):\ngot %v\nwant %v\n", "org.example", "x.y.z", gotVersions, wantVersions)
+	}
+}
+
+func TestUpdateDefaultRegistry(t *testing.T) {
+	dft := clienttest.NewMockHTTPServer(t)
+	client, _ := datasource.NewMavenRegistryAPIClient(datasource.MavenRegistry{URL: dft.URL, ReleasesEnabled: true})
+	dft.SetResponse(t, "org/example/x.y.z/maven-metadata.xml", []byte(`
+	<metadata>
+	  <groupId>org.example</groupId>
+	  <artifactId>x.y.z</artifactId>
+	  <versioning>
+	    <latest>1.0.0</latest>
+	    <release>1.0.0</release>
+	    <versions>
+	      <version>1.0.0</version>
+	    </versions>
+	  </versioning>
+	</metadata>
+	`))
+	dft.SetResponse(t, "org/example/x.y.z/1.0.0/x.y.z-1.0.0.pom", []byte(`
+	<project>
+	  <groupId>org.example</groupId>
+	  <artifactId>x.y.z</artifactId>
+	  <version>1.0.0</version>
+	</project>
+	`))
+	gotVersions, err := client.GetVersions(context.Background(), "org.example", "x.y.z")
+	if err != nil {
+		t.Fatalf("failed to get versions for Maven package %s:%s: %v", "org.example", "x.y.z", err)
+	}
+	wantVersions := []maven.String{"1.0.0"}
+	if !reflect.DeepEqual(gotVersions, wantVersions) {
+		t.Errorf("GetVersions(%s, %s):\ngot %v\nwant %v\n", "org.example", "x.y.z", gotVersions, wantVersions)
+	}
+
+	srv := clienttest.NewMockHTTPServer(t)
+	if err := client.AddRegistry(datasource.MavenRegistry{URL: srv.URL, ID: "central", ReleasesEnabled: true}); err != nil {
+		t.Fatalf("failed to add registry %s: %v", srv.URL, err)
+	}
+	srv.SetResponse(t, "org/example/x.y.z/maven-metadata.xml", []byte(`
+	<metadata>
+	  <groupId>org.example</groupId>
+	  <artifactId>x.y.z</artifactId>
+	  <versioning>
+	    <latest>2.0.0</latest>
+	    <release>2.0.0</release>
+	    <versions>
+	      <version>2.0.0</version>
+	    </versions>
+	  </versioning>
+	</metadata>
+	`))
+	srv.SetResponse(t, "org/example/x.y.z/2.0.0/x.y.z-2.0.0.pom", []byte(`
+	<project>
+	  <groupId>org.example</groupId>
+	  <artifactId>x.y.z</artifactId>
+	  <version>2.0.0</version>
+	</project>
+	`))
+
+	gotVersions, err = client.GetVersions(context.Background(), "org.example", "x.y.z")
+	if err != nil {
+		t.Fatalf("failed to get versions for Maven package %s:%s: %v", "org.example", "x.y.z", err)
+	}
+	wantVersions = []maven.String{"2.0.0"}
 	if !reflect.DeepEqual(gotVersions, wantVersions) {
 		t.Errorf("GetVersions(%s, %s):\ngot %v\nwant %v\n", "org.example", "x.y.z", gotVersions, wantVersions)
 	}

--- a/clients/datasource/maven_registry_test.go
+++ b/clients/datasource/maven_registry_test.go
@@ -209,7 +209,7 @@ func TestUpdateDefaultRegistry(t *testing.T) {
 	  </versioning>
 	</metadata>
 	`))
-	
+
 	gotVersions, err := client.GetVersions(context.Background(), "org.example", "x.y.z")
 	if err != nil {
 		t.Fatalf("failed to get versions for Maven package %s:%s: %v", "org.example", "x.y.z", err)

--- a/clients/datasource/maven_registry_test.go
+++ b/clients/datasource/maven_registry_test.go
@@ -209,13 +209,7 @@ func TestUpdateDefaultRegistry(t *testing.T) {
 	  </versioning>
 	</metadata>
 	`))
-	dft.SetResponse(t, "org/example/x.y.z/1.0.0/x.y.z-1.0.0.pom", []byte(`
-	<project>
-	  <groupId>org.example</groupId>
-	  <artifactId>x.y.z</artifactId>
-	  <version>1.0.0</version>
-	</project>
-	`))
+	
 	gotVersions, err := client.GetVersions(context.Background(), "org.example", "x.y.z")
 	if err != nil {
 		t.Fatalf("failed to get versions for Maven package %s:%s: %v", "org.example", "x.y.z", err)
@@ -241,13 +235,6 @@ func TestUpdateDefaultRegistry(t *testing.T) {
 	    </versions>
 	  </versioning>
 	</metadata>
-	`))
-	srv.SetResponse(t, "org/example/x.y.z/2.0.0/x.y.z-2.0.0.pom", []byte(`
-	<project>
-	  <groupId>org.example</groupId>
-	  <artifactId>x.y.z</artifactId>
-	  <version>2.0.0</version>
-	</project>
 	`))
 
 	gotVersions, err = client.GetVersions(context.Background(), "org.example", "x.y.z")

--- a/clients/datasource/maven_registry_test.go
+++ b/clients/datasource/maven_registry_test.go
@@ -226,7 +226,7 @@ func TestUpdateDefaultRegistry(t *testing.T) {
 	}
 
 	srv := clienttest.NewMockHTTPServer(t)
-	if err := client.AddRegistry(datasource.MavenRegistry{URL: srv.URL, ID: "central", ReleasesEnabled: true}); err != nil {
+	if err := client.AddRegistry(datasource.MavenRegistry{URL: srv.URL, ID: "default", ReleasesEnabled: true}); err != nil {
 		t.Fatalf("failed to add registry %s: %v", srv.URL, err)
 	}
 	srv.SetResponse(t, "org/example/x.y.z/maven-metadata.xml", []byte(`


### PR DESCRIPTION
If there is a repository with `central` ID defined in pom.xml it should overwrite the default Maven Central in [Super POM](https://maven.apache.org/ref/3.0.4/maven-model-builder/super-pom.html). 

In the Maven client, if the ID of a registry matches the default registry, the default registry will be updated. Also to prevent a repository without an ID to override the default registry, give the default registry an `default` ID.