### PR TITLE
Add --cdx-component-type flag to SCALIBR.

### DIFF
--- a/binary/scalibr/scalibr.go
+++ b/binary/scalibr/scalibr.go
@@ -82,6 +82,7 @@ func parseFlags(args []string) (*cli.Flags, error) {
 	spdxDocumentNamespace := fs.String("spdx-document-namespace", "", "The 'documentNamespace' field for the output SPDX document")
 	spdxCreators := fs.String("spdx-creators", "", "The 'creators' field for the output SPDX document. Format is --spdx-creators=creatortype1:creator1,creatortype2:creator2")
 	cdxComponentName := fs.String("cdx-component-name", "", "The 'metadata.component.name' field for the output CDX document")
+	cdxComponentType := fs.String("cdx-component-type", "", "The 'metadata.component.type' field for the output CDX document")
 	cdxComponentVersion := fs.String("cdx-component-version", "", "The 'metadata.component.version' field for the output CDX document")
 	cdxAuthors := fs.String("cdx-authors", "", "The 'authors' field for the output CDX document. Format is --cdx-authors=author1,author2")
 	verbose := fs.Bool("verbose", false, "Enable this to print debug logs")
@@ -120,6 +121,7 @@ func parseFlags(args []string) (*cli.Flags, error) {
 		SPDXDocumentNamespace:      *spdxDocumentNamespace,
 		SPDXCreators:               *spdxCreators,
 		CDXComponentName:           *cdxComponentName,
+		CDXComponentType:           *cdxComponentType,
 		CDXComponentVersion:        *cdxComponentVersion,
 		CDXAuthors:                 *cdxAuthors,
 		Verbose:                    *verbose,

--- a/binary/scalibr/scalibr_test.go
+++ b/binary/scalibr/scalibr_test.go
@@ -45,6 +45,12 @@ func TestRun(t *testing.T) {
 			want:      0,
 		},
 		{
+			desc:      "extract with supported cdx-component-type",
+			setupFunc: tempDir,
+			args:      []string{"scalibr", "--root", "{dir}", "--o", "cdx-json=bom.cdx.json", "--extractors", "dotnet/depsjson", "--cdx-component-type", "library"},
+			want:      0,
+		},
+		{
 			desc:      "scan subcommand with arg before flags",
 			setupFunc: tempDir,
 			args:      []string{"scalibr", "scan", "unknown", "--root", "{dir}", "--result", filepath.Join("{dir}", "result.textproto")},
@@ -56,6 +62,12 @@ func TestRun(t *testing.T) {
 			// 'unknown' should be treated as the first argument to 'scan', which should fail as it's equivalent to the above test.
 			args: []string{"scalibr", "unknown", "--root", "{dir}", "--result", filepath.Join("{dir}", "result.textproto")},
 			want: 1,
+		},
+		{
+			desc:      "extract with unknown cdx-component-type",
+			setupFunc: tempDir,
+			args:      []string{"scalibr", "--root", "{dir}", "--o", "cdx-json=bom.cdx.json", "--extractors", "dotnet/depsjson", "--cdx-component-type", "anything"},
+			want:      1,
 		},
 	}
 

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -185,6 +185,7 @@ func toDocElementID(id string) common.DocElementID {
 type CDXConfig struct {
 	ComponentName    string
 	ComponentVersion string
+	ComponentType    string
 	Authors          []string
 }
 
@@ -196,6 +197,7 @@ func ToCDX(r *scalibr.ScanResult, c CDXConfig) *cyclonedx.BOM {
 		Component: &cyclonedx.Component{
 			Name:    c.ComponentName,
 			Version: c.ComponentVersion,
+			Type:    cyclonedx.ComponentType(c.ComponentType),
 			BOMRef:  uuid.New().String(),
 		},
 		Tools: &cyclonedx.ToolsChoice{

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -637,6 +637,56 @@ func TestToCDX(t *testing.T) {
 				}),
 			},
 		},
+		{
+			desc: "Package with custom config and cdx-component-type",
+			scanResult: &scalibr.ScanResult{
+				Inventory: inventory.Inventory{
+					Packages: []*extractor.Package{{
+						Name:     "software",
+						Version:  "1.2.3",
+						PURLType: purl.TypePyPi,
+						Plugins:  []string{wheelegg.Name},
+					}},
+				},
+			},
+			config: converter.CDXConfig{
+				ComponentName:    "sbom-2",
+				ComponentType:    "library",
+				ComponentVersion: "1.0.0",
+				Authors:          []string{"author"},
+			},
+			want: &cyclonedx.BOM{
+				Metadata: &cyclonedx.Metadata{
+					Component: &cyclonedx.Component{
+						Name:    "sbom-2",
+						Type:    cyclonedx.ComponentTypeLibrary,
+						Version: "1.0.0",
+						BOMRef:  "81855ad8-681d-4d86-91e9-1e00167939cb",
+					},
+					Authors: ptr([]cyclonedx.OrganizationalContact{{Name: "author"}}),
+					Tools: &cyclonedx.ToolsChoice{
+						Components: &[]cyclonedx.Component{
+							{
+								Type: cyclonedx.ComponentTypeApplication,
+								Name: "SCALIBR",
+								ExternalReferences: ptr([]cyclonedx.ExternalReference{
+									{URL: "https://github.com/google/osv-scalibr", Type: cyclonedx.ERTypeWebsite},
+								}),
+							},
+						},
+					},
+				},
+				Components: ptr([]cyclonedx.Component{
+					{
+						BOMRef:     "6694d2c4-22ac-4208-a007-2939487f6999",
+						Type:       "library",
+						Name:       "software",
+						Version:    "1.2.3",
+						PackageURL: "pkg:pypi/software@1.2.3",
+					},
+				}),
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Adds a flag name `cdx-component-type` to allow specifying the component type then generating CDX documents.

This PR relates to issue #802.