### PR TITLE
fix: Preserve original package order during transitive dependency enrichment

### DIFF
--- a/enricher/transitivedependency/requirements/requirements.go
+++ b/enricher/transitivedependency/requirements/requirements.go
@@ -85,8 +85,16 @@ func NewEnricher(client resolve.Client) *Enricher {
 func (e Enricher) Enrich(ctx context.Context, input *enricher.ScanInput, inv *inventory.Inventory) error {
 	pkgGroups := groupPackages(inv.Packages)
 	for path, pkgMap := range pkgGroups {
-		list := make([]*extractor.Package, 0, len(pkgMap))
+		packages := make([]packageWithIndex, 0, len(pkgMap))
 		for _, indexPkg := range pkgMap {
+			packages = append(packages, indexPkg)
+		}
+		slices.SortFunc(packages, func(a, b packageWithIndex) int {
+			return a.index - b.index
+		})
+
+		list := make([]*extractor.Package, 0, len(packages))
+		for _, indexPkg := range packages {
 			list = append(list, indexPkg.pkg)
 		}
 		if len(list) == 0 || len(list[0].Metadata.(*requirements.Metadata).HashCheckingModeValues) > 0 {


### PR DESCRIPTION
https://github.com/google/osv-scanner/pull/2294#issuecomment-3524268562

The previous implementation iterated over a map to build the package list for dependency resolution, which does not guarantee a stable order.

This change modifies the logic to explicitly sort the packages based on their original index in the inventory before processing them. This ensures that the enrichment process is deterministic and preserves the relative order of packages as they appeared in the `requirements.txt` file.