### PR TITLE
fix: classify `cargoauditable` as an artifact extractor

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -164,9 +164,12 @@ var (
 	}
 	// Rust source extractors.
 	RustSource = InitMap{
-		cargolock.Name:      {cargolock.New},
+		cargolock.Name: {cargolock.New},
+		cargotoml.Name: {cargotoml.New},
+	}
+	// Rust artifact extractors.
+	RustArtifact = InitMap{
 		cargoauditable.Name: {cargoauditable.NewDefault},
-		cargotoml.Name:      {cargotoml.New},
 	}
 	// SBOM extractors.
 	SBOM = InitMap{
@@ -256,6 +259,7 @@ var (
 		PythonArtifact,
 		GoArtifact,
 		DotnetArtifact,
+		RustArtifact,
 		SBOM,
 		OS,
 		Misc,


### PR DESCRIPTION
This is how we're using it in `osv-scanner` and it extracts from a binary like `gobinary` and friends do, so I'm pretty sure this should be classed as an artifact extractor rather than a source extractor