### PR TITLE
fix: don't mention the `input.Path` in extractor errors

### DIFF
--- a/extractor/filesystem/containers/containerd/containerd_linux.go
+++ b/extractor/filesystem/containers/containerd/containerd_linux.go
@@ -129,7 +129,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	var pkgs = []*extractor.Package{}
 
 	if input.Info != nil && input.Info.Size() > e.maxMetaDBFileSize {
-		return inventory.Inventory{}, fmt.Errorf("containerd metadb file %s is too large: %d", input.Path, input.Info.Size())
+		return inventory.Inventory{}, fmt.Errorf("containerd metadb file is too large: %d", input.Info.Size())
 	}
 	// Timeout is added to make sure Scalibr does not hand if the metadb file is open by another process.
 	// This will still allow to handle the snapshot of a machine.

--- a/extractor/filesystem/containers/dockerbaseimage/dockerbaseimage.go
+++ b/extractor/filesystem/containers/dockerbaseimage/dockerbaseimage.go
@@ -17,6 +17,7 @@ package dockerbaseimage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -108,7 +109,7 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 // Extract extracts base image urls from a Dockerfile.
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	if input.Info == nil {
-		return inventory.Inventory{}, fmt.Errorf("input.Info is nil for %q", input.Path)
+		return inventory.Inventory{}, errors.New("input.Info is nil")
 	}
 	if input.Info.Size() > e.maxFileSizeBytes {
 		// Skipping too large file.

--- a/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock-v1_test.go
@@ -36,7 +36,7 @@ func TestExtractor_Extract_v1(t *testing.T) {
 				Path: "testdata/not-json.txt",
 			},
 			WantPackages: nil,
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/cpp/conanlock/conanlock.go
+++ b/extractor/filesystem/language/cpp/conanlock/conanlock.go
@@ -225,7 +225,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 
 	err := json.NewDecoder(input.Reader).Decode(&parsedLockfile)
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	pkgs := parseConanLock(*parsedLockfile)

--- a/extractor/filesystem/language/dart/pubspec/pubspec.go
+++ b/extractor/filesystem/language/dart/pubspec/pubspec.go
@@ -94,7 +94,7 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	var parsedLockfile *pubspecLockfile
 	if err := yaml.NewDecoder(input.Reader).Decode(&parsedLockfile); err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	packages := make([]*extractor.Package, 0, len(parsedLockfile.Packages))

--- a/extractor/filesystem/language/dart/pubspec/pubspec_test.go
+++ b/extractor/filesystem/language/dart/pubspec/pubspec_test.go
@@ -78,14 +78,14 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-yaml.txt",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "empty",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/empty.lock",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/erlang/mixlock/mixlockutils/mixlockutils.go
+++ b/extractor/filesystem/language/erlang/mixlock/mixlockutils/mixlockutils.go
@@ -91,7 +91,7 @@ func ParseMixLockFile(input *filesystem.ScanInput) (inventory.Inventory, error) 
 	}
 
 	if err := scanner.Err(); err != nil {
-		return inventory.Inventory{}, fmt.Errorf("error while scanning %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("error while scanning: %w", err)
 	}
 
 	return inventory.Inventory{Packages: packages}, nil

--- a/extractor/filesystem/language/golang/gomod/gomod.go
+++ b/extractor/filesystem/language/golang/gomod/gomod.go
@@ -93,7 +93,7 @@ type pkgKey struct {
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	pkgs, goVersion, err := e.extractGoMod(input)
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	// At go 1.17 and above, the go command adds an indirect requirement for each module that provides any

--- a/extractor/filesystem/language/golang/gomod/gomod_test.go
+++ b/extractor/filesystem/language/golang/gomod/gomod_test.go
@@ -77,7 +77,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-go-mod.mod",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/haskell/cabal/cabal.go
+++ b/extractor/filesystem/language/haskell/cabal/cabal.go
@@ -151,7 +151,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for s.Scan() {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return packages, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
+			return packages, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
 		}
 
 		line := s.Text()
@@ -177,7 +177,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 		}
 
 		if s.Err() != nil {
-			return packages, fmt.Errorf("error while scanning cabal.project.freeze file from %v: %w", input.Path, s.Err())
+			return packages, fmt.Errorf("error while scanning cabal.project.freeze file: %w", s.Err())
 		}
 	}
 

