### PR TITLE
feat: Write root path in AfterExtractorRun stats call

### DIFF
--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -498,6 +498,7 @@ func (wc *walkContext) runExtractor(ex Extractor, path string, isDir bool) {
 	})
 	wc.stats.AfterExtractorRun(ex.Name(), &stats.AfterExtractorStats{
 		Path:      path,
+		Root:      wc.scanRoot,
 		Runtime:   time.Since(start),
 		Inventory: &results,
 		Error:     err,

--- a/stats/types.go
+++ b/stats/types.go
@@ -23,6 +23,7 @@ import (
 // AfterExtractorStats is a struct containing stats about the results of a file extraction run.
 type AfterExtractorStats struct {
 	Path    string
+	Root    string
 	Runtime time.Duration
 
 	Inventory *inventory.Inventory


### PR DESCRIPTION
Add the scanRoot path to AfterExtractorRun, so I can get the full path of the file that was extracted in AfterExtractorRun.