### PR TITLE
ci: add job for checking filenames

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: fernandrone/linelint@7907a5dca0c28ea7dd05c6d8d8cacded713aca11 # v0.0.6
+  filenames:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - run: |
+          find . -mindepth 1 ! -regex '.*/[@A-Za-z0-9._-]*' \
+            | xargs -I '{}' bash -c \
+              "echo '{}' && echo '::error file={}::This filename contains undesired characters' && false"
   tidy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           persist-credentials: false
       - run: |
-          find . -mindepth 1 ! -regex '.*/[@A-Za-z0-9._-]*' \
-            | xargs -I '{}' bash -c \
-              "echo '{}' && echo '::error file={}::This filename contains undesired characters' && false"
+          find . -mindepth 1 ! -regex '.*/[#@A-Za-z0-9._-]*' -print0 \
+            | xargs -0 -I{} bash -c \
+              'printf "::error file=%q::This filename contains undesired characters\n" "$1" && false' _ {}
   tidy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This should ensure that files are valid across OSs - I've gone with an inclusive pattern which purposely does not have some characters that are technically legal but that I don't think there's a good reason to use them in a filename.