### PR TITLE
Added registryAuths copy to WithoutRegistries() + test cases

### DIFF
--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -113,6 +113,7 @@ func (m *MavenRegistryAPIClient) WithoutRegistries() *MavenRegistryAPIClient {
 		mu:              m.mu,
 		cacheTimestamp:  m.cacheTimestamp,
 		responses:       m.responses,
+		registryAuths:   m.registryAuths,
 	}
 }
 


### PR DESCRIPTION
Fixes #815 

There is a bug where when the Maven Client is being reset to remove custom registries that were added from processing the pom.xml. The authentication configuration that was added when the client was first created with `NewMavenRegistryAPIClient` was forgotten to be copied in the `WithoutRegistries` function. 

Also added test case for regression testing and also validate functionality before and after changes.