### PR TITLE
refactor: remove unused private field

### DIFF
--- a/common/windows/registry/live.go
+++ b/common/windows/registry/live.go
@@ -157,7 +157,6 @@ func (o *LiveKey) Values() ([]Value, error) {
 type LiveValue struct {
 	name string
 	key  *winregistry.Key
-	data *[]byte
 }
 
 // Name returns the name of the value.


### PR DESCRIPTION
This was caught by `unused` running on Windows in #548