### PR TITLE
fix(enricher): strips root prefix from absolute jar paths

### DIFF
--- a/enricher/reachability/java/java.go
+++ b/enricher/reachability/java/java.go
@@ -351,7 +351,7 @@ func enumerateReachabilityForJar(ctx context.Context, jarPath string, input *enr
 // unzipJAR unzips a JAR to a target directory. It also returns a list of paths
 // to all the nested JARs found while unzipping.
 func unzipJAR(jarPath string, input *enricher.ScanInput, jarRoot *os.Root) (nestedJARs []string, err error) {
-	file, err := input.ScanRoot.FS.Open(filepath.ToSlash(jarPath))
+	file, err := openFromRoot(input.ScanRoot, filepath.ToSlash(jarPath))
 	if err != nil {
 		return nil, err
 	}

--- a/enricher/reachability/java/reachable.go
+++ b/enricher/reachability/java/reachable.go
@@ -283,7 +283,7 @@ func (r *ReachabilityEnumerator) handleDynamicCode(jarRoot *os.Root, q *UniqueQu
 					log.Debug("assuming all package classes are reachable", "class", class, "pkg", pkg)
 					q.Push(class, cf)
 				} else {
-					log.Error("failed to find class", "class", class, "from", pkg, "err", err)
+					log.Debug("failed to find class", "class", class, "from", pkg, "err", err)
 				}
 			}
 		}
@@ -320,7 +320,7 @@ func (r *ReachabilityEnumerator) enumerateReachability(
 						codeLoading[thisClass] = struct{}{}
 						err := r.handleDynamicCode(jarRoot, q, thisClass, r.CodeLoadingStrategy)
 						if err != nil {
-							log.Error("failed to handle dynamic code", "thisClass", thisClass, "err", err)
+							log.Debug("failed to handle dynamic code", "thisClass", thisClass, "err", err)
 						}
 					}
 				}
@@ -336,7 +336,7 @@ func (r *ReachabilityEnumerator) enumerateReachability(
 						depInjection[thisClass] = struct{}{}
 						err := r.handleDynamicCode(jarRoot, q, thisClass, r.DependencyInjectionStrategy)
 						if err != nil {
-							log.Error("failed to handle dynamic code", "thisClass", thisClass, "err", err)
+							log.Debug("failed to handle dynamic code", "thisClass", thisClass, "err", err)
 						}
 					}
 				}
@@ -403,7 +403,7 @@ func (r *ReachabilityEnumerator) enumerateReachability(
 			depcf, err := r.findClass(jarRoot, r.ClassPaths, class)
 			if err != nil {
 				// Dependencies can be optional, so this is not a fatal error.
-				log.Error("failed to find class", "class", class, "from", thisClass, "cp idx", i, "error", err)
+				log.Debug("failed to find class", "class", class, "from", thisClass, "cp idx", i, "error", err)
 				continue
 			}
 

--- a/enricher/reachability/java/utils.go
+++ b/enricher/reachability/java/utils.go
@@ -15,8 +15,13 @@
 package java
 
 import (
+	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
+
+	scalibrfs "github.com/google/osv-scalibr/fs"
 )
 
 // mkdirAll simulates the same logic as os.MkdirAll but uses os.Root as input.
@@ -71,4 +76,16 @@ func mkdirAll(jarRoot *os.Root, path string, perm os.FileMode) error {
 	}
 
 	return nil
+}
+
+func openFromRoot(root *scalibrfs.ScanRoot, fullPath string) (fs.File, error) {
+	rootPath := filepath.Clean(root.Path)
+	fullPath = filepath.Clean(fullPath)
+
+	relPath := fullPath
+	if strings.HasPrefix(fullPath, rootPath) {
+		relPath = fullPath[len(rootPath):]
+	}
+
+	return root.FS.Open(relPath)
 }

--- a/enricher/reachability/java/utils.go
+++ b/enricher/reachability/java/utils.go
@@ -17,7 +17,6 @@ package java
 import (
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -79,8 +78,7 @@ func mkdirAll(jarRoot *os.Root, path string, perm os.FileMode) error {
 }
 
 func openFromRoot(root *scalibrfs.ScanRoot, fullPath string) (fs.File, error) {
-	rootPath := filepath.Clean(root.Path)
-	fullPath = filepath.Clean(fullPath)
+	rootPath := root.Path
 
 	relPath := fullPath
 	if strings.HasPrefix(fullPath, rootPath) {


### PR DESCRIPTION
when performing an artifact scan, if the JAR path is an absolute path and the root path is `\`, the prefix should be stripped from the JAR path before doing `root.FS.open()`.