### PR TITLE
Add new extensions for detecting ssl/tls certificates

### DIFF
--- a/extractor/filesystem/secrets/secrets.go
+++ b/extractor/filesystem/secrets/secrets.go
@@ -58,6 +58,11 @@ var (
 		".txt":       true,
 		".xml":       true,
 		".yaml":      true,
+		".pem":       true,
+		".crt":       true,
+		".key":       true,
+		".der":       true,
+		".cer":       true,
 	}
 
 	defaultEngine *veles.DetectionEngine


### PR DESCRIPTION
Hi @erikvarga,
as agreed in our email thread, we are extending the supported file extensions of veles to include capabilities for identifying private keys within TLS/SSL certificate files.
