### PR TITLE
refactor: follow package naming conventions for import aliases

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,6 +77,8 @@ linters:
           disabled: false
         - name: exported
           disabled: false
+        - name: import-alias-naming
+          disabled: false
         - name: indent-error-flow
           disabled: false
         - name: package-comments

--- a/artifact/image/layerscanning/image/image.go
+++ b/artifact/image/layerscanning/image/image.go
@@ -32,7 +32,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	scalibrImage "github.com/google/osv-scalibr/artifact/image"
+	scalibrimage "github.com/google/osv-scalibr/artifact/image"
 	"github.com/google/osv-scalibr/artifact/image/symlink"
 	"github.com/google/osv-scalibr/artifact/image/whiteout"
 	scalibrfs "github.com/google/osv-scalibr/fs"
@@ -125,11 +125,11 @@ func (img *Image) FS() scalibrfs.FS {
 }
 
 // ChainLayers returns the chain layers of the image.
-func (img *Image) ChainLayers() ([]scalibrImage.ChainLayer, error) {
+func (img *Image) ChainLayers() ([]scalibrimage.ChainLayer, error) {
 	if len(img.chainLayers) == 0 {
 		return nil, ErrNoLayersFound
 	}
-	scalibrChainLayers := make([]scalibrImage.ChainLayer, 0, len(img.chainLayers))
+	scalibrChainLayers := make([]scalibrimage.ChainLayer, 0, len(img.chainLayers))
 	for _, chainLayer := range img.chainLayers {
 		scalibrChainLayers = append(scalibrChainLayers, chainLayer)
 	}
@@ -156,7 +156,7 @@ func (img *Image) Size() int64 {
 
 // FromRemoteName creates an Image from a remote container image name.
 func FromRemoteName(imageName string, config *Config, imageOptions ...remote.Option) (*Image, error) {
-	v1Image, err := scalibrImage.V1ImageFromRemoteName(imageName, imageOptions...)
+	v1Image, err := scalibrimage.V1ImageFromRemoteName(imageName, imageOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load image from remote name %q: %w", imageName, err)
 	}

--- a/artifact/image/layerscanning/trace/trace.go
+++ b/artifact/image/layerscanning/trace/trace.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/log"
 
-	scalibrImage "github.com/google/osv-scalibr/artifact/image"
+	scalibrimage "github.com/google/osv-scalibr/artifact/image"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 )
 
@@ -54,7 +54,7 @@ type locationAndIndex struct {
 //
 // Note that a precondition of this algorithm is that the chain layers are ordered by order of
 // creation.
-func PopulateLayerDetails(ctx context.Context, inventory inventory.Inventory, chainLayers []scalibrImage.ChainLayer, extractors []filesystem.Extractor, config *filesystem.Config) {
+func PopulateLayerDetails(ctx context.Context, inventory inventory.Inventory, chainLayers []scalibrimage.ChainLayer, extractors []filesystem.Extractor, config *filesystem.Config) {
 	// If there are no chain layers, then there is nothing to trace. This should not happen, but we
 	// should handle it gracefully.
 	if len(chainLayers) == 0 {
@@ -221,7 +221,7 @@ func areLocationsEqual(fileLocations []string, otherFileLocations []string) bool
 }
 
 // getSingleLayerFSFromChainLayer returns the filesystem of the underlying layer in the chain layer.
-func getLayerFSFromChainLayer(chainLayer scalibrImage.ChainLayer) (scalibrfs.FS, error) {
+func getLayerFSFromChainLayer(chainLayer scalibrimage.ChainLayer) (scalibrfs.FS, error) {
 	layer := chainLayer.Layer()
 	if layer == nil {
 		return nil, errors.New("chain layer has no layer")
@@ -237,7 +237,7 @@ func getLayerFSFromChainLayer(chainLayer scalibrImage.ChainLayer) (scalibrfs.FS,
 
 // filesExistInLayer checks if any of the provided files are present in the underlying layer of the
 // chain layer.
-func filesExistInLayer(chainLayer scalibrImage.ChainLayer, fileLocations []string) bool {
+func filesExistInLayer(chainLayer scalibrimage.ChainLayer, fileLocations []string) bool {
 	layerFS, err := getLayerFSFromChainLayer(chainLayer)
 	if err != nil {
 		return false


### PR DESCRIPTION
Import aliases should follow the same conventions as package names for consistency