### PR TITLE
feat(javascript/packagelockjson): mark bundled dependencies as being in the "bundled" group

### DIFF
--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v2_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v2_test.go
@@ -588,6 +588,50 @@ func TestNPMLockExtractor_Extract_V2(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "bundled_dependencies_are_grouped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/bundled-dependencies.v3.json",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:      "ansi-regex",
+					Version:   "6.2.2",
+					PURLType:  purl.TypeNPM,
+					Locations: []string{"testdata/bundled-dependencies.v3.json"},
+					SourceCode: &extractor.SourceCodeIdentifier{
+						Commit: "",
+					},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{"bundled"},
+					},
+				},
+				{
+					Name:      "semver",
+					Version:   "7.7.2",
+					PURLType:  purl.TypeNPM,
+					Locations: []string{"testdata/bundled-dependencies.v3.json"},
+					SourceCode: &extractor.SourceCodeIdentifier{
+						Commit: "",
+					},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{"bundled", "dev"},
+					},
+				},
+				{
+					Name:      "strip-ansi",
+					Version:   "7.1.2",
+					PURLType:  purl.TypeNPM,
+					Locations: []string{"testdata/bundled-dependencies.v3.json"},
+					SourceCode: &extractor.SourceCodeIdentifier{
+						Commit: "",
+					},
+					Metadata: osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/extractor/filesystem/language/javascript/packagelockjson/testdata/bundled-dependencies.v3.json
+++ b/extractor/filesystem/language/javascript/packagelockjson/testdata/bundled-dependencies.v3.json
@@ -1,0 +1,65 @@
+{
+  "name": "npm-bundled",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-bundled",
+      "version": "1.0.0",
+      "bundleDependencies": [
+        "semver",
+        "ansi-regex"
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "strip-ansi": "^7.1.2"
+      },
+      "devDependencies": {
+        "semver": "^7.7.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    }
+  }
+}

--- a/internal/dependencyfile/packagelockjson/packagelockjson.go
+++ b/internal/dependencyfile/packagelockjson/packagelockjson.go
@@ -64,6 +64,7 @@ type Package struct {
 	Dev         bool `json:"dev,omitempty"`
 	DevOptional bool `json:"devOptional,omitempty"`
 	Optional    bool `json:"optional,omitempty"`
+	InBundle    bool `json:"inBundle,omitempty"`
 
 	Dependencies         map[string]string `json:"dependencies,omitempty"`
 	DevDependencies      map[string]string `json:"devDependencies,omitempty"`
@@ -75,17 +76,27 @@ type Package struct {
 }
 
 // DepGroups returns the list of groups this package belongs to.
-// May be empty, or one or both of "dev", "optional".
+// Supported groups are "bundled", "dev", and "optional", with an
+// empty group implying a production dependency.
 func (pkg Package) DepGroups() []string {
-	if pkg.Dev {
-		return []string{"dev"}
-	}
-	if pkg.Optional {
-		return []string{"optional"}
-	}
-	if pkg.DevOptional {
-		return []string{"dev", "optional"}
+	var groups []string
+
+	if pkg.InBundle {
+		groups = []string{"bundled"}
 	}
 
-	return nil
+	if pkg.DevOptional {
+		groups = append(groups, "dev", "optional")
+
+		return groups
+	}
+
+	if pkg.Dev {
+		groups = append(groups, "dev")
+	}
+	if pkg.Optional {
+		groups = append(groups, "optional")
+	}
+
+	return groups
 }


### PR DESCRIPTION
Despite what is said in the issue, it seems that the "bundled" status is only tracked in v2+ lockfiles 🤷 

Resolves #1283