### PR TITLE
feat: implement the manifest writer for Python requirements.txt

### DIFF
--- a/guidedremediation/internal/manifest/python/requirements.go
+++ b/guidedremediation/internal/manifest/python/requirements.go
@@ -352,12 +352,14 @@ func updateRequirements(reader io.Reader, requirements map[string][]VersionConst
 			sb.WriteString(line[index:])
 		} else {
 			// Copy space characters if nothing meaningful is found.
+			spaceIndex := -1
 			for i := len(line) - 1; i >= 0; i-- {
 				if i < 0 || !unicode.IsSpace(rune(line[i])) {
+					spaceIndex = i
 					break
 				}
-				sb.WriteByte(line[i])
 			}
+			sb.WriteString(line[spaceIndex+1:])
 		}
 	}
 

--- a/guidedremediation/internal/manifest/python/requirements.go
+++ b/guidedremediation/internal/manifest/python/requirements.go
@@ -18,8 +18,11 @@ package python
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"deps.dev/util/pypi"
 	"deps.dev/util/resolve"
@@ -29,6 +32,7 @@ import (
 	"github.com/google/osv-scalibr/guidedremediation/internal/manifest"
 	"github.com/google/osv-scalibr/guidedremediation/result"
 	"github.com/google/osv-scalibr/guidedremediation/strategy"
+	"github.com/google/osv-scalibr/log"
 )
 
 type pythonManifest struct {
@@ -170,6 +174,190 @@ func (r readWriter) Read(path string, fsys scalibrfs.FS) (manifest.Manifest, err
 
 // Write writes the manifest after applying the patches to outputPath.
 func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error {
-	// TODO(#853): implement the writer
+	f, err := fsys.Open(original.FilePath())
+	if err != nil {
+		return err
+	}
+
+	requirements := make(map[string][]VersionConstraint)
+	for _, patch := range patches {
+		for _, req := range patch.PackageUpdates {
+			requirements[req.Name] = tokenizeRequirement(req.VersionTo)
+		}
+	}
+
+	output, err := updateRequirements(f, requirements)
+	if err != nil {
+		return err
+	}
+
+	// Write the patched manifest to the output path.
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(outputPath, []byte(output), 0644); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// Define the possible operators, ordered by length descending
+// to ensure correct matching (e.g., "==" before "=" or ">=" before ">").
+var operators = []string{
+	"==", // Equal
+	"!=", // Not equal
+	">=", // Greater than or equal
+	"<=", // Less than or equal
+	"~=", // Compatible release
+	">",  // Greater than
+	"<",  // Less than
+}
+
+// VersionConstraint represents a single parsed requirement constraint,
+// consisting of an operator (e.g., "==", ">=") and a version number.
+type VersionConstraint struct {
+	operator string
+	version  string
+}
+
+// tokenizeVersionSpecifier takes a single Python version specifier string (e.g., ">=2.32.4,<3.0.0")
+// and breaks it down into individual version constraints. Each constraint is
+// represented by a VersionConstraint struct.
+func tokenizeRequirement(requirement string) []VersionConstraint {
+	if requirement == "" {
+		return []VersionConstraint{}
+	}
+
+	var tokenized []VersionConstraint
+	for _, constraint := range strings.Split(requirement, ",") {
+		constraint = strings.TrimSpace(constraint)
+		if constraint == "" {
+			continue
+		}
+
+		for _, op := range operators {
+			if strings.HasPrefix(constraint, op) {
+				tokenized = append(tokenized, VersionConstraint{
+					operator: op,
+					version:  constraint[len(op):],
+				})
+				break
+			}
+		}
+	}
+
+	return tokenized
+}
+
+// formatConstraints converts a slice of VersionConstraint structs into a
+// comma-separated string suitable for a requirements.txt file.
+//
+// If space is true:
+// - A space will be inserted between the operator and the version;
+// - A space will be inserted after the comma between constraints.
+func formatConstraints(constraints []VersionConstraint, space bool) string {
+	if len(constraints) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, vc := range constraints {
+		if space {
+			parts = append(parts, vc.operator+" "+vc.version)
+		} else {
+			parts = append(parts, vc.operator+vc.version)
+		}
+	}
+
+	if space {
+		return strings.Join(parts, ", ") // Add space after comma
+	} else {
+		return strings.Join(parts, ",")
+	}
+}
+
+// findFirstOperatorIndex finds the index of the first appearance of any operator
+// from the given list within a string. It returns -1 if no operator is found.
+func findFirstOperatorIndex(s string) int {
+	firstIndex := -1
+
+	for _, op := range operators {
+		index := strings.Index(s, op)
+		if index != -1 {
+			// If an operator is found, check if its index is smaller than
+			// the current smallest index found so far.
+			if firstIndex == -1 || index < firstIndex {
+				firstIndex = index
+			}
+		}
+	}
+	return firstIndex
+}
+
+// updateRequirements takes an io.Reader representing the requirements.txt file
+// and a map of package names to their new version constraints, returns the
+// file with the updated requirements as a string.
+func updateRequirements(reader io.Reader, requirements map[string][]VersionConstraint) (string, error) {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("error reading requirements: %w", err)
+	}
+	content := string(data)
+
+	lines := strings.SplitAfter(content, "\n")
+
+	var sb strings.Builder
+	for _, original := range lines {
+		line := strings.TrimSpace(original)
+		if line == "" {
+			sb.WriteString(original)
+			continue
+		}
+
+		d, err := pypi.ParseDependency(line)
+		if err != nil {
+			log.Warnf("failed to parse Python dependency %s: %v", line, err)
+			sb.WriteString(original)
+			continue
+		}
+
+		newReq, ok := requirements[d.Name]
+		if !ok {
+			// We don't need to update the requirement of this dependency.
+			sb.WriteString(original)
+			continue
+		}
+
+		opIndex := findFirstOperatorIndex(line)
+		if opIndex < 0 {
+			// No operator is found.
+			sb.WriteString(original)
+			continue
+		}
+		sb.WriteString(line[:opIndex])
+
+		// If the byte before the operator is a space, assume space is needed when constructing requirements.
+		extraSpace := line[opIndex-1] == ' '
+		sb.WriteString(formatConstraints(newReq, extraSpace))
+
+		index := strings.Index(line, ";")
+		if index < 0 {
+			index = strings.Index(line, "#")
+		}
+		if index >= 0 {
+			for i := index - 1; i >= 0; i-- {
+				// Copy the space bewteen requirements and post-requirements,
+				if i < 0 || line[i] != ' ' {
+					break
+				}
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(line[index:])
+		}
+
+		sb.WriteByte('\n')
+	}
+
+	return sb.String(), nil
 }

--- a/guidedremediation/internal/manifest/python/requirements.go
+++ b/guidedremediation/internal/manifest/python/requirements.go
@@ -272,9 +272,8 @@ func formatConstraints(constraints []VersionConstraint, space bool) string {
 
 	if space {
 		return strings.Join(parts, ", ") // Add space after comma
-	} else {
-		return strings.Join(parts, ",")
 	}
+	return strings.Join(parts, ",")
 }
 
 // findFirstOperatorIndex finds the index of the first appearance of any operator
@@ -347,7 +346,7 @@ func updateRequirements(reader io.Reader, requirements map[string][]VersionConst
 		}
 		if index >= 0 {
 			for i := index - 1; i >= 0; i-- {
-				// Copy the space bewteen requirements and post-requirements,
+				// Copy the space between requirements and post-requirements,
 				if i < 0 || line[i] != ' ' {
 					break
 				}

--- a/guidedremediation/internal/manifest/python/requirements.go
+++ b/guidedremediation/internal/manifest/python/requirements.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"unicode"
 
 	"deps.dev/util/pypi"
 	"deps.dev/util/resolve"
@@ -342,7 +343,7 @@ func updateRequirements(reader io.Reader, requirements map[string][]VersionConst
 		}
 		if index >= 0 {
 			for i := index - 1; i >= 0; i-- {
-				// Copy the space between requirements and post-requirements
+				// Copy the space between requirements and post-requirements.
 				if i < 0 || line[i] != ' ' {
 					break
 				}
@@ -350,15 +351,14 @@ func updateRequirements(reader io.Reader, requirements map[string][]VersionConst
 			}
 			sb.WriteString(line[index:])
 		} else {
-			// Copy the newline characters
+			// Copy space characters if nothing meaningful is found.
 			for i := len(line) - 1; i >= 0; i-- {
-				if i < 0 || (line[i] != '\n' && line[i] != '\r') {
+				if i < 0 || !unicode.IsSpace(rune(line[i])) {
 					break
 				}
 				sb.WriteByte(line[i])
 			}
 		}
-
 	}
 
 	return sb.String(), nil

--- a/guidedremediation/internal/manifest/python/requirements_test.go
+++ b/guidedremediation/internal/manifest/python/requirements_test.go
@@ -196,18 +196,18 @@ func TestWrite(t *testing.T) {
 	outFile := filepath.Join(outDir, "requirements.txt")
 
 	if err := rw.Write(manif, fsys, patches, outFile); err != nil {
-		t.Fatalf("failed to write package.json: %v", err)
+		t.Fatalf("failed to write requirements.txt: %v", err)
 	}
 
 	got, err := os.ReadFile(outFile)
 	if err != nil {
-		t.Fatalf("failed to read got package.json: %v", err)
+		t.Fatalf("failed to read got requirements.txt: %v", err)
 	}
 	want, err := os.ReadFile(filepath.Join("./testdata", "want.requirements.txt"))
 	if err != nil {
-		t.Fatalf("failed to read want package.json: %v", err)
+		t.Fatalf("failed to read want requirements.txt: %v", err)
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("package.json (-want +got):\n%s", diff)
+		t.Errorf("requirements.txt (-want +got):\n%s", diff)
 	}
 }

--- a/guidedremediation/internal/manifest/python/requirements_test.go
+++ b/guidedremediation/internal/manifest/python/requirements_test.go
@@ -15,12 +15,15 @@
 package python
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"deps.dev/util/resolve"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/guidedremediation/internal/manifest"
+	"github.com/google/osv-scalibr/guidedremediation/result"
 )
 
 type testManifest struct {
@@ -144,10 +147,67 @@ func TestRead(t *testing.T) {
 						Name:   "Mopidy-Dirble",
 					},
 					VersionType: resolve.Requirement,
-					Version:     "~= 1.1",
+					Version:     "~=1.1",
 				},
 			},
 		},
 	}
 	checkManifest(t, "Manifest", got, want)
+}
+
+func TestWrite(t *testing.T) {
+	rw := GetReadWriter()
+	fsys := fs.DirFS("./testdata")
+	manif, err := rw.Read("requirements.txt", fsys)
+	if err != nil {
+		t.Fatalf("error reading manifest: %v", err)
+	}
+
+	patches := []result.Patch{
+		{
+			PackageUpdates: []result.PackageUpdate{
+				{
+					Name:        "docopt",
+					VersionFrom: "==0.6.1",
+					VersionTo:   "==0.6.2",
+				},
+			},
+		},
+		{
+			PackageUpdates: []result.PackageUpdate{
+				{
+					Name:        "requests",
+					VersionFrom: ">=2.8.1,== 2.8.*",
+					VersionTo:   ">=2.32.4,<3.0.0",
+				},
+			},
+		},
+		{
+			PackageUpdates: []result.PackageUpdate{
+				{
+					Name:        "mopidy-dirble",
+					VersionFrom: "!=1.1",
+					VersionTo:   ">=1.3.0,<2.0.0",
+				},
+			},
+		},
+	}
+	outDir := t.TempDir()
+	outFile := filepath.Join(outDir, "requirements.txt")
+
+	if err := rw.Write(manif, fsys, patches, outFile); err != nil {
+		t.Fatalf("failed to write package.json: %v", err)
+	}
+
+	got, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("failed to read got package.json: %v", err)
+	}
+	want, err := os.ReadFile(filepath.Join("./testdata", "want.requirements.txt"))
+	if err != nil {
+		t.Fatalf("failed to read want package.json: %v", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("package.json (-want +got):\n%s", diff)
+	}
 }

--- a/guidedremediation/internal/manifest/python/testdata/want.requirements.txt
+++ b/guidedremediation/internal/manifest/python/testdata/want.requirements.txt
@@ -5,8 +5,8 @@ pytest-cov
 beautifulsoup4
 
 # The syntax supported here is the same as that of requirement specifiers.
-docopt == 0.6.1
-requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"
+docopt == 0.6.2
+requests [security] >= 2.32.4, < 3.0.0 ; python_version < "2.7"
 urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip
 
 # Minimum version 4.1.1
@@ -14,7 +14,7 @@ keyring >= 4.1.1
 # Version Exclusion. Anything except version 3.5
 coverage != 3.5
 # Compatible release. Same as >= 1.1, == 1.*
-Mopidy-Dirble~=1.1  # Some comment
+Mopidy-Dirble>=1.3.0,<2.0.0  # Some comment
 
 
 # It is possible to refer to other requirement files or constraints files.


### PR DESCRIPTION
https://github.com/google/osv-scalibr/issues/853

This PR implements the writer for Python requirements.txt so that the new requirements can be written to the file.