### PR TITLE
refactor: place embeds at the start of structs followed by a newline

### DIFF
--- a/clients/clienttest/mock_http.go
+++ b/clients/clienttest/mock_http.go
@@ -28,6 +28,7 @@ import (
 // MockHTTPServer is a simple HTTP Server for mocking basic requests.
 type MockHTTPServer struct {
 	*httptest.Server
+
 	mu            sync.Mutex
 	response      map[string][]byte // path -> response
 	authorization string            // expected Authorization header contents

--- a/clients/resolution/depsdev_client.go
+++ b/clients/resolution/depsdev_client.go
@@ -22,6 +22,7 @@ import (
 // DepsDevClient is a ResolutionClient wrapping the official resolve.APIClient
 type DepsDevClient struct {
 	resolve.APIClient
+
 	c *datasource.CachedInsightsClient
 }
 

--- a/clients/resolution/override_client.go
+++ b/clients/resolution/override_client.go
@@ -24,6 +24,7 @@ import (
 // OverrideClient wraps a resolve.Client, allowing for custom packages & versions to be added
 type OverrideClient struct {
 	resolve.Client
+
 	// Can't quite reuse resolve.LocalClient because it automatically creates dependencies
 	pkgVers map[resolve.PackageKey][]resolve.Version            // versions of a package
 	verDeps map[resolve.VersionKey][]resolve.RequirementVersion // dependencies of a version

--- a/extractor/filesystem/containers/podman/container.go
+++ b/extractor/filesystem/containers/podman/container.go
@@ -29,14 +29,14 @@ type container struct {
 
 // containerConfig is a subset of the Podman's actual containerConfig
 type containerConfig struct {
+	// embedded sub-configs
+	containerRootFSConfig
+	containerNetworkConfig
+
 	ID           string `json:"id"`
 	Pod          string `json:"pod,omitempty"`
 	Namespace    string `json:"namespace,omitempty"`
 	RawImageName string `json:"RawImageName,omitempty"`
-
-	// embedded sub-configs
-	containerRootFSConfig
-	containerNetworkConfig
 }
 
 // containerRootFSConfig contains the info about podman's Rootfs

--- a/extractor/filesystem/filesystem_test.go
+++ b/extractor/filesystem/filesystem_test.go
@@ -915,6 +915,7 @@ func setupMapFS(t *testing.T, mapFS mapFS) scalibrfs.FS {
 // To not break the test every time we add a new metric, we inherit from the NoopCollector.
 type fakeCollector struct {
 	stats.NoopCollector
+
 	AfterInodeVisitedCount int
 }
 

--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
@@ -50,8 +50,9 @@ type Extractor struct {
 
 // Config is the configuration for the pomxmlnet Extractor.
 type Config struct {
-	DependencyClient resolve.Client
 	*datasource.MavenRegistryAPIClient
+
+	DependencyClient resolve.Client
 }
 
 // NewConfig returns the configuration given the URL of the Maven registry to fetch metadata.

--- a/extractor/filesystem/language/python/requirementsnet/requirements.go
+++ b/extractor/filesystem/language/python/requirementsnet/requirements.go
@@ -40,9 +40,9 @@ const (
 
 // Config is the configuration for the Extractor.
 type Config struct {
+	resolve.Client
 	// This should be an extractor to extract inventories from requirements.txt offline.
 	*requirements.Extractor // Extractor to extract inventories from requirements.txt offline.
-	resolve.Client
 }
 
 // DefaultConfig returns the default configuration for the extractor.
@@ -55,8 +55,9 @@ func DefaultConfig() Config {
 
 // Extractor extracts python packages from requirements.txt files.
 type Extractor struct {
-	BaseExtractor *requirements.Extractor // The base extractor that we use to extract direct dependencies.
 	resolve.Client
+
+	BaseExtractor *requirements.Extractor // The base extractor that we use to extract direct dependencies.
 }
 
 // New returns a requirements.txt transitive extractor.

--- a/extractor/standalone/containers/containerd/fakeclient/fake_containerd_client.go
+++ b/extractor/standalone/containers/containerd/fakeclient/fake_containerd_client.go
@@ -39,6 +39,7 @@ import (
 // CtrdClient is a fake implementation of CtrdClient for testing purposes.
 type CtrdClient struct {
 	plugin.CtrdClient
+
 	tasksService tasks.TasksClient
 	nsService    namespaces.Store
 	// A map of task IDs to containerd.Container objects.
@@ -118,6 +119,7 @@ func initContainerTasks(tsks []*task.Process, ctrs []containerd.Container) (map[
 // TasksService is a fake implementation of the containerd tasks service.
 type TasksService struct {
 	tasks.TasksClient
+
 	tasks      []*task.Process
 	nssTaskIDs map[string][]string
 }
@@ -159,6 +161,7 @@ func (s *TasksService) List(ctx context.Context, in *tasks.ListTasksRequest, opt
 // NamespacesService is a fake implementation of the containerd namespaces service.
 type NamespacesService struct {
 	namespaces.Store
+
 	namespaces []string
 }
 
@@ -177,6 +180,7 @@ func (s *NamespacesService) List(ctx context.Context) ([]string, error) {
 // Container is a fake implementation of the containerd container object.
 type Container struct {
 	containerd.Container
+
 	id     string
 	image  string
 	digest string
@@ -223,6 +227,7 @@ func (c *Container) Image(ctx context.Context) (containerd.Image, error) {
 // Image is a fake implementation of the containerd image object.
 type Image struct {
 	containerd.Image
+
 	digest string
 }
 
@@ -244,6 +249,7 @@ func (i *Image) Target() imagespecs.Descriptor {
 // Task is a fake implementation of the containerd task object.
 type Task struct {
 	containerd.Task
+
 	rootfs string
 }
 

--- a/guidedremediation/internal/manifest/maven/pomxml.go
+++ b/guidedremediation/internal/manifest/maven/pomxml.go
@@ -45,6 +45,7 @@ import (
 // RequirementKey is a comparable type that uniquely identifies a package dependency in a manifest.
 type RequirementKey struct {
 	resolve.PackageKey
+
 	ArtifactType string
 	Classifier   string
 }
@@ -76,12 +77,14 @@ type ManifestSpecific struct {
 // PropertyWithOrigin is a maven property with the origin where it comes from.
 type PropertyWithOrigin struct {
 	maven.Property
+
 	Origin string // Origin indicates where the property comes from
 }
 
 // DependencyWithOrigin is a maven dependency with the origin where it comes from.
 type DependencyWithOrigin struct {
 	maven.Dependency
+
 	Origin string // Origin indicates where the dependency comes from
 }
 
@@ -546,6 +549,7 @@ type Patches struct {
 // Patch represents an individual dependency to be upgraded, and the version to upgrade to
 type Patch struct {
 	maven.DependencyKey
+
 	NewRequire string
 }
 
@@ -909,6 +913,7 @@ func writeProject(w io.Writer, enc *forkedxml.Encoder, raw, prefix, id string, p
 				updated["parent"] = true
 				type RawParent struct {
 					maven.ProjectKey
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawParent RawParent
@@ -950,6 +955,7 @@ func writeProject(w io.Writer, enc *forkedxml.Encoder, raw, prefix, id string, p
 				}
 				type RawProfile struct {
 					maven.Profile
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawProfile RawProfile
@@ -968,6 +974,7 @@ func writeProject(w io.Writer, enc *forkedxml.Encoder, raw, prefix, id string, p
 				}
 				type RawPlugin struct {
 					maven.Plugin
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawPlugin RawPlugin
@@ -982,6 +989,7 @@ func writeProject(w io.Writer, enc *forkedxml.Encoder, raw, prefix, id string, p
 			case "dependencyManagement":
 				type RawDependencyManagement struct {
 					maven.DependencyManagement
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawDepMgmt RawDependencyManagement
@@ -1101,6 +1109,7 @@ func writeDependency(w io.Writer, enc *forkedxml.Encoder, raw string, patches ma
 			if tt.Name.Local == "dependency" {
 				type RawDependency struct {
 					maven.Dependency
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawDep RawDependency

--- a/guidedremediation/internal/manifest/npm/packagejson.go
+++ b/guidedremediation/internal/manifest/npm/packagejson.go
@@ -40,6 +40,7 @@ import (
 // RequirementKey is a comparable type that uniquely identifies a package dependency in a manifest.
 type RequirementKey struct {
 	resolve.PackageKey
+
 	KnownAs string
 }
 

--- a/guidedremediation/internal/remediation/remediation.go
+++ b/guidedremediation/internal/remediation/remediation.go
@@ -39,8 +39,9 @@ type ResolvedGraph struct {
 
 // ResolvedManifest is a manifest, its resolved dependency graph, and the vulnerabilities found in it.
 type ResolvedManifest struct {
-	Manifest manifest.Manifest
 	ResolvedGraph
+
+	Manifest manifest.Manifest
 }
 
 // ResolveManifest resolves and find vulnerabilities in a manifest.

--- a/guidedremediation/options/options.go
+++ b/guidedremediation/options/options.go
@@ -33,6 +33,8 @@ type DependencyCachePopulator interface {
 
 // FixVulnsOptions are the options for guidedremediation.FixVulns().
 type FixVulnsOptions struct {
+	RemediationOptions
+
 	Manifest          string                       // Path to manifest file on disk.
 	Lockfile          string                       // Path to lockfile on disk.
 	Strategy          strategy.Strategy            // Remediation strategy to use.
@@ -43,11 +45,12 @@ type FixVulnsOptions struct {
 	ResolveClient     resolve.Client               // Client for dependency information.
 	DefaultRepository string                       // Default registry to fetch dependency information from.
 	DepCachePopulator DependencyCachePopulator     // Interface for populating the cache of the resolve.Client. Can be nil.
-	RemediationOptions
 }
 
 // RemediationOptions are the configuration options for vulnerability remediation.
 type RemediationOptions struct {
+	ResolutionOptions
+
 	IgnoreVulns   []string // Vulnerability IDs to ignore
 	ExplicitVulns []string // If set, only consider these vulnerability IDs & ignore all others
 
@@ -57,7 +60,6 @@ type RemediationOptions struct {
 
 	UpgradeConfig upgrade.Config // Allowed upgrade levels per package.
 
-	ResolutionOptions
 }
 
 // DefaultRemediationOptions creates a default initialized remediation configuration.

--- a/inventory/finding.go
+++ b/inventory/finding.go
@@ -37,6 +37,7 @@ type Finding struct {
 // It follows the OSV Schema format: https://ossf.github.io/osv-schema
 type PackageVuln struct {
 	osvschema.Vulnerability
+
 	// The plugins (e.g. Detectors, Enrichers) that found this vuln.
 	Plugins []string
 	// Signals that indicate this finding is not exploitable.

--- a/testing/testcollector/test_collector.go
+++ b/testing/testcollector/test_collector.go
@@ -22,6 +22,7 @@ import "github.com/google/osv-scalibr/stats"
 // by path.
 type Collector struct {
 	stats.NoopCollector
+
 	fileRequiredStats  map[string]*stats.FileRequiredStats
 	fileExtractedStats map[string]*stats.FileExtractedStats
 }


### PR DESCRIPTION
This will be enforced by the `embeddedstructfieldcheck` linter introduced in v2.2