### PR TITLE
fix: filepath usage on windows breaking container scanning

### DIFF
--- a/artifact/image/layerscanning/image/image.go
+++ b/artifact/image/layerscanning/image/image.go
@@ -674,7 +674,7 @@ func inWhiteoutDir(layer *chainLayer, filePath string) bool {
 		if filePath == "" {
 			break
 		}
-		dirname := filepath.Dir(filePath)
+		dirname := path.Dir(filePath)
 		if filePath == dirname {
 			break
 		}

--- a/artifact/image/layerscanning/image/pathtree.go
+++ b/artifact/image/layerscanning/image/pathtree.go
@@ -107,8 +107,8 @@ func (rootNode *RootNode) Insert(path string, vf *virtualFile) error {
 // getNode returns the node at the given path. This will resolve all intermediate symlinks.
 // By setting resolveFinalSymlink, you can choose not to resolve the final symlink,
 // so the returned Node could still be a symlink to another Node.
-func (rootNode *RootNode) getNode(nodePath string, resolveFinalSymlink bool, depth int) (*Node, error) {
-	nodePath, err := cleanPath(nodePath)
+func (rootNode *RootNode) getNode(rawNodePath string, resolveFinalSymlink bool, depth int) (*Node, error) {
+	nodePath, err := cleanPath(rawNodePath)
 	if err != nil {
 		log.Warnf("cleanPath(%q) error: %v", nodePath, err)
 		return nil, err


### PR DESCRIPTION
This filepath breaks windows container scanning, as it always considers you to not be in a whiteout dir.

We don't have a test in either osv-scalibr or osv-scanner that tests this, so we didn't catch it till #852 where we now return an error rather than silently dropping in cleanPath().

Blocking: https://github.com/google/osv-scanner/pull/2011

