### PR TITLE
ci: disable specific staticcheck check instead of the whole linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,7 +37,6 @@ linters:
     - prealloc         # We don't want to preallocate all the time
     - protogetter      # TODO(#274): work on enabling this
     - recvcheck        # TODO(#274): work on enabling this
-    - staticcheck      # TODO(#1394): work on enabling this
     - tagliatelle      #
     - testpackage      #
     - tparallel        # Parallel tests mixes up log lines of multiple tests in the internal test runner
@@ -108,6 +107,7 @@ linters:
     staticcheck:
       checks:
         - all
+        - -SA5011 # seems prone to false positives in tests
         - -QF1001 # apply De Morgan's law
         - -QF1003 # use tagged switch on prefix
   exclusions:


### PR DESCRIPTION
Unfortunately it's not possible to disable this check for tests only, but it's still better than having the whole linter disabled