### PR TITLE
fix: remove space in compiler directive

### DIFF
--- a/detector/weakcredentials/winlocal/win32_windows.go
+++ b/detector/weakcredentials/winlocal/win32_windows.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// go:build windows
+//go:build windows
 
 package winlocal
 


### PR DESCRIPTION
This was caught by `gocheckcompilerdirectives` running on Windows in #548