### PR TITLE
Enable .ini file extension for secret scanning

### DIFF
--- a/extractor/filesystem/secrets/secrets.go
+++ b/extractor/filesystem/secrets/secrets.go
@@ -41,6 +41,7 @@ var (
 		".cfg":       true,
 		".env":       true,
 		".html":      true,
+		".ini":       true,
 		".ipynb":     true,
 		".json":      true,
 		".log":       true,

--- a/extractor/filesystem/secrets/secrets_test.go
+++ b/extractor/filesystem/secrets/secrets_test.go
@@ -58,6 +58,11 @@ func TestFileRequired(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "accept_INI",
+			path: "config.ini",
+			want: true,
+		},
+		{
 			name: "accept_textproto",
 			path: "hello.textproto",
 			want: true,


### PR DESCRIPTION
This PR enables scanning .ini files for detecting secrets, INI files are common configuration formats across Windows and Linux. 