### PR TITLE
fix: use `errors.Is` for checking error

### DIFF
--- a/extractor/standalone/windows/regpatchlevel/regpatchlevel_windows.go
+++ b/extractor/standalone/windows/regpatchlevel/regpatchlevel_windows.go
@@ -108,7 +108,7 @@ func (e *Extractor) Extract(ctx context.Context, input *standalone.ScanInput) (i
 	for _, subkey := range subkeys {
 		entry, err := e.handleKey(reg, regPackagesRoot, subkey)
 		if err != nil {
-			if err == errSkipEntry {
+			if errors.Is(err, errSkipEntry) {
 				continue
 			}
 


### PR DESCRIPTION
This was caught by `errorlint` running on Windows in #548