### PR TITLE
docs: Rework the supported_inventory_types.md doc

### DIFF
--- a/docs/new_detector.md
+++ b/docs/new_detector.md
@@ -26,6 +26,7 @@ as an example.
 1.  Register your detector in
     [list.go](/detector/list/list.go)
     so you can use it in the CLI.
+1.  Update `docs/supported_inventory_types.md` to include your new detector.
 1.  If you added new dependencies, regenerate the go.mod file by running
 
     ```sh

--- a/docs/new_enricher.md
+++ b/docs/new_enricher.md
@@ -33,6 +33,7 @@ as an example.
 1.  Register your enricher in
     [list.go](/enricher/enricherlist/list.go)
     so you can use it in the CLI.
+1.  Update `docs/supported_inventory_types.md` to include your new enricher.
 1.  If you added new dependencies, regenerate the go.mod file by running
 
     ```sh

--- a/docs/new_extractor.md
+++ b/docs/new_extractor.md
@@ -150,6 +150,7 @@ extractor as an example.
     having to give test data specific file names).
 1.  Register your extractor in
     [list.go](/extractor/filesystem/list/list.go)
+1.  Update `docs/supported_inventory_types.md` to include your new extractor.
 1.  Optional: test locally, use the name of the extractor given by `Name()` to
     select your extractor. For the `packagejson` extractor it would look like
     this:

--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -1,97 +1,142 @@
 # Supported inventory types
 
-SCALIBR supports extracting software package information from a variety of OS and language package managers. See below for the comprehensive list. Some of these are supported by reusing extraction code from Google's [OSV-Scanner](https://github.com/google/osv-scanner).
+SCALIBR supports extracting software package information from a variety of OS and language package managers. See below
+for the comprehensive list. Some of these are supported by reusing extraction code from
+Google's [OSV-Scanner](https://github.com/google/osv-scanner).
 
 ## OS packages
 
-* Alpine
-  * APK
-* Chrome extensions
-* COS
-  * cos-package-info.json
-* DPKG (used by e.g. Debian, Ubuntu)
-* NIX
-* OPKG (used by e.g., OpenWrt and embedded Linux systems)
-* RPM (used by e.g. RHEL, CentOS, Rocky Linux)
-  * Zypper (used by e.g. openSUSE)
-* Pacman (used by e.g. Arch Linux)
-* Kernel modules (.ko)
-* Kernel archives (vmlinuz)
-* Portage (used by e.g. Gentoo Linux)
-* SNAP
-* Flatpak
-* Homebrew (used by OS X)
-* Applications (Installed on OS X)
-* Windows
-  * Build number (using either the registry or DISM)
-  * DISM-like hotpatches (using either the registry or DISM)
-  * Installed software (as reported in the control panel)
+| Inventory Type    | Details                        | Extractor Plugin                             |
+|-------------------|--------------------------------|----------------------------------------------|
+| Alpine            | APK                            | `os/apk`                                     |
+| Chrome extensions |                                | `chrome/extensions`                          |
+| COS               | cos-package-info.json          | `os/cos`                                     |
+| DPKG              | e.g. Debian, Ubuntu            | `os/dpkg`                                    |
+| NIX               |                                | `os/nix`                                     |
+| OPKG              | e.g. OpenWrt                   | `os/dpkg`                                    |
+| RPM               | e.g. RHEL, CentOS, Rocky Linux | `os/rpm`                                     |
+| Zypper            | e.g. openSUSE                  | `os/rpm`                                     |
+| Pacman            | e.g. Arch Linux                | `os/pacman`                                  |
+| Kernel modules    | .ko                            | `os/kernel/module`                           |
+| Kernel archives   | vmlinuz                        | `os/kernel/vmlinuz`                          |
+| Portage           | e.g. Gentoo Linux              | `os/portage`                                 |
+| SNAP              |                                | `os/snap`                                    |
+| Flatpak           |                                | `os/flatpak`                                 |
+| Homebrew          | OS X                           | `os/homebrew`                                |
+| Applications      | Installed on OS X              | `os/macapps`                                 |
+| Windows           | Build number                   | `windows/regosversion`                       |
+| Windows           | Hotpatches                     | `windows/dismpatch`, `windows/regpatchlevel` |
+| Windows           | Installed software             | `windows/ospackages`                         |
 
 ## Language packages
 
