### PR TITLE
fix: Reset inventories on each scan root

### DIFF
--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -165,7 +165,7 @@ func runOnScanRoot(ctx context.Context, config *Config, scanRoot *scalibrfs.Scan
 			return inventory.Inventory{}, nil, err
 		}
 	}
-	if err = wc.UpdateScanRoot(abs, scanRoot.FS); err != nil {
+	if err = wc.PrepareNewScan(abs, scanRoot.FS); err != nil {
 		return inventory.Inventory{}, nil, err
 	}
 
@@ -618,12 +618,14 @@ func (wc *walkContext) runExtractor(ex Extractor, path string, isDir bool) {
 	}
 }
 
-// UpdateScanRoot updates the scan root and the filesystem to use for the filesystem walk.
+// PrepareNewScan updates the scan root and the filesystem to use for the filesystem walk.
+// It also resets the inventory.
 // currentRoot is expected to be an absolute path.
-func (wc *walkContext) UpdateScanRoot(absRoot string, fs scalibrfs.FS) error {
+func (wc *walkContext) PrepareNewScan(absRoot string, fs scalibrfs.FS) error {
 	wc.scanRoot = absRoot
 	wc.fs = fs
 	wc.fileAPI.fs = fs
+	wc.inventory = inventory.Inventory{}
 	return nil
 }
 

--- a/extractor/filesystem/filesystem_test.go
+++ b/extractor/filesystem/filesystem_test.go
@@ -858,7 +858,7 @@ func TestRunFS(t *testing.T) {
 			if err != nil {
 				t.Fatalf("filesystem.InitializeWalkContext(..., %v): %v", fsys, err)
 			}
-			if err = wc.UpdateScanRoot(cwd, fsys); err != nil {
+			if err = wc.PrepareNewScan(cwd, fsys); err != nil {
 				t.Fatalf("wc.UpdateScanRoot(..., %v): %v", fsys, err)
 			}
 			gotInv, gotStatus, err := filesystem.RunFS(t.Context(), config, wc)
@@ -1030,7 +1030,7 @@ func TestRunFSGitignore(t *testing.T) {
 			if err != nil {
 				t.Fatalf("filesystem.InitializeWalkContext(..., %v): %v", fsys, err)
 			}
-			if err = wc.UpdateScanRoot(cwd, fsys); err != nil {
+			if err = wc.PrepareNewScan(cwd, fsys); err != nil {
 				t.Fatalf("wc.UpdateScanRoot(..., %v): %v", fsys, err)
 			}
 			gotInv, _, err := filesystem.RunFS(t.Context(), config, wc)
@@ -1177,7 +1177,7 @@ func TestRunFS_ReadError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("filesystem.InitializeWalkContext(%v): %v", config, err)
 	}
-	if err := wc.UpdateScanRoot(".", fsys); err != nil {
+	if err := wc.PrepareNewScan(".", fsys); err != nil {
 		t.Fatalf("wc.UpdateScanRoot(%v): %v", config, err)
 	}
 	gotInv, gotStatus, err := filesystem.RunFS(t.Context(), config, wc)


### PR DESCRIPTION
Hi!

I've faced an issue when multiple scanRoots are added to filesystem scan config. Let me clarify the problem.

Filesystem scan iterates over scanRoots and calls [runOnScanRoot](https://github.com/google/osv-scalibr/blob/5e7e15f4a0360dcff3e2f43aa16391895cba5775/extractor/filesystem/filesystem.go#L147). Inventories [returned](https://github.com/google/osv-scalibr/blob/5e7e15f4a0360dcff3e2f43aa16391895cba5775/extractor/filesystem/filesystem.go#L326) by this call are part of WalkContext. Code only [populates](https://github.com/google/osv-scalibr/blob/5e7e15f4a0360dcff3e2f43aa16391895cba5775/extractor/filesystem/filesystem.go#L617) these inventories and does not reset them. So, the list of inventories only grows with each call to runOnScanRoot and [resulting inventory](https://github.com/google/osv-scalibr/blob/5e7e15f4a0360dcff3e2f43aa16391895cba5775/extractor/filesystem/filesystem.go#L152) contains duplicate packages starting from the second iteration of the scan loop.

So, setting inventories field to default each time runOnScanRoot is called could solve the issue, since code already has logic to update WalkContext.