### PR TITLE
fix: always use `exec.CommandContext`

### DIFF
--- a/detector/cve/untested/cve202338408/cve202338408.go
+++ b/detector/cve/untested/cve202338408/cve202338408.go
@@ -111,7 +111,7 @@ func isVersionWithinRange(openSSHVersion string, lower string, upper string) (bo
 // Scan checks for the presence of the OpenSSH CVE-2023-38408 vulnerability on the filesystem.
 func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, px *packageindex.PackageIndex) (inventory.Finding, error) {
 	// 1. OpenSSH between and 5.5 and 9.3p1 (inclusive)
-	openSSHVersion := getOpenSSHVersion()
+	openSSHVersion := getOpenSSHVersion(ctx)
 	if openSSHVersion == "" {
 		log.Debugf("No OpenSSH version found")
 		return inventory.Finding{}, nil
@@ -176,8 +176,8 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, px *pa
 	return d.findingForPackage(dbSpecific), nil
 }
 
-func getOpenSSHVersion() string {
-	cmd := exec.Command("ssh", "-V")
+func getOpenSSHVersion(ctx context.Context) string {
+	cmd := exec.CommandContext(ctx, "ssh", "-V")
 	out, err := cmd.CombinedOutput()
 	log.Debugf("ssh -V stdout: %s", string(out))
 	if err != nil {

--- a/guidedremediation/internal/tui/model/state_relock_result.go
+++ b/guidedremediation/internal/tui/model/state_relock_result.go
@@ -545,13 +545,13 @@ func (st stateRelockResult) write(m Model) tea.Msg {
 		return fmt.Errorf("failed removing old node_modules/: %w", err)
 	}
 
-	c := exec.Command(npmPath, "install", "--package-lock-only")
+	c := exec.CommandContext(context.Background(), npmPath, "install", "--package-lock-only")
 	c.Dir = dir
 
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		if err != nil {
 			// try again with "--legacy-peer-deps"
-			c = exec.Command(npmPath, "install", "--package-lock-only", "--legacy-peer-deps")
+			c = exec.CommandContext(context.Background(), npmPath, "install", "--package-lock-only", "--legacy-peer-deps")
 			c.Dir = dir
 
 			return tea.ExecProcess(c, func(err error) tea.Msg { return writeMsg{err} })()


### PR DESCRIPTION
This will be caught by the `noctx` linter in an upcoming version - I think its better to pass in `context.Background()` in cases where we cannot get a context from the caller due to interface restrictions, rather than disabling the linter, but happy to not do that if I'm wrong