### PR TITLE
feat(secrets): add discord bot token detector

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -114,6 +114,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
 	"github.com/google/osv-scalibr/veles/secrets/digitaloceanapikey"
+	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
 	"github.com/google/osv-scalibr/veles/secrets/dockerhubpat"
 	"github.com/google/osv-scalibr/veles/secrets/elasticcloudapikey"
 	"github.com/google/osv-scalibr/veles/secrets/gcpapikey"
@@ -314,6 +315,7 @@ var (
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},
+		{discordbottoken.NewDetector(), "secrets/discordbottoken", 0},
 		{slacktoken.NewAppConfigAccessTokenDetector(), "secrets/slackappconfigaccesstoken", 0},
 		{slacktoken.NewAppConfigRefreshTokenDetector(), "secrets/slackappconfigrefreshtoken", 0},
 		{slacktoken.NewAppLevelTokenDetector(), "secrets/slackappleveltoken", 0},

--- a/veles/secrets/discordbottoken/detector.go
+++ b/veles/secrets/discordbottoken/detector.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discordbottoken
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+const (
+	// maxTokenLength is the maximum length of a valid Discord Bot Token.
+	// Discord Bot Tokens consist of three base64-encoded parts separated by dots:
+	// - Bot user ID (variable length, typically 18-19 digits encoded)
+	// - Timestamp (6 characters)
+	// - HMAC signature (27+ characters)
+	// Total length is typically around 60-75 characters.
+	maxTokenLength = 80
+
+	// maxDistance is the maximum distance between Discord Bot Token and Discord
+	// keywords to be considered for pairing.
+	maxDistance = 30
+)
+
+var (
+	// tokenRe is a regular expression that matches Discord Bot Tokens.
+	// Discord Bot Tokens have 3 parts separated by dots:
+	// 1. Base64-encoded bot user ID (starts with M or N, 24+ chars)
+	// 2. 6-character timestamp
+	// 3. 27+ character HMAC signature
+	// Reference: https://discord.com/developers/docs/reference#authentication
+	tokenRe = regexp.MustCompile(`\b([MN][A-Za-z\d]{23,}\.[A-Za-z\d_-]{6}\.[A-Za-z\d_-]{27,})\b`)
+
+	// keywordRe is a regular expression that matches Discord related keywords.
+	keywordRe = regexp.MustCompile(`(?i)(discord|bot[_\.\s-]?token|DISCORD_TOKEN)`)
+)
+
+// NewDetector returns a detector that matches Discord keyword and a Discord
+// Bot Token secret.
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: maxTokenLength,
+		MaxDistance:   maxDistance,
+		FindA:         pair.FindAllMatches(tokenRe),
+		FindB:         pair.FindAllMatches(keywordRe),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			return DiscordBotToken{Token: string(p.A.Value)}, true
+		},
+	}
+}

