### PR TITLE
[extractor/rpm] Change purl namespace for Amazon RPMs

### DIFF
--- a/extractor/filesystem/os/rpm/metadata/metadata.go
+++ b/extractor/filesystem/os/rpm/metadata/metadata.go
@@ -37,11 +37,15 @@ type Metadata struct {
 
 // ToNamespace extracts the PURL namespace from the metadata.
 func (m *Metadata) ToNamespace() string {
-	if m.OSID != "" {
+	switch m.OSID {
+	case "":
+		log.Errorf("os-release[ID] not set, fallback to ''")
+		return ""
+	case "amzn":
+		return "amazon"
+	default:
 		return m.OSID
 	}
-	log.Errorf("os-release[ID] not set, fallback to ''")
-	return ""
 }
 
 // ToDistro extracts the OS distro from the metadata.

--- a/extractor/filesystem/os/rpm/metadata/metadata_test.go
+++ b/extractor/filesystem/os/rpm/metadata/metadata_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"testing"
+
+	rpmmeta "github.com/google/osv-scalibr/extractor/filesystem/os/rpm/metadata"
+)
+
+func TestToNamespace(t *testing.T) {
+	tests := []struct {
+		osID          string
+		wantNamespace string
+	}{
+		{
+			osID:          "centos",
+			wantNamespace: "centos",
+		},
+		{
+			osID:          "fedora",
+			wantNamespace: "fedora",
+		},
+		{
+			osID:          "amzn",
+			wantNamespace: "amazon",
+		},
+		{
+			osID:          "",
+			wantNamespace: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.osID, func(t *testing.T) {
+			metadata := rpmmeta.Metadata{
+				OSID: tt.osID,
+			}
+			ns := metadata.ToNamespace()
+			if ns != tt.wantNamespace {
+				t.Fatalf("ToNamespace(%s): got %v, want %v", tt.osID, ns, tt.wantNamespace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Change namespace from `amzn` to `amazon` for amazonlinux RPMs.

Package-url generation is based on `/etc/os-release` `ID` field. While this works well for fedora, centos etc, amazonlinux is a bit different, as it uses the ID `amzn`.

In this case `amzn` is more a shortname like `el` (centos) or `fc` (fedora) While the purl specification does not expicitely list `amazon` as the correct namespace in https://github.com/package-url/purl-spec/blob/main/PURL-TYPES.rst#rpm

It says "The namespace is the vendor such as Fedora or OpenSUSE. It is not case sensitive and must be lowercased.". So it's probably better to use `amazon` rather than `amzn`.

Also most (all?) SBOM generation tools are using `amazon` (ex.: trivy or vulncheck).