-* .NET
-  * packages.lock.json
-  * packages.config
-  * deps.json
-  * portable executables
-* C++
-  * Conan packages
-* Dart
-  * pubspec.lock
-* Erlang
-  * mix.lock
-* Elixir
-  * mix.lock
-* Go
-  * Go binaries
-  * go.mod (OSV)
-* Haskell
-  * stack.yaml.lock
-  * cabal.project.freeze
-* Java
-  * Java archives
-  * Lockfiles: pom.xml, gradle.lockfile, verification-metadata.xml
-* Javascript
-  * Installed NPM packages (package.json)
-  * Lockfiles: package-lock.json, npm-shrinkwrap.json, yarn.lock, pnpm-lock.yaml, bun.lock
-* ObjectiveC
-  * Podfile.lock
-* PHP:
-  * Composer
-* Python
-  * Installed PyPI packages (global and venv)
-  * Lockfiles: requirements.txt, poetry.lock, Pipfile.lock, pdm.lock
-  * Conda packages
-  * setup.py
-* R
-  * Lockfiles: renv.lock
-* Ruby
-  * Installed Gem packages
-  * Lockfiles: Gemfile.lock (OSV)
-* Rust
-  * Cargo.lock
-  * Cargo.toml
-  * Rust binaries
-* Swift
-  * Podfile.lock
-  * Package.resolved
+| Language   | Details                                   | Extractor Plugin(s)                  |
+|------------|-------------------------------------------|--------------------------------------|
+| .NET       | packages.lock.json                        | `dotnet/packageslockjson`            |
+|            | packages.config                           | `dotnet/packagesconfig`              |
+|            | deps.json                                 | `dotnet/depsjson`                    |
+|            | portable executables                      | `dotnet/pe`                          |
+| C++        | Conan packages                            | `cpp/conanlock`                      |
+| Dart       | pubspec.lock                              | `dart/pubspec`                       |
+| Erlang     | mix.lock                                  | `erlang/mixlock`                     |
+| Elixir     | mix.lock                                  | `elixir/mixlock`                     |
+| Go         | Go binaries                               | `go/binary`                          |
+|            | go.mod (OSV)                              | `go/gomod`                           |
+| Haskell    | stack.yaml.lock                           | `haskell/stacklock`                  |
+|            | cabal.project.freeze                      | `haskell/cabal`                      |
+| Java       | Java archives                             | `java/archive`                       |
+|            | pom.xml                                   | `java/pomxml`, `java/pomxmlnet`      |
+|            | gradle.lockfile                           | `java/gradlelockfile`                |
+|            | verification-metadata.xml                 | `java/gradleverificationmetadataxml` |
+| Javascript | Installed NPM packages (package.json)     | `javascript/packagejson`             |
+|            | package-lock.json, npm-shrinkwrap.json    | `javascript/packagelockjson`         |
+|            | yarn.lock                                 | `javascript/yarnlock`                |
+|            | pnpm-lock.yaml                            | `javascript/pnpmlock`                |
+|            | bun.lock                                  | `javascript/bunlock`                 |
+| ObjectiveC | Podfile.lock                              | `swift/podfilelock`                  |
+| PHP        | Composer                                  | `php/composerlock`                   |
+| Python     | Installed PyPI packages (global and venv) | `python/wheelegg`                    |
+|            | requirements.txt                          | `python/requirements`                |
+|            | poetry.lock                               | `python/poetrylock`                  |
+|            | Pipfile.lock                              | `python/pipfilelock`                 |
+|            | pdm.lock                                  | `python/pdmlock`                     |
+|            | Conda packages                            | `python/condameta`                   |
+|            | setup.py                                  | `python/setup`                       |
+| R          | renv.lock                                 | `r/renvlock`                         |
+| Ruby       | Installed Gem packages                    | `ruby/gemspec`                       |
+|            | Gemfile.lock (OSV)                        | `ruby/gemfilelock`                   |
+| Rust       | Cargo.lock                                | `rust/cargolock`                     |
+|            | Cargo.toml                                | `rust/cargotoml`                     |
+|            | Rust binaries                             | `rust/cargoauditable`                |
+| Swift      | Podfile.lock                              | `swift/podfilelock`                  |
+|            | Package.resolved                          | `swift/packageresolved`              |
 
 ## Misc
 
