### PR TITLE
test: include an `introduced` event

### DIFF
--- a/inventory/finding.go
+++ b/inventory/finding.go
@@ -120,7 +120,7 @@ func PackageToAffected(pkg *extractor.Package, fixed string, severity *osvpb.Sev
 		Severity: []*osvpb.Severity{severity},
 		Ranges: []*osvpb.Range{{
 			Type:   osvpb.Range_ECOSYSTEM,
-			Events: []*osvpb.Event{{Fixed: fixed}},
+			Events: []*osvpb.Event{{Introduced: "0"}, {Fixed: fixed}},
 		}},
 	}}
 }


### PR DESCRIPTION
The spec requires that ranges have at least one `introduced` event - this doesn't impact any of our existing tests since they're more focused on generating advisories, but does matter for the local vuln matcher being introduced in #1608