### PR TITLE
chore(extractor/gemfilelock): add comment to `Extract` method

### DIFF
--- a/extractor/filesystem/language/ruby/gemfilelock/gemfilelock.go
+++ b/extractor/filesystem/language/ruby/gemfilelock/gemfilelock.go
@@ -110,6 +110,7 @@ func parseLockfileSections(input *filesystem.ScanInput) ([]*gemlockSection, erro
 	return sections, nil
 }
 
+// Extract extracts packages from the Gemfile.lock file.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	sections, err := parseLockfileSections(input)
 	if err != nil {


### PR DESCRIPTION
This will be enforced by the linter in the future

Relates to #274
Relates to #455
Relates to #768