-* Wordpress plugins
-  * Installed plugins
-* VSCode extensions
-* Chrome extensions
+| Type              | Extractor Plugin    |
+|-------------------|---------------------|
+| Wordpress plugins | `wordpress/plugins` |
+| VSCode extensions | `vscode/extensions` |
+| Chrome extensions | `chrome/extensions` |
 
 ## Container inventory
 
-* Containerd container images that are running on host
-* Docker container images that are running on host
-* Podman container images that are running on host
+| Type                        | Extractor Plugin                                                                   |
+|-----------------------------|------------------------------------------------------------------------------------|
+| Containerd container images | `containers/containerd-runtime` (standalone), `containers/containerd` (filesystem) |
+| Docker container images     | `containers/docker` (standalone)                                                   |
+| Podman container images     | `containers/podman` (filesystem)                                                   |
 
 ## SBOM files
 
-* SPDX SBOM descriptors
-* CycloneDX SBOM descriptors
+| Type                       | Extractor Plugin |
+|----------------------------|------------------|
+| SPDX SBOM descriptors      | `sbom/spdx`      |
+| CycloneDX SBOM descriptors | `sbom/cdx`       |
 
-If you're a SCALIBR user and are interested in having it support new inventory types we're happy to accept contributions. See the docs on [how to add a new Extractor](/docs/new_extractor.md).
+If you're a SCALIBR user and are interested in having it support new inventory types we're happy to accept
+contributions. See the docs on [how to add a new Extractor](/docs/new_extractor.md).
+
+# Plugins
+
+SCALIBR's functionality is extended by a variety of plugins.
+
+## Enrichers
+
+| Description                                                        | Plugin Name                         |
+|--------------------------------------------------------------------|-------------------------------------|
+| Extracts details about the base image from container image layers. | `baseimage`                         |
+| Filters findings based on VEX statements.                          | `vex/filter`                        |
+| Enriches secret findings with additional details.                  | `secrets/velesvalidate`             |
+| Performs reachability analysis for Java code.                      | `reachability/java`                 |
+| Resolves transitive dependencies for Python pip packages.          | `transitivedependency/requirements` |
+
+## Detectors
+
+| Description                                              | Plugin Name                              |
+|----------------------------------------------------------|------------------------------------------|
+| Checks for overly permissive permissions on /etc/passwd. | `cis/generic-linux/etcpasswdpermissions` |
+| Runs govulncheck on Go binaries.                         | `govulncheck/binary`                     |
+| Checks if the Linux distribution is end-of-life.         | `endoflife/linuxdistro`                  |
+| Detects vulnerability CVE-2023-38408 in OpenSSH.         | `cve/cve-2023-38408`                     |
+| Detects vulnerability CVE-2022-33891 in Spark UI.        | `cve/cve-2022-33891`                     |
+| Detects vulnerability CVE-2020-16846 in Salt.            | `cve/cve-2020-16846`                     |
+| Detects vulnerability CVE-2023-6019 in Ray Dashboard.    | `cve/cve-2023-6019`                      |
+| Detects vulnerability CVE-2020-11978 in Apache Airflow.  | `cve/cve-2020-11978`                     |
+| Detects vulnerability CVE-2024-2912 in BentoML.          | `cve/cve-2024-2912`                      |
+| Checks for default credentials in code-server.           | `weakcredentials/codeserver`             |
+| Checks for weak passwords in /etc/shadow.                | `weakcredentials/etcshadow`              |
+| Checks for default credentials in File Browser.          | `weakcredentials/filebrowser`            |
+| Checks for weak passwords for local Windows accounts.    | `weakcredentials/winlocal`               |
+
+## Annotators
+
+| Description                                                    | Plugin Name              |
+|----------------------------------------------------------------|--------------------------|
+| Annotates findings from APK packages for VEX generation.       | `vex/os-duplicate/apk`   |
+| Annotates findings from cached directories for VEX generation. | `vex/cachedir`           |
+| Annotates findings from COS packages for VEX generation.       | `vex/os-duplicate/cos`   |
+| Annotates findings from DPKG packages for VEX generation.      | `vex/os-duplicate/dpkg`  |
+| Annotates findings from RPM packages for VEX generation.       | `vex/os-duplicate/rpm`   |
+| Annotates DPKG findings where no executable is present.        | `vex/no-executable/dpkg` |
+| Misc annotations from NPM.                                     | `misc/from-npm`          |

