### PR TITLE
fix: append ecosystem suffix only when local registry is not empty

### DIFF
--- a/binary/cli/cli.go
+++ b/binary/cli/cli.go
@@ -515,7 +515,7 @@ func (f *Flags) extractorsToRun() ([]filesystem.Extractor, []standalone.Extracto
 		if e.Name() == gobinary.Name {
 			e.(*gobinary.Extractor).VersionFromContent = f.GoBinaryVersionFromContent
 		}
-		if e.Name() == pomxmlnet.Name {
+		if e.Name() == pomxmlnet.Name && f.LocalRegistry != "" {
 			e.(*pomxmlnet.Extractor).MavenClient.SetLocalRegistry(filepath.Join(f.LocalRegistry, "maven"))
 		}
 	}

--- a/clients/resolution/combined_native_client.go
+++ b/clients/resolution/combined_native_client.go
@@ -106,7 +106,6 @@ func (c *CombinedNativeClient) clientForSystem(sys resolve.System) (resolve.Clie
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	var err error
-
 	switch sys {
 	case resolve.Maven:
 		if c.mavenRegistryClient == nil {

--- a/clients/resolution/combined_native_client.go
+++ b/clients/resolution/combined_native_client.go
@@ -106,10 +106,15 @@ func (c *CombinedNativeClient) clientForSystem(sys resolve.System) (resolve.Clie
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	var err error
+
 	switch sys {
 	case resolve.Maven:
 		if c.mavenRegistryClient == nil {
-			c.mavenRegistryClient, err = NewMavenRegistryClient(c.opts.MavenRegistry, filepath.Join(c.opts.LocalRegistry, "maven"))
+			localRegistry := c.opts.LocalRegistry
+			if localRegistry != "" {
+				localRegistry = filepath.Join(c.opts.LocalRegistry, "maven")
+			}
+			c.mavenRegistryClient, err = NewMavenRegistryClient(c.opts.MavenRegistry, localRegistry)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Previously, ecosystem suffix is appended to the local registry all the time. By default, local registry is empty and this behaviour makes it non-empty so that the client will try to write the responses to the local file system. 

This PR fixes the behaviour by only appending the ecosystem suffix to non-empty local registry.