### PR TITLE
feat(secrets): add qwen ai api key detector

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -139,6 +139,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/pypiapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/pyxkeyv1"
 	"github.com/google/osv-scalibr/veles/secrets/pyxkeyv2"
+	"github.com/google/osv-scalibr/veles/secrets/qwenaiapikey"
 	"github.com/google/osv-scalibr/veles/secrets/recaptchakey"
 	"github.com/google/osv-scalibr/veles/secrets/rubygemsapikey"
 	"github.com/google/osv-scalibr/veles/secrets/slacktoken"
@@ -359,6 +360,7 @@ var (
 		{jwt.NewDetector(), "secrets/jwttoken", 0},
 		{pyxkeyv1.NewDetector(), "secrets/pyxkeyv1", 0},
 		{pyxkeyv2.NewDetector(), "secrets/pyxkeyv2", 0},
+		{qwenaiapikey.NewDetector(), "secrets/qwenaiapikey", 0},
 		{telegrambotapitoken.NewDetector(), "secrets/telegrambotapitoken", 0},
 	})
 

--- a/veles/secrets/qwenaiapikey/detector.go
+++ b/veles/secrets/qwenaiapikey/detector.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qwenaiapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+const (
+	// maxKeyLength is the maximum length of a valid Qwen AI API Key.
+	// Standard keys are "sk-" followed by 32 hex chars, so 35 chars total.
+	maxKeyLength = 40
+
+	// maxDistance is the maximum distance between Qwen AI API Key and keywords
+	// to be considered for pairing.
+	maxDistance = 50
+)
+
+var (
+	// tokenRe is a regular expression that matches Qwen AI API Keys.
+	// Format: sk- followed by 32 lowercase hex/alphanumeric characters.
+	// Example: sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c
+	tokenRe = regexp.MustCompile(`\b(sk-[a-z0-9]{32})\b`)
+
+	// keywordRe is a regular expression that matches Qwen/DashScope related keywords.
+	keywordRe = regexp.MustCompile(`(?i)(qwen|dashscope|aliyun|apikey|sk-?sp)`)
+)
+
+// NewDetector returns a detector that matches Qwen AI keywords and API Key secret.
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: maxKeyLength,
+		MaxDistance:   maxDistance,
+		FindA:         pair.FindAllMatches(tokenRe),
+		FindB:         pair.FindAllMatches(keywordRe),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			return QwenAIAPIKey{Key: string(p.A.Value)}, true
+		},
+	}
+}

