### PR TITLE
chore: make godoc comments more consistent

### DIFF
--- a/artifact/image/layerscanning/image/virtual_file.go
+++ b/artifact/image/layerscanning/image/virtual_file.go
@@ -143,6 +143,7 @@ func (f *virtualFile) Info() (fs.FileInfo, error) {
 // ========================================================
 // fs.FileInfo METHODS
 // ========================================================
+
 func (f *virtualFile) Size() int64 {
 	return f.size
 }

--- a/clients/datasource/maven_registry_auth_test.go
+++ b/clients/datasource/maven_registry_auth_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This test uses datasource package in order to test auth data
 package datasource
 
 import (

--- a/enricher/reachability/java/javaclass.go
+++ b/enricher/reachability/java/javaclass.go
@@ -90,7 +90,7 @@ const (
 	ConstantKindModule             ConstantKind = 19
 	ConstantKindPackage            ConstantKind = 20
 
-	// This is not a real Java class constant kind.
+	// ConstantKindPlaceholder is not a real Java class constant kind.
 	// We use this to implement long and double constants taking up two entries
 	// in the constant pool, as well as the constant pool being 1-indexed.
 	//

--- a/extractor/filesystem/internal/walkdir_iterate_test.go
+++ b/extractor/filesystem/internal/walkdir_iterate_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// These are the same tests as in io/fs/walk_test.go, but ignoring the order of walking.
 package internal
 
 import (
@@ -30,6 +29,8 @@ import (
 
 	scalibrfs "github.com/google/osv-scalibr/fs"
 )
+
+// These are the same tests as in io/fs/walk_test.go, but ignoring the order of walking.
 
 type Node struct {
 	name    string

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -118,9 +118,9 @@ type InitMap map[string][]InitFn
 var (
 	// Language extractors.
 
-	// C++ source extractors.
+	// CppSource extractors for C++.
 	CppSource = InitMap{conanlock.Name: {conanlock.New}}
-	// Java source extractors.
+	// JavaSource extractors for Java.
 	JavaSource = InitMap{
 		gradlelockfile.Name:                {gradlelockfile.New},
 		gradleverificationmetadataxml.Name: {gradleverificationmetadataxml.New},
@@ -128,11 +128,11 @@ var (
 		pomxml.Name:    {pomxml.New},
 		pomxmlnet.Name: {pomxmlnet.NewDefault},
 	}
-	// Java artifact extractors.
+	// JavaArtifact extractors for Java.
 	JavaArtifact = InitMap{
 		javaarchive.Name: {javaarchive.NewDefault},
 	}
-	// Javascript source extractors.
+	// JavascriptSource extractors for Javascript.
 	JavascriptSource = InitMap{
 		packagejson.Name:     {packagejson.NewDefault},
 		packagelockjson.Name: {packagelockjson.NewDefault},
@@ -140,11 +140,11 @@ var (
 		yarnlock.Name:        {yarnlock.New},
 		bunlock.Name:         {bunlock.New},
 	}
-	// Javascript artifact extractors.
+	// JavascriptArtifact extractors for Javascript.
 	JavascriptArtifact = InitMap{
 		packagejson.Name: {packagejson.NewDefault},
 	}
-	// Python source extractors.
+	// PythonSource extractors for Python.
 	PythonSource = InitMap{
 		// requirements extraction for environments with and without network access.
 		requirements.Name: {requirements.NewDefault},
@@ -155,46 +155,46 @@ var (
 		condameta.Name:    {condameta.NewDefault},
 		uvlock.Name:       {uvlock.New},
 	}
-	// Python artifact extractors.
+	// PythonArtifact extractors for Python.
 	PythonArtifact = InitMap{
 		wheelegg.Name: {wheelegg.NewDefault},
 	}
-	// Go source extractors.
+	// GoSource extractors for Go.
 	GoSource = InitMap{
 		gomod.Name: {gomod.New},
 	}
-	// Go artifact extractors.
+	// GoArtifact extractors for Go.
 	GoArtifact = InitMap{
 		gobinary.Name: {gobinary.NewDefault},
 	}
-	// Dart source extractors.
+	// DartSource extractors for Dart.
 	DartSource = InitMap{pubspec.Name: {pubspec.New}}
-	// Erlang source extractors.
+	// ErlangSource extractors for Erlang.
 	ErlangSource = InitMap{mixlock.Name: {mixlock.New}}
-	// Nim source extractors.
+	// NimSource extractors for Nim.
 	NimSource = InitMap{nimble.Name: {nimble.New}}
-	// Lua source extractors.
+	// LuaSource extractors for Lua.
 	LuaSource = InitMap{luarocks.Name: {luarocks.New}}
-	// Elixir source extractors.
+	// ElixirSource extractors for Elixir.
 	ElixirSource = InitMap{elixir.Name: {elixir.NewDefault}}
-	// Haskell source extractors.
+	// HaskellSource extractors for Haskell.
 	HaskellSource = InitMap{
 		stacklock.Name: {stacklock.NewDefault},
 		cabal.Name:     {cabal.NewDefault},
 	}
-	// R source extractors
+	// RSource extractors for R source extractors
 	RSource = InitMap{renvlock.Name: {renvlock.New}}
-	// Ruby source extractors.
+	// RubySource extractors for Ruby.
 	RubySource = InitMap{
 		gemspec.Name:     {gemspec.NewDefault},
 		gemfilelock.Name: {gemfilelock.New},
 	}
-	// Rust source extractors.
+	// RustSource extractors for Rust.
 	RustSource = InitMap{
 		cargolock.Name: {cargolock.New},
 		cargotoml.Name: {cargotoml.New},
 	}
-	// Rust artifact extractors.
+	// RustArtifact extractors for Rust.
 	RustArtifact = InitMap{
 		cargoauditable.Name: {cargoauditable.NewDefault},
 	}
@@ -203,19 +203,19 @@ var (
 		cdx.Name:  {cdx.New},
 		spdx.Name: {spdx.New},
 	}
-	// Dotnet (.NET) source extractors.
+	// DotnetSource extractors for Dotnet (.NET).
 	DotnetSource = InitMap{
 		depsjson.Name:         {depsjson.NewDefault},
 		packagesconfig.Name:   {packagesconfig.NewDefault},
 		packageslockjson.Name: {packageslockjson.NewDefault},
 	}
-	// Dotnet (.NET) artifact extractors.
+	// DotnetArtifact extractors for Dotnet (.NET).
 	DotnetArtifact = InitMap{
 		dotnetpe.Name: {dotnetpe.NewDefault},
 	}
-	// PHP Source extractors.
+	// PHPSource extractors for PHP Source extractors.
 	PHPSource = InitMap{composerlock.Name: {composerlock.New}}
-	// Swift source extractors.
+	// SwiftSource extractors for Swift.
 	SwiftSource = InitMap{
 		packageresolved.Name: {packageresolved.NewDefault},
 		podfilelock.Name:     {podfilelock.NewDefault},
@@ -247,7 +247,7 @@ var (
 		winget.Name:   {winget.NewDefault},
 	}
 
-	// Credential extractors.
+	// Secrets list extractors for credentials.
 	Secrets = initMapFromVelesPlugins([]velesPlugin{
 		{anthropicapikey.NewDetector(), "secrets/anthropicapikey", 0},
 		{azuretoken.NewDetector(), "secrets/azuretoken", 0},
@@ -279,7 +279,7 @@ var (
 		chromeextensions.Name: {chromeextensions.New},
 	}
 
-	// Misc source extractors.
+	// MiscSource extractors for miscellaneous purposes.
 	MiscSource = InitMap{
 		asdf.Name: {asdf.New},
 	}

--- a/purl/purl.go
+++ b/purl/purl.go
@@ -45,7 +45,7 @@ const (
 	TypeConan = "conan"
 	// TypeConda is a pkg:conda purl.
 	TypeConda = "conda"
-	// COS is the pkg:cos purl
+	// TypeCOS is the pkg:cos purl
 	TypeCOS = "cos"
 	// TypeCran is a pkg:cran purl.
 	TypeCran = "cran"
@@ -65,7 +65,7 @@ const (
 	TypeGolang = "golang"
 	// TypeHackage is a pkg:hackage purl.
 	TypeHackage = "hackage"
-	// Type Haskell is a pkg:haskell purl.
+	// TypeHaskell is a pkg:haskell purl.
 	TypeHaskell = "haskell"
 	// TypeMacApps is a pkg:macapps purl.
 	TypeMacApps = "macapps"
@@ -103,7 +103,7 @@ const (
 	TypeWordpress = "wordpress"
 	// TypeAsdf is pkg:asdf purl
 	TypeAsdf = "asdf"
-	// Macports is pkg:macports purl
+	// TypeMacports is pkg:macports purl
 	TypeMacports = "macports"
 	// TypeWinget is pkg:winget purl
 	TypeWinget = "winget"


### PR DESCRIPTION
This addresses all violations of the new [`godoc` linter](https://golangci-lint.run/docs/linters/configuration/#godoclint) that is included in v2.5