### PR TITLE
feat(cargolock): detect yanked versions [osv-scanner#1417]

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -76,6 +76,9 @@ type Package struct {
 	LayerDetails *LayerDetails
 	// The additional data found in the package.
 	Metadata any
+
+	// Yanked is set to true if the version of the package is yanked on crates.io.
+	Yanked bool `json:"yanked,omitempty"`
 }
 
 // Annotation are additional information about the package.

--- a/extractor/filesystem/language/rust/cargolock/cargolock_test.go
+++ b/extractor/filesystem/language/rust/cargolock/cargolock_test.go
@@ -163,6 +163,22 @@ func TestExtractor_Extract(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			Name: "yanked package",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/yanked-version.lock",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:      "url",
+					Version:   "2.5.3",
+					PURLType:  purl.TypeCargo,
+					Locations: []string{"testdata/yanked-version.lock"},
+					Yanked:    true,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/extractor/filesystem/language/rust/cargolock/testdata/yanked-version.lock
+++ b/extractor/filesystem/language/rust/cargolock/testdata/yanked-version.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "url"
+version = "2.5.3"


### PR DESCRIPTION
This PR adds detection of yanked Cargo packages via crates.io API.

- Updates the `cargolock` extractor to mark packages as `Yanked`.
- Adds test case for a yanked package version (`yanked-version.lock`).

Implements part of [osv-scanner#1417](https://github.com/google/osv-scanner/issues/1417).
