### PR TITLE
feat(cdx): extract CDX locations into metadata only [fixes #893]

### DIFF
--- a/extractor/filesystem/sbom/cdx/cdx.go
+++ b/extractor/filesystem/sbom/cdx/cdx.go
@@ -134,7 +134,7 @@ func (e Extractor) convertCdxBomToPackage(cdxBom *cyclonedx.BOM, path string) []
 	enumerateComponents(*cdxBom.Components, &results)
 
 	for p := range results {
-		results[p].Locations = append([]string{path}, results[p].Locations...)
+		results[p].Locations = []string{path}
 	}
 
 	return results
@@ -168,7 +168,7 @@ func convertComponentToInventory(cdxPkg cyclonedx.Component) *extractor.Package 
 	if cdxPkg.Evidence != nil && cdxPkg.Evidence.Occurrences != nil {
 		for _, occ := range *cdxPkg.Evidence.Occurrences {
 			if occ.Location != "" {
-				pkg.Locations = append(pkg.Locations, occ.Location)
+				m.CDXLocations = append(m.CDXLocations, occ.Location)
 			}
 		}
 	}

--- a/extractor/filesystem/sbom/cdx/cdx_test.go
+++ b/extractor/filesystem/sbom/cdx/cdx_test.go
@@ -179,10 +179,13 @@ func TestExtract(t *testing.T) {
 					PURLType: purl.TypeNPM,
 					Metadata: &cdxmeta.Metadata{
 						PURL: purlFromString(t, "pkg:npm/%40gar%2Fpromisify@1.1.3"),
+						CDXLocations: []string{
+							"home/test/.vscode-server/bin/node_modules/@gar/promisify/package.json",
+							"usr/lib/node_modules/@gar/promisify/package.json",
+						},
 					},
 					Locations: []string{
 						"testdata/sbom-with-locations.cdx.json",
-						"home/test/.vscode-server/bin/node_modules/@gar/promisify/package.json",
 					},
 				},
 			},

--- a/extractor/filesystem/sbom/cdx/metadata/metadata.go
+++ b/extractor/filesystem/sbom/cdx/metadata/metadata.go
@@ -21,6 +21,7 @@ import (
 
 // Metadata holds parsing information for packages extracted from CDX files.
 type Metadata struct {
-	PURL *purl.PackageURL
-	CPEs []string
+	PURL         *purl.PackageURL
+	CPEs         []string
+	CDXLocations []string
 }

--- a/extractor/filesystem/sbom/cdx/testdata/sbom-with-locations.cdx.json
+++ b/extractor/filesystem/sbom/cdx/testdata/sbom-with-locations.cdx.json
@@ -14,7 +14,10 @@
              "occurrences": [
                  {
                      "location": "home/test/.vscode-server/bin/node_modules/@gar/promisify/package.json"
-                 }
+                 },
+                 {
+                    "location": "usr/lib/node_modules/@gar/promisify/package.json"
+                }
              ]
          }
      }]


### PR DESCRIPTION
This PR enhances the CycloneDX SBOM extractor as part of issue #893.

- Parsing JSON and XML CycloneDX files.
- Storing component location data in Metadata (not in top-level Locations).
- Adding unit tests for extraction and metadata preservation.

Closes #893