### PR TITLE
feat: manifest reader for Python requirements

### DIFF
--- a/guidedremediation/internal/manifest/python/requirements.go
+++ b/guidedremediation/internal/manifest/python/requirements.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package python provides the manifest parsing and writing for Python requirements.txt.
+package python
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+
+	"deps.dev/util/pypi"
+	"deps.dev/util/resolve"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
+	scalibrfs "github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/guidedremediation/internal/manifest"
+	"github.com/google/osv-scalibr/guidedremediation/result"
+	"github.com/google/osv-scalibr/guidedremediation/strategy"
+)
+
+type pythonManifest struct {
+	filePath     string
+	root         resolve.Version
+	requirements []resolve.RequirementVersion
+}
+
+// FilePath returns the path to the manifest file.
+func (m *pythonManifest) FilePath() string {
+	return m.filePath
+}
+
+// Root returns the Version representing this package.
+func (m *pythonManifest) Root() resolve.Version {
+	return m.root
+}
+
+// System returns the ecosystem of this manifest.
+func (m *pythonManifest) System() resolve.System {
+	return resolve.PyPI
+}
+
+// Requirements returns all direct requirements (including dev).
+func (m *pythonManifest) Requirements() []resolve.RequirementVersion {
+	return m.requirements
+}
+
+// Groups returns the dependency groups that the direct requirements belong to.
+func (m *pythonManifest) Groups() map[manifest.RequirementKey][]string {
+	return nil
+}
+
+// LocalManifests returns Manifests of any local packages.
+func (m *pythonManifest) LocalManifests() []manifest.Manifest {
+	return nil
+}
+
+// EcosystemSpecific returns any ecosystem-specific information for this manifest.
+func (m *pythonManifest) EcosystemSpecific() any {
+	return nil
+}
+
+// PatchRequirement modifies the manifest's requirements to include the new requirement version.
+func (m *pythonManifest) PatchRequirement(req resolve.RequirementVersion) error {
+	// TODO(#853): implement this function
+	return nil
+}
+
+// Clone returns a copy of this manifest that is safe to modify.
+func (m *pythonManifest) Clone() manifest.Manifest {
+	clone := &pythonManifest{
+		filePath:     m.filePath,
+		root:         m.root,
+		requirements: slices.Clone(m.requirements),
+	}
+	clone.root.AttrSet = m.root.AttrSet.Clone()
+
+	return clone
+}
+
+type readWriter struct{}
+
+// GetReadWriter returns a ReadWriter for requirements.txt manifest files.
+func GetReadWriter() manifest.ReadWriter {
+	return readWriter{}
+}
+
+// System returns the ecosystem of this ReadWriter.
+func (r readWriter) System() resolve.System {
+	return resolve.PyPI
+}
+
+// SupportedStrategies returns the remediation strategies supported for this manifest.
+func (r readWriter) SupportedStrategies() []strategy.Strategy {
+	// TODO(#853): add relax and in-place strategy
+	return []strategy.Strategy{}
+}
+
+// Read parses the manifest from the given file.
+func (r readWriter) Read(path string, fsys scalibrfs.FS) (manifest.Manifest, error) {
+	path = filepath.ToSlash(path)
+	f, err := fsys.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	ctx := context.Background()
+	inv, err := requirements.NewDefault().Extract(ctx, &filesystem.ScanInput{
+		FS:     fsys,
+		Path:   path,
+		Root:   filepath.Dir(path),
+		Reader: f,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var reqs []resolve.RequirementVersion
+	for _, pkg := range inv.Packages {
+		m := pkg.Metadata.(*requirements.Metadata)
+		d, err := pypi.ParseDependency(m.Requirement)
+		if err != nil {
+			return nil, err
+		}
+		reqs = append(reqs, resolve.RequirementVersion{
+			VersionKey: resolve.VersionKey{
+				PackageKey: resolve.PackageKey{
+					System: resolve.PyPI,
+					Name:   pkg.Name,
+				},
+				Version:     d.Constraint,
+				VersionType: resolve.Requirement,
+			},
+		})
+	}
+
+	return &pythonManifest{
+		filePath: path,
+		root: resolve.Version{
+			VersionKey: resolve.VersionKey{
+				PackageKey: resolve.PackageKey{
+					System: resolve.PyPI,
+					Name:   "",
+				},
+				VersionType: resolve.Concrete,
+				Version:     "",
+			},
+		},
+		requirements: reqs,
+	}, nil
+}
+
+// Write writes the manifest after applying the patches to outputPath.
+func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error {
+	// TODO(#853): implement the writer
+	return nil
+}

--- a/guidedremediation/internal/manifest/python/requirements.go
+++ b/guidedremediation/internal/manifest/python/requirements.go
@@ -58,7 +58,7 @@ func (m *pythonManifest) Requirements() []resolve.RequirementVersion {
 
 // Groups returns the dependency groups that the direct requirements belong to.
 func (m *pythonManifest) Groups() map[manifest.RequirementKey][]string {
-	return nil
+	return map[manifest.RequirementKey][]string{}
 }
 
 // LocalManifests returns Manifests of any local packages.
@@ -152,10 +152,10 @@ func (r readWriter) Read(path string, fsys scalibrfs.FS) (manifest.Manifest, err
 			VersionKey: resolve.VersionKey{
 				PackageKey: resolve.PackageKey{
 					System: resolve.PyPI,
-					Name:   "",
+					Name:   "myproject",
 				},
 				VersionType: resolve.Concrete,
-				Version:     "",
+				Version:     "1.0.0",
 			},
 		},
 		requirements: reqs,

--- a/guidedremediation/internal/manifest/python/requirements_test.go
+++ b/guidedremediation/internal/manifest/python/requirements_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package python
+
+import (
+	"testing"
+
+	"deps.dev/util/resolve"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/guidedremediation/internal/manifest"
+)
+
+type testManifest struct {
+	FilePath     string
+	Root         resolve.Version
+	System       resolve.System
+	Requirements []resolve.RequirementVersion
+}
+
+func checkManifest(t *testing.T, name string, got manifest.Manifest, want testManifest) {
+	t.Helper()
+	if want.FilePath != got.FilePath() {
+		t.Errorf("%s.FilePath() = %q, want %q", name, got.FilePath(), want.FilePath)
+	}
+	if diff := cmp.Diff(want.Root, got.Root()); diff != "" {
+		t.Errorf("%s.Root() (-want +got):\n%s", name, diff)
+	}
+	if want.System != got.System() {
+		t.Errorf("%s.System() = %v, want %v", name, got.System(), want.System)
+	}
+	if diff := cmp.Diff(want.Requirements, got.Requirements()); diff != "" {
+		t.Errorf("%s.Requirements() (-want +got):\n%s", name, diff)
+	}
+}
+
+func TestRead(t *testing.T) {
+	fsys := fs.DirFS("./testdata")
+	pypiRW := GetReadWriter()
+	got, err := pypiRW.Read("requirements.txt", fsys)
+	if err != nil {
+		t.Fatalf("error reading manifest: %v", err)
+	}
+	want := testManifest{
+		FilePath: "requirements.txt",
+		Root: resolve.Version{
+			VersionKey: resolve.VersionKey{
+				PackageKey: resolve.PackageKey{
+					System: resolve.PyPI,
+					Name:   "",
+				},
+				VersionType: resolve.Concrete,
+				Version:     "",
+			},
+		},
+		System: resolve.PyPI,
+		Requirements: []resolve.RequirementVersion{
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.PyPI,
+						Name:   "flask",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "==1.0.0",
+				},
+			},
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.PyPI,
+						Name:   "django",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "==1.11.29",
+				},
+			},
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.PyPI,
+						Name:   "requests",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "==2.20.0",
+				},
+			},
+		},
+	}
+	checkManifest(t, "Manifest", got, want)
+}

