### PR TITLE
chore: ensure package comment starts with capital "P"

### DIFF
--- a/guidedremediation/result/result.go
+++ b/guidedremediation/result/result.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package result defines the remediation result structs
+// Package result defines the remediation result structs
 package result
 
 import (


### PR DESCRIPTION
This will be enforced by the linter in the future

Relates to #274