### PR TITLE
fix: only set local registry for Maven client when it's not empty

### DIFF
--- a/binary/cli/cli.go
+++ b/binary/cli/cli.go
@@ -474,7 +474,7 @@ func (f *Flags) pluginsToRun() ([]plugin.Plugin, error) {
 			if p.Name() == gobinary.Name {
 				p.(*gobinary.Extractor).VersionFromContent = f.GoBinaryVersionFromContent
 			}
-			if p.Name() == pomxmlnet.Name {
+			if p.Name() == pomxmlnet.Name && f.LocalRegistry != "" {
 				p.(*pomxmlnet.Extractor).MavenClient.SetLocalRegistry(filepath.Join(f.LocalRegistry, "maven"))
 			}
 			if p.Name() == binary.Name {


### PR DESCRIPTION
Fixed in https://github.com/google/osv-scalibr/pull/851 but reverted in https://github.com/google/osv-scalibr/pull/796.