### PR TITLE
feat(pypi): try all available files to parse requirements

### DIFF
--- a/clients/resolution/pypi_registry_client.go
+++ b/clients/resolution/pypi_registry_client.go
@@ -89,26 +89,26 @@ func (c *PyPIRegistryClient) Versions(ctx context.Context, pk resolve.PackageKey
 		case ".gz":
 			_, v, err = pypi.SdistVersion(resp.Name, file.Name)
 			if err != nil {
-				log.Errorf("failed to extract version from sdist file name %s: %v", file.Name, err)
+				log.Warnf("failed to extract version from sdist file name %s: %v", file.Name, err)
 				continue
 			}
 		case ".whl":
 			info, err := pypi.ParseWheelName(file.Name)
 			if err != nil {
-				log.Errorf("failed to parse wheel name %s: %v", file.Name, err)
+				log.Warnf("failed to parse wheel name %s: %v", file.Name, err)
 				continue
 			}
 			v = info.Version
 		case ".egg":
 			v, err = versionFromEggFilename(file.Name)
 			if err != nil {
-				log.Errorf("failed to extract version from file %s: %v", file.Name, err)
+				log.Warnf("failed to extract version from file %s: %v", file.Name, err)
 				continue
 			}
 		case ".zip":
 			v, err = versionFromZipFilename(file.Name)
 			if err != nil {
-				log.Errorf("failed to extract version from file %s: %v", file.Name, err)
+				log.Warnf("failed to extract version from file %s: %v", file.Name, err)
 				continue
 			}
 		default:
@@ -199,7 +199,7 @@ func (c *PyPIRegistryClient) Requirements(ctx context.Context, vk resolve.Versio
 		case ".whl":
 			metadata, err = pypi.WheelMetadata(ctx, bytes.NewReader(data), int64(len(data)))
 		default:
-			log.Warnf("unsupported file extension for requirements: %s", ext)
+			log.Infof("unsupported file extension for requirements: %s", ext)
 			continue
 		}
 		if err != nil {
@@ -245,7 +245,7 @@ func lookupFile(vk resolve.VersionKey, name string, files []internalpypi.File) [
 		case ".gz":
 			_, v, err := pypi.SdistVersion(name, file.Name)
 			if err != nil {
-				log.Errorf("failed to extract version from sdist file name %s: %v", file.Name, err)
+				log.Warnf("failed to extract version from sdist file name %s: %v", file.Name, err)
 				continue
 			}
 			if v != vk.Version {
@@ -254,7 +254,7 @@ func lookupFile(vk resolve.VersionKey, name string, files []internalpypi.File) [
 		case ".whl":
 			info, err := pypi.ParseWheelName(file.Name)
 			if err != nil {
-				log.Errorf("failed to parse wheel name %s: %v", file.Name, err)
+				log.Warnf("failed to parse wheel name %s: %v", file.Name, err)
 				continue
 			}
 			if info.Version != vk.Version {
@@ -263,7 +263,7 @@ func lookupFile(vk resolve.VersionKey, name string, files []internalpypi.File) [
 		case ".egg":
 			v, err := versionFromEggFilename(file.Name)
 			if err != nil {
-				log.Errorf("failed to extract version from file %s: %v", file.Name, err)
+				log.Warnf("failed to extract version from file %s: %v", file.Name, err)
 				continue
 			}
 			if v != vk.Version {
@@ -272,7 +272,7 @@ func lookupFile(vk resolve.VersionKey, name string, files []internalpypi.File) [
 		case ".zip":
 			v, err := versionFromZipFilename(file.Name)
 			if err != nil {
-				log.Errorf("failed to extract version from file %s: %v", file.Name, err)
+				log.Warnf("failed to extract version from file %s: %v", file.Name, err)
 				continue
 			}
 			if v != vk.Version {

--- a/clients/resolution/pypi_registry_client_test.go
+++ b/clients/resolution/pypi_registry_client_test.go
@@ -256,6 +256,19 @@ func TestRequirements(t *testing.T) {
 			"yanked": false
 		  },
 		  {
+			"core-metadata": false,
+			"data-dist-info-metadata": false,
+			"filename": "beautifulsoup4-4.12.3.tar.gz",
+			"hashes": {
+			  "sha256": "74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"
+			},
+			"requires-python": ">=3.6.0",
+			"size": 581181,
+			"upload-time": "2024-01-17T16:53:17.902970Z",
+			"url": "`+srv.URL+`/beautifulsoup4-4.12.3.tar.gz",
+			"yanked": false
+		  },
+		  {
 			"core-metadata": {
 			  "sha256": "524392d64a088e56a4232f50d6edb208dc03105394652acb72c6d5fa64c89f3e"
 			},
@@ -270,19 +283,6 @@ func TestRequirements(t *testing.T) {
 			"size": 147925,
 			"upload-time": "2024-01-17T16:53:12.779164Z",
 			"url": "`+srv.URL+`/beautifulsoup4-4.12.3-py3-none-any.whl",
-			"yanked": false
-		  },
-		  {
-			"core-metadata": false,
-			"data-dist-info-metadata": false,
-			"filename": "beautifulsoup4-4.12.3.tar.gz",
-			"hashes": {
-			  "sha256": "74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"
-			},
-			"requires-python": ">=3.6.0",
-			"size": 581181,
-			"upload-time": "2024-01-17T16:53:17.902970Z",
-			"url": "https://files.pythonhosted.org/packages/b3/ca/824b1195773ce6166d388573fc106ce56d4a805bd7427b624e063596ec58/beautifulsoup4-4.12.3.tar.gz",
 			"yanked": false
 		  },
 		  {


### PR DESCRIPTION
Related to https://github.com/google/osv-scanner/issues/2077

Previously, we only tried to parse the first file in the list for Python requirements, however, that file may be some format that we don't support. This causes error during dependency resolution.

Instead, this PR tries to parse the files in the list one by one until we successfully parse some requirements. This PR also changes logging level from Error to Warn for failures to parse requirements.