### PR TITLE
feat: also check error in the resolved graph

### DIFF
--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
@@ -201,6 +201,10 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	if err != nil {
 		return inventory.Inventory{}, fmt.Errorf("failed resolving %v: %w", root, err)
 	}
+	if g.Error != "" {
+		return inventory.Inventory{}, fmt.Errorf("failed resolving %v: %s", root, g.Error)
+	}
+
 	copy(g.Edges, g.Edges)
 
 	details := map[string]*extractor.Package{}

--- a/extractor/filesystem/language/python/requirementsnet/requirements.go
+++ b/extractor/filesystem/language/python/requirementsnet/requirements.go
@@ -154,7 +154,10 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 
 	g, err := resolver.Resolve(ctx, root.VersionKey)
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("failed resolving %v: %w", root, err)
+		return inventory.Inventory{}, fmt.Errorf("failed resolving: %w", err)
+	}
+	if g.Error != "" {
+		return inventory.Inventory{}, fmt.Errorf("failed resolving: %s", g.Error)
 	}
 
 	pkgs := []*extractor.Package{}


### PR DESCRIPTION
There may be graph-wide resolution [error](https://github.com/google/deps.dev/blob/main/util/resolve/graph.go#L67) in the resolve graph so we should return the error if it's not empty.