--- a/veles/secrets/qwenaiapikey/detector_test.go
+++ b/veles/secrets/qwenaiapikey/detector_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qwenaiapikey_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/qwenaiapikey"
+)
+
+func TestDetector_Detect(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{qwenaiapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		{
+			name:  "empty_input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "invalid_token_format_too_short",
+			input: "qwen_api_key: sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7", // 31 hex chars
+			want:  nil,
+		},
+		{
+			name:  "invalid_token_format_wrong_prefix",
+			input: "qwen_api_key: pk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c",
+			want:  nil,
+		},
+		{
+			name:  "invalid_token_format_uppercase",
+			input: "qwen_api_key: sk-2F3A4B5C6D7E8F9A0B1C2D3E4F5A6B7C", // regex expects lowercase
+			want:  nil,
+		},
+		{
+			name:  "keyword_but_no_secret",
+			input: `qwen://SOMEOTHERFORMAT123`,
+			want:  nil,
+		},
+		{
+			name:  "false_positive_token_but_no_keyword",
+			input: `config: sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c`,
+			want:  nil,
+		},
+		{
+			name:  "valid_key_with_qwen_keyword",
+			input: `qwen_api_key: sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c`,
+			want: []veles.Secret{
+				qwenaiapikey.QwenAIAPIKey{
+					Key: "sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c",
+				},
+			},
+		},
+		{
+			name:  "valid_key_with_dashscope_keyword",
+			input: `DASHSCOPE_API_KEY=sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c`,
+			want: []veles.Secret{
+				qwenaiapikey.QwenAIAPIKey{
+					Key: "sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c",
+				},
+			},
+		},
+		{
+			name:  "valid_key_with_aliyun_keyword",
+			input: `aliyun_api_key: sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c`,
+			want: []veles.Secret{
+				qwenaiapikey.QwenAIAPIKey{
+					Key: "sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c",
+				},
+			},
+		},
+		{
+			name: "far_apart_token",
+			input: `qwen:
+AAAAAAAAAA` + strings.Repeat("\nfiller line with random data", 100) + `
+sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c`,
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/qwenaiapikey/qwenaiapikey.go
+++ b/veles/secrets/qwenaiapikey/qwenaiapikey.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package qwenaiapikey contains a Veles Secret type and a Detector for
+// [Qwen AI API Keys](https://help.aliyun.com/zh/model-studio/developer-reference/get-api-key).
+package qwenaiapikey
+
+// QwenAIAPIKey is a Veles Secret that holds relevant information for a
+// [Qwen AI API Key](https://help.aliyun.com/zh/model-studio/developer-reference/get-api-key).
+type QwenAIAPIKey struct {
+	Key string
+}

--- a/veles/secrets/qwenaiapikey/validator.go
+++ b/veles/secrets/qwenaiapikey/validator.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qwenaiapikey
+
+import (
+	"net/http"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+const (
+	// dashScopeGenerationEndpoint is the API endpoint for DashScope model generation.
+	dashScopeGenerationEndpoint = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
+)
+
+// NewValidator creates a new Validator that validates the QwenAIAPIKey via
+// the DashScope API.
+//
+// It performs a POST request to the generation endpoint.
+// - If the API key is valid but the body is empty/invalid, we expect 400 Bad Request.
+// - If the API key is invalid, we expect 401 Unauthorized or 403 Forbidden.
+// - 200 OK is theoretically possible if we sent a valid payload, but 400 is enough to prove auth worked.
+func NewValidator() *sv.Validator[QwenAIAPIKey] {
+	return &sv.Validator[QwenAIAPIKey]{
+		Endpoint:   dashScopeGenerationEndpoint,
+		HTTPMethod: http.MethodPost,
+		HTTPHeaders: func(s QwenAIAPIKey) map[string]string {
+			return map[string]string{"Authorization": "Bearer " + s.Key}
+		},
+		// 200 OK: Request succeeded (unlikely with empty body but implies valid auth)
+		// 400 Bad Request: Auth succeeded, but request parameters were invalid (implies valid auth)
+		ValidResponseCodes: []int{http.StatusOK, http.StatusBadRequest},
+		// 401 Unauthorized: Invalid API Key
+		// 403 Forbidden: API Key valid format but permission denied/invalid
+		InvalidResponseCodes: []int{http.StatusUnauthorized, http.StatusForbidden},
+	}
+}

--- a/veles/secrets/qwenaiapikey/validator_test.go
+++ b/veles/secrets/qwenaiapikey/validator_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qwenaiapikey_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/qwenaiapikey"
+)
+
+const (
+	validatorTestKey = "sk-2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c"
+)
+
+// mockTransport redirects requests to the test server
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the original URL with our test server URL for DashScope API.
+	if strings.Contains(req.URL.Host, "aliyuncs.com") {
+		// Just parse the test server URL and replace scheme/host
+		// We don't need full parsing since we know it's a test server
+		req.URL.Scheme = "http"
+		req.URL.Host = m.testServer.Listener.Addr().String()
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// mockDashScopeAPIServer creates a mock DashScope generation endpoint for testing
+// validators.
+func mockDashScopeAPIServer(t *testing.T, expectedKey string, statusCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Expect a POST to /api/v1/services/aigc/text-generation/generation
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/generation") {
+			t.Errorf("unexpected request: %s %s, expected: POST .../generation", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		// Check Authorization header
+		auth := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + expectedKey
+		if auth != expectedAuth {
+			t.Errorf("expected Authorization header %q, got: %q", expectedAuth, auth)
+		}
+
+		w.WriteHeader(statusCode)
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name        string
+		statusCode  int
+		want        veles.ValidationStatus
+		expectError bool
+	}{
+		{
+			name:       "valid_key_bad_request",
+			statusCode: http.StatusBadRequest, // 400 means auth passed but body failed -> Valid secret
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "valid_key_ok",
+			statusCode: http.StatusOK, // 200 also means valid
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "invalid_key_unauthorized",
+			statusCode: http.StatusUnauthorized,
+			want:       veles.ValidationInvalid,
+		},
+		{
+			name:       "invalid_key_forbidden",
+			statusCode: http.StatusForbidden,
+			want:       veles.ValidationInvalid,
+		},
+		{
+			name:        "server_error",
+			statusCode:  http.StatusInternalServerError,
+			want:        veles.ValidationFailed,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock server
+			server := mockDashScopeAPIServer(t, validatorTestKey, tc.statusCode)
+			defer server.Close()
+
+			// Create client with custom transport
+			client := &http.Client{
+				Transport: &mockTransport{testServer: server},
+			}
+
+			// Create validator with mock client
+			validator := qwenaiapikey.NewValidator()
+			validator.HTTPC = client
+
+			// Create test key
+			key := qwenaiapikey.QwenAIAPIKey{Key: validatorTestKey}
+
+			// Test validation
+			got, err := validator.Validate(t.Context(), key)
+
+			// Check error expectation
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Validate() expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			}
+
+			// Check validation status
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new secret detector for Qwen AI API keys as requested in issue #1372.

### Summary
- Implemented **QwenAIAPIKey** secret type.
- Added a detector using regex sk-[a-z0-9]{32} and keyword pairing (qwen, dashscope, etc.).
- Added a validator using the DashScope generation endpoint. Validation relies on status code 400 Bad Request as an indicator of a valid key format with an empty request body, distinguishinf it from 401 Unauthorized.
- Added unit tests for detection and validation logic.
- Registered the detector in the global plugin list.

Verified with local tests and linting.

Fixes #1372

CC: @erikvarga