### PR TITLE
refactor: use lowercase in error message

### DIFF
--- a/extractor/standalone/windows/dismpatch/dismparser/dism_parser.go
+++ b/extractor/standalone/windows/dismpatch/dismparser/dism_parser.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// ErrParsingError indicates an error while parsing the DISM output.
-	ErrParsingError = errors.New("Could not parse DISM output successfully")
+	ErrParsingError = errors.New("could not parse DISM output successfully")
 
 	versionRegexp = regexp.MustCompile(`~(\d+\.\d+\.\d+\.\d+)$`)
 )


### PR DESCRIPTION
This was mistakenly reverted in #634 - there is actually at least one linter enabled that's meant to be enforcing this but it is not currently working properly for some reason; I'm looking into why that is, but for now just fixing this manually