### PR TITLE
fix(javareach): handle abs path in windows

### DIFF
--- a/enricher/reachability/java/java.go
+++ b/enricher/reachability/java/java.go
@@ -27,7 +27,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -357,7 +356,7 @@ func enumerateReachabilityForJar(ctx context.Context, jarPath string, input *enr
 // unzipJAR unzips a JAR to a target directory. It also returns a list of paths
 // to all the nested JARs found while unzipping.
 func unzipJAR(jarPath string, input *enricher.ScanInput, jarRoot *os.Root) (nestedJARs []string, err error) {
-	file, err := openFromRoot(input.ScanRoot, filepath.ToSlash(jarPath))
+	file, err := openFromRoot(input.ScanRoot, jarPath)
 	if err != nil {
 		return nil, err
 	}

--- a/enricher/reachability/java/utils.go
+++ b/enricher/reachability/java/utils.go
@@ -17,6 +17,7 @@ package java
 import (
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -85,5 +86,5 @@ func openFromRoot(root *scalibrfs.ScanRoot, fullPath string) (fs.File, error) {
 		relPath = fullPath[len(rootPath):]
 	}
 
-	return root.FS.Open(relPath)
+	return root.FS.Open(filepath.ToSlash(relPath))
 }


### PR DESCRIPTION
https://github.com/google/osv-scalibr/pull/934 strips the root prefix from the abs JAR path, but it doesn't work for windows.
We should convert Windows slashes to forward slashes after stripping the prefix.