### PR TITLE
fix: Add `--ignore-scripts` flag to npm lockfile generation

### DIFF
--- a/guidedremediation/guidedremediation.go
+++ b/guidedremediation/guidedremediation.go
@@ -597,7 +597,7 @@ func writeNpmLockfile(ctx context.Context, path string) error {
 		return fmt.Errorf("failed removing old node_modules/: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, npmPath, "install", "--package-lock-only")
+	cmd := exec.CommandContext(ctx, npmPath, "install", "--package-lock-only", "--ignore-scripts")
 	cmd.Dir = dir
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard


### PR DESCRIPTION
This change adds the `--ignore-scripts` flag to `npm install` command in the guided remediation process. This is toprevent the execution of potentially malicious npm scripts when regenerating the `package-lock.json` file.