--- a/extractor/filesystem/language/haskell/stacklock/stacklock.go
+++ b/extractor/filesystem/language/haskell/stacklock/stacklock.go
@@ -151,7 +151,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for s.Scan() {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return packages, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
+			return packages, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
 		}
 
 		line := strings.TrimSpace(s.Text())
@@ -176,7 +176,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 		}
 
 		if s.Err() != nil {
-			return packages, fmt.Errorf("error while scanning cabal.project.freeze file from %v: %w", input.Path, s.Err())
+			return packages, fmt.Errorf("error while scanning cabal.project.freeze file: %w", s.Err())
 		}
 	}
 

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml.go
@@ -72,7 +72,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	err := xml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	packages := make([]*extractor.Package, 0, len(parsedLockfile.Components))

--- a/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
+++ b/extractor/filesystem/language/java/gradleverificationmetadataxml/gradleverificationmetadataxml_test.go
@@ -110,7 +110,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-xml.txt",
 			},
 			WantPackages: nil,
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/java/pomxml/pomxml.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml.go
@@ -85,10 +85,10 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 
 	err := xml.NewDecoder(input.Reader).Decode(&project)
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 	if err := project.Interpolate(); err != nil {
-		return inventory.Inventory{}, fmt.Errorf("failed to interpolate pom.xml %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("failed to interpolate pom.xml: %w", err)
 	}
 
 	// Merging parents data by parsing local parent pom.xml.

--- a/extractor/filesystem/language/java/pomxml/pomxml_test.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml_test.go
@@ -86,7 +86,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-pom.txt",
 			},
 			WantPackages: nil,
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "invalid syntax",
@@ -94,7 +94,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/invalid-syntax.xml",
 			},
 			WantPackages: nil,
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet.go
@@ -108,7 +108,7 @@ func (e Extractor) FileRequired(fapi filesystem.FileAPI) bool {
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	var project maven.Project
 	if err := datasource.NewMavenDecoder(input.Reader).Decode(&project); err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 	// Empty JDK and ActivationOS indicates merging the default profiles.
 	if err := project.MergeProfiles("", maven.ActivationOS{}); err != nil {

--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet_test.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet_test.go
@@ -79,7 +79,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/maven/not-pom.txt",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "invalid xml syntax",

--- a/extractor/filesystem/language/javascript/bunlock/bunlock.go
+++ b/extractor/filesystem/language/javascript/bunlock/bunlock.go
@@ -117,11 +117,11 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	b, err := io.ReadAll(input.Reader)
 
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %q: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	if err := json.Unmarshal(jsonc.ToJSON(b), &parsedLockfile); err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %q: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract %w", err)
 	}
 
 	packages := make([]*extractor.Package, 0, len(parsedLockfile.Packages))
@@ -132,7 +132,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 		name, version, commit, err := structurePackageDetails(pkg)
 
 		if err != nil {
-			errs = append(errs, fmt.Errorf("could not extract '%s' from %q: %w", key, input.Path, err))
+			errs = append(errs, fmt.Errorf("could not extract '%s': %w", key, err))
 
 			continue
 		}

--- a/extractor/filesystem/language/javascript/bunlock/bunlock_test.go
+++ b/extractor/filesystem/language/javascript/bunlock/bunlock_test.go
@@ -89,7 +89,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-json.txt",
 			},
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 			WantPackages: nil,
 		},
 		{
@@ -147,7 +147,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/bad-tuple.json5",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract 'wrappy-bad1' from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract 'wrappy-bad1'"},
 			WantPackages: []*extractor.Package{
 				{
 					Name:       "wrappy",
@@ -166,7 +166,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/bad-tuple.json5",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract 'wrappy-bad2' from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract 'wrappy-bad2'"},
 			WantPackages: []*extractor.Package{
 				{
 					Name:       "wrappy",

--- a/extractor/filesystem/language/javascript/packagejson/packagejson.go
+++ b/extractor/filesystem/language/javascript/packagejson/packagejson.go
@@ -144,7 +144,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	p, err := parse(input.Path, input.Reader)
 	if err != nil {
 		e.reportFileExtracted(input.Path, input.Info, err)
-		return inventory.Inventory{}, fmt.Errorf("packagejson.parse(%s): %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("packagejson.parse: %w", err)
 	}
 
 	pkgs := []*extractor.Package{}

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
@@ -36,7 +36,7 @@ func TestNPMLockExtractor_Extract_V1(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-json.txt",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v2_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v2_test.go
@@ -36,7 +36,7 @@ func TestNPMLockExtractor_Extract_V2(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-json.txt",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson.go
@@ -307,7 +307,7 @@ func (e Extractor) extractPkgLock(_ context.Context, input *filesystem.ScanInput
 	err := json.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return nil, fmt.Errorf("could not extract from %q: %w", input.Path, err)
+		return nil, fmt.Errorf("could not extract: %w", err)
 	}
 
 	packages := slices.Collect(maps.Values(parseNpmLock(*parsedLockfile)))

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson_test.go
@@ -231,7 +231,7 @@ func TestExtractor_Extract_Shrinkwrap_JSON(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-json.txt",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "valid package-lock.json only",

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
@@ -260,7 +260,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	err := yaml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil && !errors.Is(err, io.EOF) {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	// this will happen if the file is empty

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock_test.go
@@ -89,7 +89,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-yaml.txt",
 			},
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 			WantPackages: nil,
 		},
 		{

--- a/extractor/filesystem/language/javascript/yarnlock/yarnlock.go
+++ b/extractor/filesystem/language/javascript/yarnlock/yarnlock.go
@@ -207,7 +207,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 
 	packageGroups, err := groupYarnPackageDescriptions(ctx, scanner)
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("error while scanning %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("error while scanning: %w", err)
 	}
 
 	packages := make([]*extractor.Package, 0, len(packageGroups))

--- a/extractor/filesystem/language/php/composerlock/composerlock.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock.go
@@ -99,7 +99,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	err := json.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	packages := make(

--- a/extractor/filesystem/language/php/composerlock/composerlock_test.go
+++ b/extractor/filesystem/language/php/composerlock/composerlock_test.go
@@ -85,7 +85,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-json.txt",
 			},
 			WantPackages: nil,
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/python/pdmlock/pdmlock.go
+++ b/extractor/filesystem/language/python/pdmlock/pdmlock.go
@@ -74,7 +74,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 
 	_, err := toml.NewDecoder(input.Reader).Decode(&parsedLockFile)
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 	packages := make([]*extractor.Package, 0, len(parsedLockFile.Packages))
 

--- a/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
+++ b/extractor/filesystem/language/python/pdmlock/pdmlock_test.go
@@ -90,7 +90,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-toml.txt",
 			},
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 			WantPackages: nil,
 		},
 		{

--- a/extractor/filesystem/language/python/pipfilelock/pipfilelock.go
+++ b/extractor/filesystem/language/python/pipfilelock/pipfilelock.go
@@ -75,7 +75,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	err := json.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	details := make(map[string]*extractor.Package)

--- a/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
+++ b/extractor/filesystem/language/python/pipfilelock/pipfilelock_test.go
@@ -84,7 +84,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-json.txt",
 			},
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 			WantPackages: nil,
 		},
 		{

--- a/extractor/filesystem/language/python/poetrylock/poetrylock.go
+++ b/extractor/filesystem/language/python/poetrylock/poetrylock.go
@@ -103,7 +103,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	_, err := toml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	packages := make([]*extractor.Package, 0, len(parsedLockfile.Packages))

--- a/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
+++ b/extractor/filesystem/language/python/poetrylock/poetrylock_test.go
@@ -84,7 +84,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-toml.txt",
 			},
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 			WantPackages: nil,
 		},
 		{

--- a/extractor/filesystem/language/python/setup/setup.go
+++ b/extractor/filesystem/language/python/setup/setup.go
@@ -151,7 +151,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for s.Scan() {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return packages, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
+			return packages, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
 		}
 
 		line := s.Text()
@@ -188,7 +188,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 		}
 
 		if s.Err() != nil {
-			return packages, fmt.Errorf("error while scanning setup.py file from %v: %w", input.Path, s.Err())
+			return packages, fmt.Errorf("error while scanning setup.py file: %w", s.Err())
 		}
 	}
 

--- a/extractor/filesystem/language/python/uvlock/uvlock.go
+++ b/extractor/filesystem/language/python/uvlock/uvlock.go
@@ -89,7 +89,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	_, err := toml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	packages := make([]*extractor.Package, 0, len(parsedLockfile.Packages))

--- a/extractor/filesystem/language/python/uvlock/uvlock_test.go
+++ b/extractor/filesystem/language/python/uvlock/uvlock_test.go
@@ -98,7 +98,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/not-toml.txt",
 			},
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 			WantPackages: nil,
 		},
 		{

--- a/extractor/filesystem/language/python/wheelegg/wheelegg.go
+++ b/extractor/filesystem/language/python/wheelegg/wheelegg.go
@@ -181,7 +181,7 @@ var ErrSizeNotSet = errors.New("input.Info is nil, but should have Size set")
 func (e Extractor) extractZip(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Package, error) {
 	r, err := scalibrfs.NewReaderAt(input.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("newReaderAt(%s): %w", input.Path, err)
+		return nil, fmt.Errorf("newReaderAt: %w", err)
 	}
 
 	if input.Info == nil {
@@ -190,7 +190,7 @@ func (e Extractor) extractZip(ctx context.Context, input *filesystem.ScanInput) 
 	s := input.Info.Size()
 	zr, err := zip.NewReader(r, s)
 	if err != nil {
-		return nil, fmt.Errorf("zip.NewReader(%s): %w", input.Path, err)
+		return nil, fmt.Errorf("zip.NewReader: %w", err)
 	}
 	pkgs := []*extractor.Package{}
 	for _, f := range zr.File {
@@ -213,7 +213,7 @@ func (e Extractor) extractZip(ctx context.Context, input *filesystem.ScanInput) 
 func (e Extractor) openAndExtract(f *zip.File, input *filesystem.ScanInput) (*extractor.Package, error) {
 	r, err := f.Open()
 	if err != nil {
-		return nil, fmt.Errorf("on %q: Open(%s): %w", input.Path, f.Name, err)
+		return nil, fmt.Errorf("f.Open(%s): %w", f.Name, err)
 	}
 	defer r.Close()
 
@@ -229,7 +229,7 @@ func (e Extractor) openAndExtract(f *zip.File, input *filesystem.ScanInput) (*ex
 func (e Extractor) extractSingleFile(r io.Reader, path string) (*extractor.Package, error) {
 	p, err := parse(r)
 	if err != nil {
-		return nil, fmt.Errorf("wheelegg.parse(%s): %w", path, err)
+		return nil, fmt.Errorf("wheelegg.parse: %w", err)
 	}
 
 	p.Locations = []string{path}

--- a/extractor/filesystem/language/r/renvlock/renvlock.go
+++ b/extractor/filesystem/language/r/renvlock/renvlock.go
@@ -72,7 +72,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	err := json.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	packages := make([]*extractor.Package, 0, len(parsedLockfile.Packages))

--- a/extractor/filesystem/language/r/renvlock/renvlock_test.go
+++ b/extractor/filesystem/language/r/renvlock/renvlock_test.go
@@ -35,7 +35,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-json.txt",
 			},
 			WantPackages: nil,
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/ruby/gemspec/gemspec.go
+++ b/extractor/filesystem/language/ruby/gemspec/gemspec.go
@@ -130,7 +130,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	p, err := extract(input.Path, input.Reader)
 	e.reportFileExtracted(input.Path, input.Info, filesystem.ExtractorErrorToFileExtractedResult(err))
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("gemspec.parse(%s): %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("gemspec.parse: %w", err)
 	}
 	if p == nil {
 		return inventory.Inventory{}, nil

--- a/extractor/filesystem/language/rust/cargoauditable/cargoauditable.go
+++ b/extractor/filesystem/language/rust/cargoauditable/cargoauditable.go
@@ -141,7 +141,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 			return inventory.Inventory{}, nil
 		}
 		log.Debugf("error getting dependency information from binary (%s) for extraction: %v", input.Path, err)
-		return inventory.Inventory{}, fmt.Errorf("rustaudit.GetDependencyInfo(%q): %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("rustaudit.GetDependencyInfo: %w", err)
 	}
 
 	pkgs := []*extractor.Package{}

--- a/extractor/filesystem/language/rust/cargolock/cargolock.go
+++ b/extractor/filesystem/language/rust/cargolock/cargolock.go
@@ -72,7 +72,7 @@ func (e Extractor) Extract(_ context.Context, input *filesystem.ScanInput) (inve
 	_, err := toml.NewDecoder(input.Reader).Decode(&parsedLockfile)
 
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	packages := make([]*extractor.Package, 0, len(parsedLockfile.Packages))

--- a/extractor/filesystem/language/rust/cargolock/cargolock_test.go
+++ b/extractor/filesystem/language/rust/cargolock/cargolock_test.go
@@ -86,7 +86,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-toml.txt",
 			},
 			WantPackages: nil,
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no packages",

--- a/extractor/filesystem/language/rust/cargotoml/cargotoml.go
+++ b/extractor/filesystem/language/rust/cargotoml/cargotoml.go
@@ -145,7 +145,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 
 	_, err := toml.NewDecoder(input.Reader).Decode(&parsedTomlFile)
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	packages := make([]*extractor.Package, 0, len(parsedTomlFile.Dependencies)+1)
@@ -159,7 +159,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 
 	for name, dependency := range parsedTomlFile.Dependencies {
 		if err := ctx.Err(); err != nil {
-			return inventory.Inventory{Packages: packages}, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
+			return inventory.Inventory{Packages: packages}, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
 		}
 
 		var srcCode *extractor.SourceCodeIdentifier

--- a/extractor/filesystem/language/rust/cargotoml/cargotoml_test.go
+++ b/extractor/filesystem/language/rust/cargotoml/cargotoml_test.go
@@ -85,7 +85,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/not-toml.txt",
 			},
 			WantPackages: nil,
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "Invalid dependency toml",
@@ -93,7 +93,7 @@ func TestExtractor_Extract(t *testing.T) {
 				Path: "testdata/invalid-dependency.toml",
 			},
 			WantPackages: nil,
-			WantErr:      extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "no dependencies",

--- a/extractor/filesystem/misc/chrome/extensions/extensions.go
+++ b/extractor/filesystem/misc/chrome/extensions/extensions.go
@@ -123,22 +123,22 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	var m manifest
 	if err := json.NewDecoder(input.Reader).Decode(&m); err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract manifest from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract manifest: %w", err)
 	}
 	if err := m.validate(); err != nil {
-		return inventory.Inventory{}, fmt.Errorf("bad format in manifest %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("bad format in manifest: %w", err)
 	}
 
 	id, err := extractExtensionsIDFromPath(input)
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract extension id from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract extension id: %w", err)
 	}
 
 	// if default locale is specified some fields of the manifest may be
 	// written inside the ./_locales/LOCALE_CODE/messages.json file
 	if m.DefaultLocale != "" {
 		if err := extractLocaleInfo(&m, input); err != nil {
-			return inventory.Inventory{}, fmt.Errorf("could not extract locale info from %s: %w", input.Path, err)
+			return inventory.Inventory{}, fmt.Errorf("could not extract locale info: %w", err)
 		}
 	}
 

--- a/extractor/filesystem/misc/chrome/extensions/extensions_test.go
+++ b/extractor/filesystem/misc/chrome/extensions/extensions_test.go
@@ -112,7 +112,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/nolocaleoekpmoecnnnilnnbdlolhkhi/1.89.1/manifest.json",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract locale info from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract locale info"},
 		},
 		{
 			Name: "locale specified",

--- a/extractor/filesystem/misc/vscodeextensions/vscodeextensions.go
+++ b/extractor/filesystem/misc/vscodeextensions/vscodeextensions.go
@@ -84,13 +84,13 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	var exts []*extension
 	if err := json.NewDecoder(input.Reader).Decode(&exts); err != nil {
-		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
 	}
 
 	pkgs := make([]*extractor.Package, 0, len(exts))
 	for _, ext := range exts {
 		if err := ext.validate(); err != nil {
-			return inventory.Inventory{}, fmt.Errorf("bad format in %s: %w", input.Path, err)
+			return inventory.Inventory{}, fmt.Errorf("bad format: %w", err)
 		}
 		pkgs = append(pkgs, &extractor.Package{
 			Name:      ext.Identifier.ID,

--- a/extractor/filesystem/misc/vscodeextensions/vscodeextensions_test.go
+++ b/extractor/filesystem/misc/vscodeextensions/vscodeextensions_test.go
@@ -93,7 +93,7 @@ func TestExtractor_Extract(t *testing.T) {
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/invalid.json",
 			},
-			WantErr: extracttest.ContainsErrStr{Str: "could not extract from"},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
 		},
 		{
 			Name: "one extension",

--- a/extractor/filesystem/os/apk/apk.go
+++ b/extractor/filesystem/os/apk/apk.go
@@ -146,7 +146,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
-			return nil, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
+			return nil, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
 		}
 
 		record := scanner.Record()
@@ -184,7 +184,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error while parsing apk status file %q: %w", input.Path, err)
+		return nil, fmt.Errorf("error while parsing apk status file: %w", err)
 	}
 
 	return packages, nil

--- a/extractor/filesystem/os/cos/cos.go
+++ b/extractor/filesystem/os/cos/cos.go
@@ -155,7 +155,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.P
 	dec := json.NewDecoder(input.Reader)
 	var packages cosPackageInfo
 	if err := dec.Decode(&packages); err != nil {
-		err := fmt.Errorf("failed to json decode %q: %w", input.Path, err)
+		err := fmt.Errorf("failed to json decode: %w", err)
 		log.Debugf(err.Error())
 		// TODO(b/281023532): We should not mark the overall SCALIBR scan as failed if we can't parse a file.
 		return nil, fmt.Errorf("%w", err)

--- a/extractor/filesystem/os/dpkg/dpkg.go
+++ b/extractor/filesystem/os/dpkg/dpkg.go
@@ -183,7 +183,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for eof := false; !eof; {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return pkgs, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
+			return pkgs, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
 		}
 
 		h, err := rd.ReadMIMEHeader()

--- a/extractor/filesystem/os/flatpak/flatpak.go
+++ b/extractor/filesystem/os/flatpak/flatpak.go
@@ -163,7 +163,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 		})
 	}
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("flatpak.extract(%s): %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("flatpak.extract: %w", err)
 	}
 	if p == nil {
 		return inventory.Inventory{}, nil

--- a/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
+++ b/extractor/filesystem/os/kernel/vmlinuz/vmlinuz.go
@@ -161,7 +161,7 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.P
 
 	r, err := scalibrfs.NewReaderAt(input.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("NewReaderAt(%s): %w", input.Path, err)
+		return nil, fmt.Errorf("NewReaderAt: %w", err)
 	}
 
 	magicType, err := magic.GetType(r)

--- a/extractor/filesystem/os/macapps/macapps.go
+++ b/extractor/filesystem/os/macapps/macapps.go
@@ -148,7 +148,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 		})
 	}
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("macOS Application.extract(%s): %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("macOS Application.extract: %w", err)
 	}
 	if p == nil {
 		return inventory.Inventory{}, nil

--- a/extractor/filesystem/os/nix/nix.go
+++ b/extractor/filesystem/os/nix/nix.go
@@ -99,7 +99,7 @@ var packageStoreUnstableRegex = regexp.MustCompile(`^([a-zA-Z0-9]{32})-([a-zA-Z0
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	// Check for cancellation or timeout.
 	if err := ctx.Err(); err != nil {
-		return inventory.Inventory{}, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
 	}
 
 	m, err := osrelease.GetOSRelease(input.FS)

--- a/extractor/filesystem/os/pacman/pacman.go
+++ b/extractor/filesystem/os/pacman/pacman.go
@@ -162,7 +162,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 	for s.Scan() {
 		// Return if canceled or exceeding deadline.
 		if err := ctx.Err(); err != nil {
-			return packages, fmt.Errorf("%s halted at %q because of context error: %w", e.Name(), input.Path, err)
+			return packages, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
 		}
 
 		line := s.Text()
@@ -185,7 +185,7 @@ func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanI
 				log.Warnf("Reached EOF for desc file in %v", input.Path)
 				break
 			}
-			return packages, fmt.Errorf("%s halted at %q: %w", e.Name(), input.Path, err)
+			return packages, fmt.Errorf("%s halted: %w", e.Name(), err)
 		}
 	}
 

--- a/extractor/filesystem/os/snap/snap.go
+++ b/extractor/filesystem/os/snap/snap.go
@@ -17,6 +17,7 @@ package snap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -165,15 +166,15 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.P
 	snap := snap{}
 	dec := yaml.NewDecoder(input.Reader)
 	if err := dec.Decode(&snap); err != nil {
-		return nil, fmt.Errorf("failed to yaml decode %q: %w", input.Path, err)
+		return nil, fmt.Errorf("failed to yaml decode: %w", err)
 	}
 
 	if snap.Name == "" {
-		return nil, fmt.Errorf("missing snap name from %q", input.Path)
+		return nil, errors.New("missing snap name")
 	}
 
 	if snap.Version == "" {
-		return nil, fmt.Errorf("missing snap version from %q", input.Path)
+		return nil, errors.New("missing snap version")
 	}
 
 	pkg := &extractor.Package{

--- a/extractor/filesystem/sbom/cdx/cdx.go
+++ b/extractor/filesystem/sbom/cdx/cdx.go
@@ -17,7 +17,7 @@ package cdx
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	var cdxExtractor = findExtractor(input.Path)
 
 	if cdxExtractor == nil {
-		return inventory.Inventory{}, fmt.Errorf("sbom/cdx extractor: Invalid file format %s, only JSON and XML are supported", input.Path)
+		return inventory.Inventory{}, errors.New("sbom/cdx extractor: Invalid file format, only JSON and XML are supported")
 	}
 
 	cdxBOM, err := cdxExtractor(input.Reader)

--- a/extractor/filesystem/sbom/spdx/spdx.go
+++ b/extractor/filesystem/sbom/spdx/spdx.go
@@ -17,7 +17,7 @@ package spdx
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"path/filepath"
 	"strings"
@@ -79,7 +79,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	var parseSbom, isSupported = findExtractor(input.Path)
 
 	if !isSupported {
-		return inventory.Inventory{}, fmt.Errorf("sbom/spdx extractor: Invalid file format %s, only JSON, YAML, RDF, and TagValue are supported", input.Path)
+		return inventory.Inventory{}, errors.New("sbom/spdx extractor: Invalid file format, only JSON, YAML, RDF, and TagValue are supported")
 	}
 
 	spdxDoc, err := parseSbom(input.Reader)

--- a/extractor/filesystem/secrets/secrets.go
+++ b/extractor/filesystem/secrets/secrets.go
@@ -110,7 +110,7 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	secrets, err := e.e.Detect(ctx, input.Reader)
 	if err != nil {
-		return inventory.Inventory{}, fmt.Errorf("unable to scan %q for secrets: %w", input.Path, err)
+		return inventory.Inventory{}, fmt.Errorf("unable to scan for secrets: %w", err)
 	}
 	i := inventory.Inventory{}
 	for _, s := range secrets {


### PR DESCRIPTION
Resolves #821