--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -1,10 +1,28 @@
-# Supported inventory types
+# Supported Plugins
 
-SCALIBR supports extracting software package information from a variety of OS and language package managers. See below
-for the comprehensive list. Some of these are supported by reusing extraction code from
+OSV-SCALIBR uses a plugin-based system for its scanning and vulnerability matching capabilities. During each run, a
+series of plugins are enabled to perform specific tasks.
+
+Plugins are grouped into the following categories:
+
+- **Extractors**: Identify software packages, dependencies, and other inventory.
+- **Detectors**: Detect security findings, such as misconfigurations or specific vulnerabilities.
+- **Enrichers**: Augment inventory with additional data from external sources.
+- **Annotators**: Add contextual information to the inventory.
+
+> [!TIP]
+> Learn how to contribute new plugins by reading the documentation
+> for [new extractors](/docs/new_extractor.md), [new detectors](/docs/new_detector.md),
+> and [new enrichers](/docs/new_enricher.md).
+
+The following sections list all available plugins.
+
+## Extractors
+
+OSV-SCALIBR extractors support a wide variety of OS and language package managers. Some reuse extraction logic from
 Google's [OSV-Scanner](https://github.com/google/osv-scanner).
 
-## OS packages
+### OS packages
 
 | Inventory Type    | Details                        | Extractor Plugin                             |
 |-------------------|--------------------------------|----------------------------------------------|
@@ -28,7 +46,7 @@ Google's [OSV-Scanner](https://github.com/google/osv-scanner).
 | Windows           | Hotpatches                     | `windows/dismpatch`, `windows/regpatchlevel` |
 | Windows           | Installed software             | `windows/ospackages`                         |
 
-## Language packages
+### Language packages
 
 | Language   | Details                                   | Extractor Plugin(s)                  |
 |------------|-------------------------------------------|--------------------------------------|
@@ -79,7 +97,7 @@ Google's [OSV-Scanner](https://github.com/google/osv-scanner).
 | VSCode extensions | `vscode/extensions` |
 | Chrome extensions | `chrome/extensions` |
 
-## Container inventory
+### Container inventory
 
 | Type                        | Extractor Plugin                                                                   |
 |-----------------------------|------------------------------------------------------------------------------------|
@@ -87,7 +105,7 @@ Google's [OSV-Scanner](https://github.com/google/osv-scanner).
 | Docker container images     | `containers/docker` (standalone)                                                   |
 | Podman container images     | `containers/podman` (filesystem)                                                   |
 
-## SBOM files
+### SBOM files
 
 | Type                       | Extractor Plugin |
 |----------------------------|------------------|
@@ -96,10 +114,6 @@ Google's [OSV-Scanner](https://github.com/google/osv-scanner).
 
 If you're a SCALIBR user and are interested in having it support new inventory types we're happy to accept
 contributions. See the docs on [how to add a new Extractor](/docs/new_extractor.md).
-
-# Plugins
-
-SCALIBR's functionality is extended by a variety of plugins.
 
 ## Enrichers
 


### PR DESCRIPTION
I realized that we did not have a comprehensive list of plugins available in a single place. This attempts to create one in the supported_inventory_types.md doc. We probably want to rename that doc to something else, and provide a link from the README page pointing here that this is where all the plugin names are listed. 