### PR TITLE
ci: Add gemini config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,11 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: false
+    include_drafts: true
+ignore_patterns: []


### PR DESCRIPTION
Add a generic gemini config which defaults to waiting for gemini to be invoked (with /gemini review) before performing an automated review.