--- a/guidedremediation/internal/manifest/python/requirements_test.go
+++ b/guidedremediation/internal/manifest/python/requirements_test.go
@@ -59,10 +59,10 @@ func TestRead(t *testing.T) {
 			VersionKey: resolve.VersionKey{
 				PackageKey: resolve.PackageKey{
 					System: resolve.PyPI,
-					Name:   "",
+					Name:   "myproject",
 				},
 				VersionType: resolve.Concrete,
-				Version:     "",
+				Version:     "1.0.0",
 			},
 		},
 		System: resolve.PyPI,
@@ -71,20 +71,38 @@ func TestRead(t *testing.T) {
 				VersionKey: resolve.VersionKey{
 					PackageKey: resolve.PackageKey{
 						System: resolve.PyPI,
-						Name:   "flask",
+						Name:   "pytest",
 					},
 					VersionType: resolve.Requirement,
-					Version:     "==1.0.0",
 				},
 			},
 			{
 				VersionKey: resolve.VersionKey{
 					PackageKey: resolve.PackageKey{
 						System: resolve.PyPI,
-						Name:   "django",
+						Name:   "pytest-cov",
 					},
 					VersionType: resolve.Requirement,
-					Version:     "==1.11.29",
+				},
+			},
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.PyPI,
+						Name:   "beautifulsoup4",
+					},
+					VersionType: resolve.Requirement,
+				},
+			},
+
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.PyPI,
+						Name:   "docopt",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "== 0.6.1",
 				},
 			},
 			{
@@ -94,7 +112,39 @@ func TestRead(t *testing.T) {
 						Name:   "requests",
 					},
 					VersionType: resolve.Requirement,
-					Version:     "==2.20.0",
+					Version:     ">= 2.8.1, == 2.8.*",
+				},
+			},
+
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.PyPI,
+						Name:   "keyring",
+					},
+					VersionType: resolve.Requirement,
+					Version:     ">= 4.1.1",
+				},
+			},
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.PyPI,
+						Name:   "coverage",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "!= 3.5",
+				},
+			},
+
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.PyPI,
+						Name:   "Mopidy-Dirble",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "~= 1.1",
 				},
 			},
 		},

