### PR TITLE
ci: update renovate config to not update Go dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
       "groupName": "workflows"
     },
     {
-      "matchLanguages": ["golang"],
+      "matchCategories": ["golang"],
       "enabled": false
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,30 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "timezone": "Australia/Sydney",
   "schedule": ["before 6am on monday"],
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodTidy"],
   "osvVulnerabilityAlerts": true,
-  "lockFileMaintenance": { "enabled": true },
+  "lockFileMaintenance": { 
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],
-      "groupName": "Major Updates",
-      "enabled": true
-    },
-    {
-      "matchLanguages": ["golang"],
-      "groupName": "osv-scalibr minor"
+      "groupName": "Major Updates"
     },
     {
       "matchFileNames": [".github/**"],
       "groupName": "workflows"
     },
     {
-      "matchDepTypes": ["golang"],
+      "matchLanguages": ["golang"],
       "enabled": false
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodTidy"],
   "osvVulnerabilityAlerts": true,
-  "lockFileMaintenance": { 
+  "lockFileMaintenance": {
     "enabled": true
   },
   "packageRules": [


### PR DESCRIPTION
As Google does internal patching of Go dependencies for this library, we don't want Renovate always updating them to latest to avoid unnecessary churn.

I have also updated the config to match the format Renovate uses when it generates the config, and migrated us from `matchLanguages` to `matchCategories`