### PR TITLE
feat: do not perform dependency resolution if requirements in hash-checking mode

### DIFF
--- a/extractor/filesystem/language/python/requirementsnet/requirements_test.go
+++ b/extractor/filesystem/language/python/requirementsnet/requirements_test.go
@@ -25,10 +25,11 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirementsnet"
 	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
 	"github.com/google/osv-scalibr/testing/extracttest"
 )
 
-func TestExtract(t *testing.T) {
+func TestExtractor_Extract(t *testing.T) {
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "basic",
@@ -66,6 +67,131 @@ func TestExtract(t *testing.T) {
 					Version:   "2.0.0",
 					Locations: []string{"testdata/requirements.txt"},
 				},
+			},
+		},
+		{
+			// Copied from offline requirements extractor
+			Name: "hash checking mode",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/hash-checking.txt",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					// foo1==1.0 --hash=sha256:
+					Name:      "foo1",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"sha256:123"}, Requirement: "foo1==1.0"},
+				},
+				{
+					// foo2==1.0 --hash=sha256:123 --global-option=foo --config-settings=bar
+					Name:      "foo2",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"sha256:123"}, Requirement: "foo2==1.0"},
+				},
+				{
+					// foo3==1.0 --config-settings=bar --global-option=foo --hash=sha256:123
+					Name:      "foo3",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"sha256:123"}, Requirement: "foo3==1.0"},
+				},
+				{
+					// foo4==1.0 --hash=wrongformatbutok
+					Name:      "foo4",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"wrongformatbutok"}, Requirement: "foo4==1.0"},
+				},
+				{
+					// foo5==1.0; python_version < "2.7" --hash=sha256:123
+					Name:      "foo5",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"sha256:123"}, Requirement: "foo5==1.0; python_version < \"2.7\""},
+				},
+				{
+					// foo6==1.0 --hash=sha256:123 unexpected_text_after_first_option_does_not_stay_around --global-option=foo
+					Name:      "foo6",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"sha256:123"}, Requirement: "foo6==1.0"},
+				},
+				{
+					// foo7==1.0 unexpected_text_before_options_stays_around --hash=sha256:123
+					Name:      "foo7",
+					Version:   "1.0unexpected_text_before_options_stays_around",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"sha256:123"}, Requirement: "foo7==1.0 unexpected_text_before_options_stays_around"},
+				},
+				{
+					// foo8==1.0 --hash=sha256:123 --hash=sha256:456
+					Name:      "foo8",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"sha256:123", "sha256:456"}, Requirement: "foo8==1.0"},
+				},
+				{
+					// foo9==1.0 --hash=sha256:123 \
+					// 	--hash=sha256:456
+					Name:      "foo9",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"sha256:123", "sha256:456"}, Requirement: "foo9==1.0"},
+				},
+				// missing a version
+				// foo10== --hash=sha256:123 --hash=sha256:123
+				{
+					// foo11==1.0 --hash=sha256:not_base16_encoded_is_ok_;#
+					Name:      "foo11",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{"sha256:not_base16_encoded_is_ok_;#"}, Requirement: "foo11==1.0"},
+				},
+				{
+					// foo12==1.0 --hash=
+					Name:      "foo12",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{}, Requirement: "foo12==1.0"},
+				},
+				{
+					// foo13==1.0 --hash sha256:123
+					// The hash in this case is not recognized because it does not use an "=" separator
+					// as specified by https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode,
+					// but it is dropped from the version.
+					Name:      "foo13",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{}, Requirement: "foo13==1.0"},
+				},
+				{
+					// foo14=1.0 -C bar
+					// short form for --config-settings flag, see https://pip.pypa.io/en/stable/cli/pip_install/#install-config-settings
+					Name:      "foo14",
+					Version:   "1.0",
+					PURLType:  purl.TypePyPi,
+					Locations: []string{"testdata/hash-checking.txt"},
+					Metadata:  &requirements.Metadata{VersionComparator: "==", HashCheckingModeValues: []string{}, Requirement: "foo14==1.0"},
+				},
+				// Per the grammar in https://peps.python.org/pep-0508/#grammar, "--config-settings" may be
+				// a valid version component, but such a string is not allowed as a version by
+				// https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers.
+				//
+				// foo15== --config-settings --hash=sha256:123
 			},
 		},
 	}

--- a/extractor/filesystem/language/python/requirementsnet/testdata/hash-checking.txt
+++ b/extractor/filesystem/language/python/requirementsnet/testdata/hash-checking.txt
@@ -1,0 +1,30 @@
+foo1==1.0 --hash=sha256:123
+
+foo2==1.0 --hash=sha256:123 --global-option=foo --config-settings=bar
+
+foo3==1.0 --config-settings=bar --global-option=foo --hash=sha256:123
+
+foo4==1.0 --hash=wrongformatbutok
+
+foo5==1.0; python_version < "2.7" --hash=sha256:123
+
+foo6==1.0 --hash=sha256:123 unexpected_text_after_options_does_not_stay_around
+
+foo7==1.0 unexpected_text_before_options_stays_around --hash=sha256:123
+
+foo8==1.0 --hash=sha256:123 --hash=sha256:456
+
+foo9==1.0 --hash=sha256:123 \
+  --hash=sha256:456
+
+foo10== --hash=sha256:123 --hash=sha256:123
+
+foo11==1.0 --hash=sha256:not_base16_encoded_is_ok_;#
+
+foo12==1.0 --hash=
+
+foo13==1.0 --hash sha256:123
+
+foo14==1.0 -C bar
+
+foo15== --config-settings --hash=sha256:123


### PR DESCRIPTION
https://github.com/google/osv-scalibr/issues/663

If any package in a requirements file has hashes, this indicates it's in [hash-checking mode](https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode), and thus dependencies that are not listed in the requirements file won't be installed. 

In this PR, we skip dependency resolution for hash-checking mode so we don't waste efforts on resolving a potential lockfile.