### PR TITLE
fix(composerlock): don't use `reference` as the commit if it contains a dot

### DIFF
--- a/extractor/filesystem/language/php/composerlock/composerlock.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock.go
@@ -39,6 +39,7 @@ type composerPackage struct {
 	Version string `json:"version"`
 	Dist    struct {
 		Reference string `json:"reference"`
+		Shasum    string `json:"shasum"`
 	} `json:"dist"`
 }
 
@@ -70,13 +71,19 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 }
 
 func buildPackage(input *filesystem.ScanInput, pkg composerPackage, groups []string) *extractor.Package {
+	commit := pkg.Dist.Shasum
+
+	if commit == "" {
+		commit = pkg.Dist.Reference
+	}
+
 	return &extractor.Package{
 		Name:      pkg.Name,
 		Version:   pkg.Version,
 		PURLType:  purl.TypeComposer,
 		Locations: []string{input.Path},
 		SourceCode: &extractor.SourceCodeIdentifier{
-			Commit: pkg.Dist.Reference,
+			Commit: commit,
 		},
 		Metadata: osv.DepGroupMetadata{
 			DepGroupVals: groups,
@@ -102,7 +109,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	)
 
 	for _, pkg := range parsedLockfile.Packages {
-		packages = append(packages, buildPackage(input, pkg, []string{""}))
+		packages = append(packages, buildPackage(input, pkg, []string{}))
 	}
 
 	for _, pkg := range parsedLockfile.PackagesDev {

--- a/extractor/filesystem/language/php/composerlock/composerlock.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock.go
@@ -69,6 +69,21 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	return filepath.Base(api.Path()) == "composer.lock"
 }
 
+func buildPackage(input *filesystem.ScanInput, pkg composerPackage, groups []string) *extractor.Package {
+	return &extractor.Package{
+		Name:      pkg.Name,
+		Version:   pkg.Version,
+		PURLType:  purl.TypeComposer,
+		Locations: []string{input.Path},
+		SourceCode: &extractor.SourceCodeIdentifier{
+			Commit: pkg.Dist.Reference,
+		},
+		Metadata: osv.DepGroupMetadata{
+			DepGroupVals: groups,
+		},
+	}
+}
+
 // Extract extracts packages from a composer.lock file passed through the scan input.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	var parsedLockfile *composerLock
@@ -86,34 +101,12 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 		uint64(len(parsedLockfile.Packages))+uint64(len(parsedLockfile.PackagesDev)),
 	)
 
-	for _, composerPackage := range parsedLockfile.Packages {
-		packages = append(packages, &extractor.Package{
-			Name:      composerPackage.Name,
-			Version:   composerPackage.Version,
-			PURLType:  purl.TypeComposer,
-			Locations: []string{input.Path},
-			SourceCode: &extractor.SourceCodeIdentifier{
-				Commit: composerPackage.Dist.Reference,
-			},
-			Metadata: osv.DepGroupMetadata{
-				DepGroupVals: []string{},
-			},
-		})
+	for _, pkg := range parsedLockfile.Packages {
+		packages = append(packages, buildPackage(input, pkg, []string{""}))
 	}
 
-	for _, composerPackage := range parsedLockfile.PackagesDev {
-		packages = append(packages, &extractor.Package{
-			Name:      composerPackage.Name,
-			Version:   composerPackage.Version,
-			PURLType:  purl.TypeComposer,
-			Locations: []string{input.Path},
-			SourceCode: &extractor.SourceCodeIdentifier{
-				Commit: composerPackage.Dist.Reference,
-			},
-			Metadata: osv.DepGroupMetadata{
-				DepGroupVals: []string{"dev"},
-			},
-		})
+	for _, pkg := range parsedLockfile.PackagesDev {
+		packages = append(packages, buildPackage(input, pkg, []string{"dev"}))
 	}
 
 	return inventory.Inventory{Packages: packages}, nil

--- a/extractor/filesystem/language/php/composerlock/composerlock.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
@@ -39,7 +40,6 @@ type composerPackage struct {
 	Version string `json:"version"`
 	Dist    struct {
 		Reference string `json:"reference"`
-		Shasum    string `json:"shasum"`
 	} `json:"dist"`
 }
 
@@ -71,10 +71,11 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 }
 
 func buildPackage(input *filesystem.ScanInput, pkg composerPackage, groups []string) *extractor.Package {
-	commit := pkg.Dist.Shasum
+	commit := pkg.Dist.Reference
 
-	if commit == "" {
-		commit = pkg.Dist.Reference
+	// a dot means the reference is likely a tag, rather than a commit
+	if strings.Contains(commit, ".") {
+		commit = ""
 	}
 
 	return &extractor.Package{

--- a/extractor/filesystem/language/php/composerlock/composerlock_test.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock_test.go
@@ -222,7 +222,7 @@ func TestExtractor_Extract(t *testing.T) {
 					PURLType:  purl.TypeComposer,
 					Locations: []string{"testdata/drupal-packages.json"},
 					SourceCode: &extractor.SourceCodeIdentifier{
-						Commit: "70b03b6c7868ced71ed0b3ca596ad83e76c2adc0",
+						Commit: "",
 					},
 					Metadata: osv.DepGroupMetadata{
 						DepGroupVals: []string{},
@@ -234,7 +234,7 @@ func TestExtractor_Extract(t *testing.T) {
 					PURLType:  purl.TypeComposer,
 					Locations: []string{"testdata/drupal-packages.json"},
 					SourceCode: &extractor.SourceCodeIdentifier{
-						Commit: "7ceaa18c1b0d42d12aafe5fcc0b5fe22a2ab3096",
+						Commit: "",
 					},
 					Metadata: osv.DepGroupMetadata{
 						DepGroupVals: []string{"dev"},

--- a/extractor/filesystem/language/php/composerlock/composerlock_test.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock_test.go
@@ -198,6 +198,50 @@ func TestExtractor_Extract(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "drupal_packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/drupal-packages.json",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:      "drupal/core",
+					Version:   "10.4.5",
+					PURLType:  purl.TypeComposer,
+					Locations: []string{"testdata/drupal-packages.json"},
+					SourceCode: &extractor.SourceCodeIdentifier{
+						Commit: "5247dbaa65b42b601058555f4a8b2bd541f5611f",
+					},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+				{
+					Name:      "drupal/tfa",
+					Version:   "2.0.0-alpha4",
+					PURLType:  purl.TypeComposer,
+					Locations: []string{"testdata/drupal-packages.json"},
+					SourceCode: &extractor.SourceCodeIdentifier{
+						Commit: "70b03b6c7868ced71ed0b3ca596ad83e76c2adc0",
+					},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+				{
+					Name:      "theseer/tokenizer",
+					Version:   "1.1.3",
+					PURLType:  purl.TypeComposer,
+					Locations: []string{"testdata/drupal-packages.json"},
+					SourceCode: &extractor.SourceCodeIdentifier{
+						Commit: "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+					},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/extractor/filesystem/language/php/composerlock/composerlock_test.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock_test.go
@@ -229,6 +229,18 @@ func TestExtractor_Extract(t *testing.T) {
 					},
 				},
 				{
+					Name:      "drupal/field_time",
+					Version:   "1.0.0-beta5",
+					PURLType:  purl.TypeComposer,
+					Locations: []string{"testdata/drupal-packages.json"},
+					SourceCode: &extractor.SourceCodeIdentifier{
+						Commit: "7ceaa18c1b0d42d12aafe5fcc0b5fe22a2ab3096",
+					},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				{
 					Name:      "theseer/tokenizer",
 					Version:   "1.1.3",
 					PURLType:  purl.TypeComposer,

--- a/extractor/filesystem/language/php/composerlock/testdata/drupal-packages.json
+++ b/extractor/filesystem/language/php/composerlock/testdata/drupal-packages.json
@@ -1,0 +1,307 @@
+{
+  "_readme": [
+    "This file locks the dependencies of your project to a known state",
+    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+    "This file is @generated automatically"
+  ],
+  "content-hash": "123abc",
+  "packages": [
+    {
+      "name": "drupal/core",
+      "version": "10.4.5",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/drupal/core.git",
+        "reference": "5247dbaa65b42b601058555f4a8b2bd541f5611f"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/drupal/core/zipball/5247dbaa65b42b601058555f4a8b2bd541f5611f",
+        "reference": "5247dbaa65b42b601058555f4a8b2bd541f5611f",
+        "shasum": ""
+      },
+      "require": {
+        "asm89/stack-cors": "^2.1",
+        "composer-runtime-api": "^2.1",
+        "composer/semver": "^3.3",
+        "doctrine/annotations": "^1.14",
+        "egulias/email-validator": "^3.2.1|^4.0",
+        "ext-date": "*",
+        "ext-dom": "*",
+        "ext-filter": "*",
+        "ext-gd": "*",
+        "ext-hash": "*",
+        "ext-json": "*",
+        "ext-pcre": "*",
+        "ext-pdo": "*",
+        "ext-session": "*",
+        "ext-simplexml": "*",
+        "ext-spl": "*",
+        "ext-tokenizer": "*",
+        "ext-xml": "*",
+        "guzzlehttp/guzzle": "^7.5",
+        "guzzlehttp/psr7": "^2.4.5",
+        "masterminds/html5": "^2.7",
+        "mck89/peast": "^1.14",
+        "pear/archive_tar": "^1.4.14",
+        "php": ">=8.1.0",
+        "psr/log": "^3.0",
+        "sebastian/diff": "^4",
+        "symfony/console": "^6.4",
+        "symfony/dependency-injection": "^6.4",
+        "symfony/event-dispatcher": "^6.4",
+        "symfony/filesystem": "^6.4",
+        "symfony/finder": "^6.4",
+        "symfony/http-foundation": "^6.4",
+        "symfony/http-kernel": "^6.4",
+        "symfony/mailer": "^6.4",
+        "symfony/mime": "^6.4",
+        "symfony/polyfill-iconv": "^1.26",
+        "symfony/process": "^6.4",
+        "symfony/psr-http-message-bridge": "^2.1|^6.4",
+        "symfony/routing": "^6.4",
+        "symfony/serializer": "^6.4",
+        "symfony/validator": "^6.4",
+        "symfony/yaml": "^6.4",
+        "twig/twig": "^3.15.0"
+      },
+      "conflict": {
+        "drush/drush": "<12.4.3"
+      },
+      "replace": {
+        "drupal/core-annotation": "self.version",
+        "drupal/core-assertion": "self.version",
+        "drupal/core-class-finder": "self.version",
+        "drupal/core-datetime": "self.version",
+        "drupal/core-dependency-injection": "self.version",
+        "drupal/core-diff": "self.version",
+        "drupal/core-discovery": "self.version",
+        "drupal/core-event-dispatcher": "self.version",
+        "drupal/core-file-cache": "self.version",
+        "drupal/core-file-security": "self.version",
+        "drupal/core-filesystem": "self.version",
+        "drupal/core-front-matter": "self.version",
+        "drupal/core-gettext": "self.version",
+        "drupal/core-graph": "self.version",
+        "drupal/core-http-foundation": "self.version",
+        "drupal/core-php-storage": "self.version",
+        "drupal/core-plugin": "self.version",
+        "drupal/core-proxy-builder": "self.version",
+        "drupal/core-render": "self.version",
+        "drupal/core-serialization": "self.version",
+        "drupal/core-transliteration": "self.version",
+        "drupal/core-utility": "self.version",
+        "drupal/core-uuid": "self.version",
+        "drupal/core-version": "self.version"
+      },
+      "suggest": {
+        "ext-zip": "Needed to extend the plugin.manager.archiver service capability with the handling of files in the ZIP format."
+      },
+      "type": "drupal-core",
+      "extra": {
+        "drupal-scaffold": {
+          "file-mapping": {
+            "[web-root]/.htaccess": "assets/scaffold/files/htaccess",
+            "[web-root]/README.md": "assets/scaffold/files/drupal.README.md",
+            "[web-root]/index.php": "assets/scaffold/files/index.php",
+            "[web-root]/.csslintrc": "assets/scaffold/files/csslintrc",
+            "[web-root]/robots.txt": "assets/scaffold/files/robots.txt",
+            "[web-root]/update.php": "assets/scaffold/files/update.php",
+            "[web-root]/web.config": "assets/scaffold/files/web.config",
+            "[web-root]/INSTALL.txt": "assets/scaffold/files/drupal.INSTALL.txt",
+            "[web-root]/.eslintignore": "assets/scaffold/files/eslintignore",
+            "[web-root]/.eslintrc.json": "assets/scaffold/files/eslintrc.json",
+            "[web-root]/.ht.router.php": "assets/scaffold/files/ht.router.php",
+            "[web-root]/sites/README.txt": "assets/scaffold/files/sites.README.txt",
+            "[project-root]/.editorconfig": "assets/scaffold/files/editorconfig",
+            "[web-root]/example.gitignore": "assets/scaffold/files/example.gitignore",
+            "[web-root]/themes/README.txt": "assets/scaffold/files/themes.README.txt",
+            "[project-root]/.gitattributes": "assets/scaffold/files/gitattributes",
+            "[web-root]/modules/README.txt": "assets/scaffold/files/modules.README.txt",
+            "[web-root]/profiles/README.txt": "assets/scaffold/files/profiles.README.txt",
+            "[web-root]/sites/example.sites.php": "assets/scaffold/files/example.sites.php",
+            "[web-root]/sites/development.services.yml": "assets/scaffold/files/development.services.yml",
+            "[web-root]/sites/example.settings.local.php": "assets/scaffold/files/example.settings.local.php",
+            "[web-root]/sites/default/default.services.yml": "assets/scaffold/files/default.services.yml",
+            "[web-root]/sites/default/default.settings.php": "assets/scaffold/files/default.settings.php"
+          }
+        }
+      },
+      "autoload": {
+        "files": [
+          "includes/bootstrap.inc"
+        ],
+        "psr-4": {
+          "Drupal\\Core\\": "lib/Drupal/Core",
+          "Drupal\\Component\\": "lib/Drupal/Component"
+        },
+        "classmap": [
+          "lib/Drupal.php",
+          "lib/Drupal/Component/DependencyInjection/Container.php",
+          "lib/Drupal/Component/DependencyInjection/PhpArrayContainer.php",
+          "lib/Drupal/Component/FileCache/FileCacheFactory.php",
+          "lib/Drupal/Component/Utility/Timer.php",
+          "lib/Drupal/Component/Utility/Unicode.php",
+          "lib/Drupal/Core/Cache/Cache.php",
+          "lib/Drupal/Core/Cache/CacheBackendInterface.php",
+          "lib/Drupal/Core/Cache/CacheTagsChecksumInterface.php",
+          "lib/Drupal/Core/Cache/CacheTagsChecksumTrait.php",
+          "lib/Drupal/Core/Cache/CacheTagsInvalidatorInterface.php",
+          "lib/Drupal/Core/Cache/DatabaseBackend.php",
+          "lib/Drupal/Core/Cache/DatabaseCacheTagsChecksum.php",
+          "lib/Drupal/Core/Database/Connection.php",
+          "lib/Drupal/Core/Database/Database.php",
+          "lib/Drupal/Core/Database/StatementInterface.php",
+          "lib/Drupal/Core/DependencyInjection/Container.php",
+          "lib/Drupal/Core/DrupalKernel.php",
+          "lib/Drupal/Core/DrupalKernelInterface.php",
+          "lib/Drupal/Core/Installer/InstallerRedirectTrait.php",
+          "lib/Drupal/Core/Site/Settings.php",
+          "lib/Drupal/Component/Datetime/Time.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "GPL-2.0-or-later"
+      ],
+      "description": "Drupal is an open source content management platform powering millions of websites and applications.",
+      "support": {
+        "source": "https://github.com/drupal/core/tree/10.4.5"
+      },
+      "time": "2025-03-19T15:53:40+00:00"
+    },
+    {
+      "name": "drupal/tfa",
+      "version": "2.0.0-alpha4",
+      "source": {
+        "type": "git",
+        "url": "https://git.drupalcode.org/project/tfa.git",
+        "reference": "2.0.0-alpha4"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://ftp.drupal.org/files/projects/tfa-2.0.0-alpha4.zip",
+        "reference": "2.0.0-alpha4",
+        "shasum": "70b03b6c7868ced71ed0b3ca596ad83e76c2adc0"
+      },
+      "require": {
+        "chillerlan/php-qrcode": "^1.0.9 || ^2.0 || ^3.2 || ^4.0",
+        "drupal/core": "^10.1 || ^11",
+        "drupal/encrypt": "^3.1",
+        "php": "^8.1",
+        "spomky-labs/otphp": "^11.2"
+      },
+      "require-dev": {
+        "drupal/encrypt": "*",
+        "drupal/key": "*",
+        "drush/drush": "^11 || ^12 || ^13",
+        "mglaman/phpstan-drupal": "^1.1",
+        "phpstan/extension-installer": "^1.2",
+        "phpstan/phpstan": "^1.9",
+        "phpstan/phpstan-deprecation-rules": "^1.1",
+        "phpstan/phpstan-phpunit": "^1.3"
+      },
+      "type": "drupal-module",
+      "extra": {
+        "drupal": {
+          "version": "2.0.0-alpha4",
+          "datestamp": "1732925521",
+          "security-coverage": {
+            "status": "not-covered",
+            "message": "Alpha releases are not covered by Drupal security advisories."
+          }
+        },
+        "drush": {
+          "services": {
+            "drush.services.yml": "^11"
+          }
+        }
+      },
+      "notification-url": "https://packages.drupal.org/8/downloads",
+      "license": [
+        "GPL-2.0-or-later"
+      ],
+      "authors": [
+        {
+          "name": "cmlara",
+          "homepage": "https://www.drupal.org/user/1790054"
+        },
+        {
+          "name": "coltrane",
+          "homepage": "https://www.drupal.org/user/91990"
+        },
+        {
+          "name": "daggerhart",
+          "homepage": "https://www.drupal.org/user/167806"
+        },
+        {
+          "name": "greggles",
+          "homepage": "https://www.drupal.org/user/36762"
+        },
+        {
+          "name": "jcnventura",
+          "homepage": "https://www.drupal.org/user/122464"
+        },
+        {
+          "name": "nerdstein",
+          "homepage": "https://www.drupal.org/user/1557710"
+        },
+        {
+          "name": "poker10",
+          "homepage": "https://www.drupal.org/user/272316"
+        }
+      ],
+      "description": "Pluggable provider of two factor authentication for Drupal",
+      "homepage": "https://www.drupal.org/project/tfa",
+      "support": {
+        "source": "https://git.drupalcode.org/project/tfa"
+      }
+    },
+    {
+      "name": "theseer/tokenizer",
+      "version": "1.1.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/theseer/tokenizer.git",
+        "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+        "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+        "shasum": ""
+      },
+      "require": {
+        "ext-dom": "*",
+        "ext-tokenizer": "*",
+        "ext-xmlwriter": "*",
+        "php": "^7.0"
+      },
+      "type": "library",
+      "autoload": {
+        "classmap": ["src/"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["BSD-3-Clause"],
+      "authors": [
+        {
+          "name": "Arne Blankerts",
+          "email": "arne@blankerts.de",
+          "role": "Developer"
+        }
+      ],
+      "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+      "time": "2019-06-13T22:48:21+00:00"
+    }
+  ],
+  "packages-dev": [],
+  "aliases": [],
+  "minimum-stability": "dev",
+  "stability-flags": [],
+  "prefer-stable": true,
+  "prefer-lowest": false,
+  "platform": {
+    "php": "^7.1.3"
+  },
+  "platform-dev": []
+}

--- a/extractor/filesystem/language/php/composerlock/testdata/drupal-packages.json
+++ b/extractor/filesystem/language/php/composerlock/testdata/drupal-packages.json
@@ -294,7 +294,53 @@
       "time": "2019-06-13T22:48:21+00:00"
     }
   ],
-  "packages-dev": [],
+  "packages-dev": [
+    {
+      "name": "drupal/field_time",
+      "version": "1.0.0-beta5",
+      "source": {
+        "type": "git",
+        "url": "https://git.drupalcode.org/project/field_time.git",
+        "reference": "1.0.0-beta5"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://ftp.drupal.org/files/projects/field_time-1.0.0-beta5.zip",
+        "reference": "1.0.0-beta5",
+        "shasum": "7ceaa18c1b0d42d12aafe5fcc0b5fe22a2ab3096"
+      },
+      "require": {
+        "drupal/core": "^9 || ^10 || ^11"
+      },
+      "type": "drupal-module",
+      "extra": {
+        "drupal": {
+          "version": "1.0.0-beta5",
+          "datestamp": "1728318848",
+          "security-coverage": {
+            "status": "not-covered",
+            "message": "Beta releases are not covered by Drupal security advisories."
+          }
+        }
+      },
+      "notification-url": "https://packages.drupal.org/8/downloads",
+      "license": [
+        "GPL-2.0-or-later"
+      ],
+      "authors": [
+        {
+          "name": "kgaut",
+          "homepage": "https://www.drupal.org/user/686336"
+        }
+      ],
+      "description": "Provides a Time form element and Time and TimeRange field.",
+      "homepage": "https://www.drupal.org/project/field_time",
+      "support": {
+        "source": "https://git.drupalcode.org/project/field_time",
+        "issues": "https://www.drupal.org/project/field_time/issues"
+      }
+    }
+  ],
   "aliases": [],
   "minimum-stability": "dev",
   "stability-flags": [],


### PR DESCRIPTION
Its possible for the `reference` field to contain values other than commits, such as for Drupal packages it holds a tag-type value.

Because I'm not sure all of the details behind when this will be the case, I've gone with having us blank the commit if the value has a dot in it since that is not a valid character in a SHA anyway, but this might not cover all situations e.g. if a branch-type value could be used.

Since we're hoping to soon have special handling for Drupal packages and I couldn't find non-Drupal package with this situation, I've used the test from #950 meaning that PR will just change the existing test case rather than add a new one 🤷 

I have also stretched this a little to encapsulate the package building in a dedicated function since its the same for dev and non-dev, and with #950 there'll be more conditional logic so I think it makes sense to do that and might as well do it now