### PR TITLE
test: remove methods and structs that are not used on Windows

### DIFF
--- a/detector/cis/generic_linux/etcpasswdpermissions/detector_dummy_test.go
+++ b/detector/cis/generic_linux/etcpasswdpermissions/detector_dummy_test.go
@@ -19,7 +19,6 @@ package etcpasswdpermissions_test
 import (
 	"errors"
 	"io/fs"
-	"time"
 )
 
 func (fakeFS) Open(name string) (fs.File, error) { return nil, errors.New("unsupported system") }
@@ -29,13 +28,3 @@ func (fakeFS) ReadDir(name string) ([]fs.DirEntry, error) {
 func (fakeFS) Stat(name string) (fs.FileInfo, error) {
 	return nil, errors.New("not implemented")
 }
-func (fakeFile) Stat() (fs.FileInfo, error) { return nil, errors.New("unsupported system") }
-func (fakeFile) Read([]byte) (int, error)   { return 0, errors.New("unsupported system") }
-func (fakeFile) Close() error               { return nil }
-
-func (fakeFileInfo) Name() string       { return "unsupported" }
-func (fakeFileInfo) Size() int64        { return 0 }
-func (fakeFileInfo) Mode() fs.FileMode  { return 0 }
-func (fakeFileInfo) ModTime() time.Time { return time.Now() }
-func (fakeFileInfo) IsDir() bool        { return false }
-func (fakeFileInfo) Sys() any           { return nil }

--- a/detector/cis/generic_linux/etcpasswdpermissions/detector_helper_test.go
+++ b/detector/cis/generic_linux/etcpasswdpermissions/detector_helper_test.go
@@ -24,6 +24,18 @@ import (
 	"time"
 )
 
+type fakeFile struct {
+	perms fs.FileMode
+	uid   uint32
+	gid   uint32
+}
+
+type fakeFileInfo struct {
+	perms fs.FileMode
+	uid   uint32
+	gid   uint32
+}
+
 func (f *fakeFS) Open(name string) (fs.File, error) {
 	if name == "etc/passwd" {
 		if f.exists {

--- a/detector/cis/generic_linux/etcpasswdpermissions/etcpasswdpermissions_test.go
+++ b/detector/cis/generic_linux/etcpasswdpermissions/etcpasswdpermissions_test.go
@@ -37,18 +37,6 @@ type fakeFS struct {
 	gid    uint32
 }
 
-type fakeFile struct {
-	perms fs.FileMode
-	uid   uint32
-	gid   uint32
-}
-
-type fakeFileInfo struct {
-	perms fs.FileMode
-	uid   uint32
-	gid   uint32
-}
-
 func TestScan(t *testing.T) {
 	if !slices.Contains([]string{"linux"}, runtime.GOOS) {
 		t.Skipf("Skipping test for unsupported OS %q", runtime.GOOS)


### PR DESCRIPTION
Everything that is being (re)moved is used via the `fakeFS#Open` method which on Windows just returns an error.

This was caught by the `unused` linter when running on Windows 