### PR TITLE
fix(semantic): handle Red Hat versions with colons but not epochs

### DIFF
--- a/semantic/testdata/redhat-versions.txt
+++ b/semantic/testdata/redhat-versions.txt
@@ -170,3 +170,17 @@ b~1:1 > a1:1
 1.1.a < 1.2.ββ
 1.1.a < 0:1.2.ββ
 1.1.α < 1.1.a
+
+# versions with colons that are not epochs
+1.m+e2:1 < 4.m+e1:1
+1.module+el9.4.0+23026+aaa2e3cb.2.noarch.rpm-nginx:1 < 4.module+el9.5.0+22954+e2d70a1c.1.noarch.rpm-nginx:1
+1.m+el9.4.0+2.na.r-n:1 < 4.m+el9.5.0+1.na.r-n:1
+4.0+2.na.r-n:1 < 5.0+1.na.r-n:1
+0+2.na.r-n:1 > 0+1.na.r-n:1
+0+2-n:1 > 0+1-n:1
+0+-n:1 = 0+-n:1
+0+2-n:1 > 0+1-n:1
++2-n:1 > +1-n:1
++2-:1 > +1-:1
++2- > +1-
++2-: > +1-:

--- a/semantic/version-redhat.go
+++ b/semantic/version-redhat.go
@@ -24,6 +24,16 @@ type redHatVersion struct {
 	release string
 }
 
+// isOnlyDigits returns true if the given string contains only digits
+func isOnlyDigits(str string) bool {
+	for _, c := range str {
+		if !isASCIIDigit(c) {
+			return false
+		}
+	}
+	return true
+}
+
 // isASCIIDigit returns true if the given rune is an ASCII digit.
 //
 // Unicode digits are not considered ASCII digits by this function.
@@ -209,29 +219,23 @@ func (v redHatVersion) CompareStr(str string) (int, error) {
 // parseRedHatVersion parses a Red Hat version into a redHatVersion struct.
 //
 // A Red Hat version contains the following components:
-// - name (of the package), represented as "n"
 // - epoch, represented as "e"
 // - version, represented as "v"
 // - release, represented as "r"
-// - architecture, represented as "a"
 //
-// When all components are present, the version is represented as "n-e:v-r.a",
+// When all components are present, the version is represented as "e:v-r",
 // though only the version is actually required.
 func parseRedHatVersion(str string) redHatVersion {
-	bf, af, hasColon := strings.Cut(str, ":")
+	epoch, vr, hasColon := strings.Cut(str, ":")
 
-	if !hasColon {
-		af, bf = bf, af
+	// if there's not a colon, or the "epoch" value has characters other than digits,
+	// then the string does not have an epoch value
+	if !hasColon || !isOnlyDigits(epoch) {
+		vr = str
+		epoch = ""
 	}
 
-	// (note, we don't actually use the name)
-	name, epoch, hasName := strings.Cut(bf, "-")
-
-	if !hasName {
-		epoch = name
-	}
-
-	version, release, hasRelease := strings.Cut(af, "-")
+	version, release, hasRelease := strings.Cut(vr, "-")
 
 	if hasRelease {
 		release = "-" + release


### PR DESCRIPTION
RedHat versions follow the "e:v-r" format, which is a _subset_ of the "n-e:v-r.a" format [described in the blogpost I based my implementation off](https://blog.jasonantman.com/2014/07/how-yum-and-rpm-compare-versions/#how-rpm-compares-version-parts).

Notably, epochs are only such if they are a digit, otherwise it's all part of the version including the colon - in practice it seems this is very rare (which makes sense) but recently we've had some advisories published with versions that do use the colon, which revealed this bug