### PR TITLE
fix(cve/cve-2023-38408): include introduced event in finding

### DIFF
--- a/detector/cve/untested/cve202338408/cve202338408.go
+++ b/detector/cve/untested/cve202338408/cve202338408.go
@@ -97,7 +97,7 @@ func (Detector) findingForPackage(dbSpecific *structpb.Struct, pkg *extractor.Pa
 				}},
 				Ranges: []*osvpb.Range{{
 					Type:   osvpb.Range_ECOSYSTEM,
-					Events: []*osvpb.Event{{Fixed: "9.3.p2"}},
+					Events: []*osvpb.Event{{Introduced: "0"}, {Fixed: "9.3.p2"}},
 				}},
 			}},
 			DatabaseSpecific: dbSpecific,


### PR DESCRIPTION
The spec requires that ranges have at least one `introduced` event, so the advisory being generated by this detector is technically invalid