--- a/veles/secrets/discordbottoken/detector_test.go
+++ b/veles/secrets/discordbottoken/detector_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discordbottoken_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
+)
+
+func TestDetector_Detect(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{discordbottoken.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		{
+			name:  "empty_input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "invalid_token_format_wrong_prefix",
+			input: "discord bot_token: AABC123456789012345678.G1ab2c.abcdefghijklmnopqrstuvwxyzabc",
+			want:  nil,
+		},
+		{
+			name:  "invalid_token_format_too_short_third_part",
+			input: "discord bot_token: MTIzNDU2Nzg5MDEyMzQ1Njc4.G1ab2c.short",
+			want:  nil,
+		},
+		{
+			name:  "discord_keyword_but_no_secret",
+			input: `discord://SOMEOTHERFORMAT123`,
+			want:  nil,
+		},
+		{
+			name:  "false_positive_token_but_no_keyword",
+			input: `config: MTIzNDU2Nzg5MDEyMzQ1Njc4.G1ab2c.abcdefghijklmnopqrstuvwxyzabc`,
+			want:  nil,
+		},
+		{
+			name:  "valid_bot_token_with_discord_keyword",
+			input: `discord bot_token: MTIzNDU2Nzg5MDEyMzQ1Njc4.G1ab2c.abcdefghijklmnopqrstuvwxyzabc`,
+			want: []veles.Secret{
+				discordbottoken.DiscordBotToken{
+					Token: "MTIzNDU2Nzg5MDEyMzQ1Njc4.G1ab2c.abcdefghijklmnopqrstuvwxyzabc",
+				},
+			},
+		},
+		{
+			name:  "valid_bot_token_with_DISCORD_TOKEN_keyword",
+			input: `DISCORD_TOKEN=NTEyMzQ1Njc4OTAxMjM0NTY3.Hx9Y8z.ABCDEFghijKLMNOPqrstuvWXYZabcd`,
+			want: []veles.Secret{
+				discordbottoken.DiscordBotToken{
+					Token: "NTEyMzQ1Njc4OTAxMjM0NTY3.Hx9Y8z.ABCDEFghijKLMNOPqrstuvWXYZabcd",
+				},
+			},
+		},
+		{
+			name:  "valid_bot_token_with_bot_token_keyword",
+			input: `bot_token = "MTIzNDU2Nzg5MDEyMzQ1Njc4OQ.abcdef.abcdefghijklmnopqrstuvwxyzabc"`,
+			want: []veles.Secret{
+				discordbottoken.DiscordBotToken{
+					Token: "MTIzNDU2Nzg5MDEyMzQ1Njc4OQ.abcdef.abcdefghijklmnopqrstuvwxyzabc",
+				},
+			},
+		},
+		{
+			name: "far_apart_token",
+			input: `discord:
+AAAAAAAAAA` + strings.Repeat("\nfiller line with random data", 500) + `
+MTIzNDU2Nzg5MDEyMzQ1Njc4.G1ab2c.abcdefghijklmnopqrstuvwxyzabc`,
+			want: nil,
+		},
+		{
+			name:  "token_with_underscores_and_hyphens",
+			input: `discord: MTIzNDU2Nzg5MDEyMzQ1Njc4.G_ab-c.abc_def-ghijklmnopqrstu_wxyz-ab`,
+			want: []veles.Secret{
+				discordbottoken.DiscordBotToken{
+					Token: "MTIzNDU2Nzg5MDEyMzQ1Njc4.G_ab-c.abc_def-ghijklmnopqrstu_wxyz-ab",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/discordbottoken/discordbottoken.go
+++ b/veles/secrets/discordbottoken/discordbottoken.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package discordbottoken contains a Veles Secret type and a Detector for
+// [Discord Bot Tokens](https://discord.com/developers/docs/reference#authentication)
+package discordbottoken
+
+// DiscordBotToken is a Veles Secret that holds relevant information for a
+// [Discord Bot Token](https://discord.com/developers/docs/reference#authentication)
+type DiscordBotToken struct {
+	Token string
+}

--- a/veles/secrets/discordbottoken/validator.go
+++ b/veles/secrets/discordbottoken/validator.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discordbottoken
+
+import (
+	"errors"
+	"net/http"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+const (
+	// discordAPIBaseURL is the base URL for Discord API.
+	discordAPIBaseURL = "https://discord.com/api/v10"
+	// discordUserEndpoint is the API endpoint for token validation.
+	discordUserEndpoint = "/users/@me"
+)
+
+// NewValidator creates a new Validator that validates the DiscordBotToken via
+// the /users/@me API endpoint.
+//
+// It performs a GET request to the Discord API endpoint to test bot's auth
+// token. Valid tokens return 200 OK, while invalid tokens return 401
+// Unauthorized.
+//
+// Reference: https://discord.com/developers/docs/resources/user#get-current-user
+func NewValidator() *sv.Validator[DiscordBotToken] {
+	return &sv.Validator[DiscordBotToken]{
+		EndpointFunc: func(t DiscordBotToken) (string, error) {
+			if t.Token == "" {
+				return "", errors.New("discord bot token is empty")
+			}
+			return discordAPIBaseURL + discordUserEndpoint, nil
+		},
+		HTTPMethod: http.MethodGet,
+		HTTPHeaders: func(t DiscordBotToken) map[string]string {
+			// Discord Bot tokens require "Bot " prefix in Authorization header
+			return map[string]string{
+				"Authorization": "Bot " + t.Token,
+			}
+		},
+		ValidResponseCodes:   []int{http.StatusOK},
+		InvalidResponseCodes: []int{http.StatusUnauthorized},
+	}
+}

--- a/veles/secrets/discordbottoken/validator_test.go
+++ b/veles/secrets/discordbottoken/validator_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discordbottoken_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
+)
+
+const (
+	validatorTestToken = "MTIzNDU2Nzg5MDEyMzQ1Njc4.G1ab2c.abcdefghijklmnopqrstuvwxyzabc"
+)
+
+// mockTransport redirects requests to the test server
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the original URL with our test server URL for Discord API hosts.
+	if req.URL.Host == "discord.com" {
+		testURL, _ := url.Parse(m.testServer.URL)
+		req.URL.Scheme = testURL.Scheme
+		req.URL.Host = testURL.Host
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// mockDiscordAPIServer creates a mock Discord /users/@me endpoint for testing
+// validators.
+func mockDiscordAPIServer(t *testing.T, expectedToken string, statusCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Expect a GET to /users/@me
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/users/@me") {
+			t.Errorf("unexpected request: %s %s, expected: GET /users/@me", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		// Check Authorization header
+		auth := r.Header.Get("Authorization")
+		expectedAuth := "Bot " + expectedToken
+		if auth != expectedAuth {
+			t.Errorf("expected Authorization header %q, got: %q", expectedAuth, auth)
+		}
+
+		w.WriteHeader(statusCode)
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name        string
+		statusCode  int
+		want        veles.ValidationStatus
+		expectError bool
+	}{
+		{
+			name:       "valid_key",
+			statusCode: http.StatusOK,
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "invalid_key_unauthorized",
+			statusCode: http.StatusUnauthorized,
+			want:       veles.ValidationInvalid,
+		},
+		{
+			name:        "server_error",
+			statusCode:  http.StatusInternalServerError,
+			want:        veles.ValidationFailed,
+			expectError: true,
+		},
+		{
+			name:        "bad_gateway",
+			statusCode:  http.StatusBadGateway,
+			want:        veles.ValidationFailed,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock server
+			server := mockDiscordAPIServer(t, validatorTestToken, tc.statusCode)
+			defer server.Close()
+
+			// Create client with custom transport
+			client := &http.Client{
+				Transport: &mockTransport{testServer: server},
+			}
+
+			// Create validator with mock client
+			validator := discordbottoken.NewValidator()
+			validator.HTTPC = client
+
+			// Create test key
+			key := discordbottoken.DiscordBotToken{Token: validatorTestToken}
+
+			// Test validation
+			got, err := validator.Validate(t.Context(), key)
+
+			// Check error expectation
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Validate() expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			}
+
+			// Check validation status
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidator_ContextCancellation(t *testing.T) {
+	// Create a server that delays response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create client with custom transport
+	client := &http.Client{
+		Transport: &mockTransport{testServer: server},
+	}
+
+	validator := discordbottoken.NewValidator()
+	validator.HTTPC = client
+
+	key := discordbottoken.DiscordBotToken{Token: validatorTestToken}
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// Test validation with cancelled context
+	got, err := validator.Validate(ctx, key)
+
+	if err == nil {
+		t.Errorf("Validate() expected error due to context cancellation, got nil")
+	}
+	if got != veles.ValidationFailed {
+		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
+	}
+}
+
+func TestValidator_EmptyToken(t *testing.T) {
+	validator := discordbottoken.NewValidator()
+
+	key := discordbottoken.DiscordBotToken{Token: ""}
+
+	got, err := validator.Validate(t.Context(), key)
+
+	if err == nil {
+		t.Errorf("Validate() expected error for empty token, got nil")
+	}
+	if got != veles.ValidationFailed {
+		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
+	}
+}


### PR DESCRIPTION
This PR implements a secret detector for Discord Bot Tokens as requested in issue #1287.

### Changes
- Added **DiscordBotToken** definition.
- Implemented regex-based detector with keyword pairing to reduce false positives.
  - Regex matches the standard 3-part format: [UserId].[Timestamp].[HMAC].
  - Keywords: discord, bot_token, DISCORD_TOKEN.
- Implemented API validator using Discord's public /users/@me endpoint.
- Added comprehensive unit tests covering valid tokens, invalid formats, and edge cases.
- Registered the new detector in extractor/filesystem/list/list.go.

### Verification
- **Unit Tests**: All tests passed (go test ./veles/secrets/discordbottoken/...).
- **Integration**: Verified plugin registration (go test ./extractor/filesystem/list/...).
- **Linting**: Passed golangci-lint.

Fixes #1287

CC: @erikvarga