### PR TITLE
fix: enabling enrichers causes nil pointer dereference

### DIFF
--- a/scalibr.go
+++ b/scalibr.go
@@ -292,12 +292,17 @@ func (s Scanner) ScanContainer(ctx context.Context, img *image.Image, config *Sc
 	}
 
 	// Suppress running enrichers until after layer details are populated.
-	enrichers := pl.Enrichers(config.Plugins)
-	for i, p := range config.Plugins {
-		if _, ok := p.(enricher.Enricher); ok {
-			config.Plugins[i] = nil
+	var enrichers []enricher.Enricher
+	var nonEnricherPlugins []plugin.Plugin
+
+	for _, p := range config.Plugins {
+		if e, ok := p.(enricher.Enricher); ok {
+			enrichers = append(enrichers, e)
+		} else {
+			nonEnricherPlugins = append(nonEnricherPlugins, p)
 		}
 	}
+	config.Plugins = nonEnricherPlugins
 
 	chainLayers, err := img.ChainLayers()
 	if err != nil {


### PR DESCRIPTION
ScanContainer() suppresses running enrichers until after layer details are populated, but the current code causes a nil dereference as it also tries to [get every plugin's name](https://github.com/google/osv-scalibr/blob/bf54ba73cd3daff607f7bd86c77485805661ae93/scalibr.go#L116) after setting all enrichers to nil.

closes https://github.com/google/osv-scalibr/issues/894