### PR TITLE
fix: Reusing grpc connection bandaid

### DIFF
--- a/clients/datasource/insights.go
+++ b/clients/datasource/insights.go
@@ -74,7 +74,7 @@ func NewCachedInsightsClient(addr string, userAgent string) (*CachedInsightsClie
 	connectionsMu.Lock()
 	defer connectionsMu.Unlock()
 
-	key := addr+"|"+userAgent
+	key := addr + "|" + userAgent
 	if conn, ok := connections[key]; ok {
 		return &CachedInsightsClient{
 			InsightsClient:    pb.NewInsightsClient(conn),

--- a/clients/depsdev/v1alpha1/grpcclient/grpcclient.go
+++ b/clients/depsdev/v1alpha1/grpcclient/grpcclient.go
@@ -68,6 +68,7 @@ func New(cfg *Config) (pb.InsightsClient, error) {
 
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
+		//nolint:gocritic // No need to unlock before exiting, as we are exiting immediately.
 		log.Fatalf("Getting system cert pool: %v", err)
 	}
 	creds := credentials.NewClientTLSFromCert(certPool, "")


### PR DESCRIPTION
This is a bandaid fix to avoid port exhaustion in osv-scanner when running tests, while a more long term solution is designed, tracked in #1641.

As we never provide a way to close the gRPC connection that's created, the cached connection is always valid for the runtime of the process.