### PR TITLE
fix(java/pomxml): don't require offline network

### DIFF
--- a/extractor/filesystem/language/java/pomxml/pomxml.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml.go
@@ -72,7 +72,7 @@ func (e Extractor) Version() int { return 0 }
 
 // Requirements of the extractor
 func (e Extractor) Requirements() *plugin.Capabilities {
-	return &plugin.Capabilities{Network: plugin.NetworkOffline}
+	return &plugin.Capabilities{}
 }
 
 // FileRequired returns true if the specified file matches Maven POM lockfile patterns.


### PR DESCRIPTION
This extractor does not care about network access, so should not be declaring itself as _requiring_ an offline network

Blocks https://github.com/google/osv-scanner/pull/2466