### PR TITLE
feat(semantic): support `Hackage` ecosystem

### DIFF
--- a/semantic/parse_test.go
+++ b/semantic/parse_test.go
@@ -33,6 +33,7 @@ var ecosystems = []string{
 	"crates.io",
 	"Debian",
 	"Go",
+	"Hackage",
 	"Hex",
 	"Mageia",
 	"Maven",


### PR DESCRIPTION
This ecosystem is similar to semver, except it allows any number of components and does not support build strings.

I have verified the version comparison results in native Haskell: https://play.haskell.org/saved/aKjdOrEG

Relates to #457