### PR TITLE
fix(filesystem): ensure there is at least one gitignore before slicing

### DIFF
--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -528,7 +528,7 @@ func (wc *walkContext) handleFile(path string, d fs.DirEntry, fserr error) error
 }
 
 func (wc *walkContext) postHandleFile(path string, d fs.DirEntry) {
-	if wc.useGitignore && d.Type().IsDir() {
+	if len(wc.gitignores) > 0 && d.Type().IsDir() {
 		// Remove .gitignores that applied to this directory.
 		wc.gitignores = wc.gitignores[:len(wc.gitignores)-1]
 	}


### PR DESCRIPTION
Currently our post walking function assumes that every directory will have had a "git ignore" matcher recorded (with an empty one being used if there is no actual `.gitignore` file), but [that doesn't happen if we get an error](https://github.com/google/osv-scalibr/blob/2ff8112aeff8ca6ec3c093d7aabe09fb56f0c544/extractor/filesystem/filesystem.go#L448-L454) other than [`fs.ErrNotExist` when attempting to read the `.gitignore` in the directory](https://github.com/google/osv-scalibr/blob/2ff8112aeff8ca6ec3c093d7aabe09fb56f0c544/extractor/filesystem/internal/gitignore.go#L53-L56).

Since we [always call the post walking function in all cases](https://github.com/google/osv-scalibr/blob/2ff8112aeff8ca6ec3c093d7aabe09fb56f0c544/extractor/filesystem/internal/walkdir_iterate.go#L43-L48), this results in a panic.

This can be easily triggered by having `osv-scanner` scan a directory that the current user does not have permission to access, which is very easily done by attempting to scan `/tmp` recursively as that usually has at least one inner directory owned by `root`.

Relates to https://github.com/google/osv-scanner/issues/2278