### PR TITLE
chore: make start of comment match exported thing

### DIFF
--- a/artifact/image/layerscanning/testing/fakelayerbuilder/extractor.go
+++ b/artifact/image/layerscanning/testing/fakelayerbuilder/extractor.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/osv-scalibr/purl"
 )
 
-// Extractor extracts FakeTestLayers built from the FakeLayerBuilder
+// FakeTestLayersExtractor extracts FakeTestLayers built from the FakeLayerBuilder
 type FakeTestLayersExtractor struct {
 }
 

--- a/extractor/standalone/containers/containerd/containerd_linux.go
+++ b/extractor/standalone/containers/containerd/containerd_linux.go
@@ -126,7 +126,7 @@ func (e Extractor) Requirements() *plugin.Capabilities {
 	}
 }
 
-// Extractor extracts containers from the containerd API.
+// Extract extracts containers from the containerd API.
 func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) (inventory.Inventory, error) {
 	var result = []*extractor.Package{}
 	if e.checkIfSocketExists {

--- a/extractor/standalone/containers/docker/docker.go
+++ b/extractor/standalone/containers/docker/docker.go
@@ -59,7 +59,7 @@ func (e Extractor) Requirements() *plugin.Capabilities {
 	return &plugin.Capabilities{RunningSystem: true}
 }
 
-// Extractor extracts containers from the docker API.
+// Extract extracts containers from the docker API.
 func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) (inventory.Inventory, error) {
 	if e.client == nil {
 		var err error


### PR DESCRIPTION
This will be enforced by the linter in the future

Relates to #274