--- a/guidedremediation/internal/manifest/python/testdata/requirements.txt
+++ b/guidedremediation/internal/manifest/python/testdata/requirements.txt
@@ -1,0 +1,3 @@
+flask==1.0.0
+django==1.11.29
+requests==2.20.0

--- a/guidedremediation/internal/manifest/python/testdata/requirements.txt
+++ b/guidedremediation/internal/manifest/python/testdata/requirements.txt
@@ -1,3 +1,28 @@
-flask==1.0.0
-django==1.11.29
-requests==2.20.0
+# This is a comment, to show how #-prefixed lines are ignored.
+# It is possible to specify requirements as plain names.
+pytest
+pytest-cov
+beautifulsoup4
+
+# The syntax supported here is the same as that of requirement specifiers.
+docopt == 0.6.1
+requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"
+urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip
+
+# Minimum version 4.1.1
+keyring >= 4.1.1
+# Version Exclusion. Anything except version 3.5
+coverage != 3.5
+# Compatible release. Same as >= 1.1, == 1.*
+Mopidy-Dirble ~= 1.1
+
+
+# It is possible to refer to other requirement files or constraints files.
+-r other-requirements.txt
+-c constraints.txt
+
+# It is possible to refer to specific local distribution paths.
+./downloads/numpy-1.9.2-cp34-none-win32.whl
+
+# It is possible to refer to URLs.
+http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl


### PR DESCRIPTION
https://github.com/google/osv-scalibr/issues/853

This PR adds a basic manifest reader for Python requirements file.