### PR TITLE
feat(secrets): add mistral api key detector

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -136,6 +136,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/perplexityapikey"
 	"github.com/google/osv-scalibr/veles/secrets/postmanapikey"
 	"github.com/google/osv-scalibr/veles/secrets/privatekey"
+	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
 	"github.com/google/osv-scalibr/veles/secrets/pypiapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/pyxkeyv1"
 	"github.com/google/osv-scalibr/veles/secrets/pyxkeyv2"
@@ -312,6 +313,7 @@ var (
 		{azurestorageaccountaccesskey.NewDetector(), "secrets/azurestorageaccountaccesskey", 0},
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
+		{mistralapikey.NewDetector(), "secrets/mistralapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},
 		{slacktoken.NewAppConfigAccessTokenDetector(), "secrets/slackappconfigaccesstoken", 0},

--- a/veles/secrets/mistralapikey/detector.go
+++ b/veles/secrets/mistralapikey/detector.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mistralapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+const (
+	// maxKeyLength is the maximum length of a valid Mistral API Key.
+	maxKeyLength = 40
+
+	// maxDistance is the maximum distance between Mistral API Key and keywords
+	// to be considered for pairing.
+	maxDistance = 50
+)
+
+var (
+	// tokenRe is a regular expression that matches Mistral API Keys.
+	// Format: Typically 32 characters, alphanumeric.
+	tokenRe = regexp.MustCompile(`\b([a-zA-Z0-9]{32})\b`)
+
+	// keywordRe is a regular expression that matches Mistral related keywords.
+	keywordRe = regexp.MustCompile(`(?i)(mistral|mistral_api)`)
+)
+
+// NewDetector returns a detector that matches Mistral keywords and API Key secret.
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: maxKeyLength,
+		MaxDistance:   maxDistance,
+		FindA:         pair.FindAllMatches(tokenRe),
+		FindB:         pair.FindAllMatches(keywordRe),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			return MistralAPIKey{Key: string(p.A.Value)}, true
+		},
+	}
+}

--- a/veles/secrets/mistralapikey/detector_test.go
+++ b/veles/secrets/mistralapikey/detector_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mistralapikey_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
+)
+
+func TestDetector_Detect(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{mistralapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		{
+			name:  "empty_input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "invalid_token_format_too_short",
+			input: "mistral_api_key: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p", // 31 chars
+			want:  nil,
+		},
+		{
+			name:  "valid_key_with_mistral_keyword",
+			input: `mistral_api_key: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6`,
+			want: []veles.Secret{
+				mistralapikey.MistralAPIKey{
+					Key: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+				},
+			},
+		},
+		{
+			name:  "valid_key_with_uppercase",
+			input: `MISTRAL_API_KEY=A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6`,
+			want: []veles.Secret{
+				mistralapikey.MistralAPIKey{
+					Key: "A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6",
+				},
+			},
+		},
+		{
+			name:  "false_positive_token_but_no_keyword",
+			input: `config: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6`,
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/mistralapikey/mistralapikey.go
+++ b/veles/secrets/mistralapikey/mistralapikey.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mistralapikey contains a Veles Secret type and a Detector for
+// [Mistral API Keys](https://docs.mistral.ai/api/).
+package mistralapikey
+
+// MistralAPIKey is a Veles Secret that holds relevant information for a
+// [Mistral API Key](https://docs.mistral.ai/api/).
+type MistralAPIKey struct {
+	Key string
+}

--- a/veles/secrets/mistralapikey/validator.go
+++ b/veles/secrets/mistralapikey/validator.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mistralapikey
+
+import (
+	"net/http"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+const (
+	// mistralModelsEndpoint is the API endpoint to list Mistral models.
+	mistralModelsEndpoint = "https://api.mistral.ai/v1/models"
+)
+
+// NewValidator creates a new Validator that validates the MistralAPIKey via
+// the Mistral API.
+//
+// It performs a GET request to the models endpoint.
+// - 200 OK: Valid Secret.
+// - 401 Unauthorized: Invalid Secret.
+func NewValidator() *sv.Validator[MistralAPIKey] {
+	return &sv.Validator[MistralAPIKey]{
+		Endpoint:   mistralModelsEndpoint,
+		HTTPMethod: http.MethodGet,
+		HTTPHeaders: func(s MistralAPIKey) map[string]string {
+			return map[string]string{"Authorization": "Bearer " + s.Key}
+		},
+		ValidResponseCodes:   []int{http.StatusOK},
+		InvalidResponseCodes: []int{http.StatusUnauthorized},
+	}
+}

--- a/veles/secrets/mistralapikey/validator_test.go
+++ b/veles/secrets/mistralapikey/validator_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mistralapikey_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
+)
+
+const (
+	validatorTestKey = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+)
+
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Host, "mistral.ai") {
+		req.URL.Scheme = "http"
+		req.URL.Host = m.testServer.Listener.Addr().String()
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func mockMistralAPIServer(t *testing.T, expectedKey string, statusCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/v1/models") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		auth := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + expectedKey
+		if auth != expectedAuth {
+			t.Errorf("expected Authorization header %q, got: %q", expectedAuth, auth)
+		}
+
+		w.WriteHeader(statusCode)
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		want       veles.ValidationStatus
+	}{
+		{
+			name:       "valid_key",
+			statusCode: http.StatusOK,
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "invalid_key",
+			statusCode: http.StatusUnauthorized,
+			want:       veles.ValidationInvalid,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := mockMistralAPIServer(t, validatorTestKey, tc.statusCode)
+			defer server.Close()
+
+			client := &http.Client{
+				Transport: &mockTransport{testServer: server},
+			}
+
+			validator := mistralapikey.NewValidator()
+			validator.HTTPC = client
+
+			key := mistralapikey.MistralAPIKey{Key: validatorTestKey}
+			got, err := validator.Validate(t.Context(), key)
+
+			if err != nil {
+				t.Errorf("Validate() unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a secret detector for Mistral API Keys as requested in issue #1480.

### Features
- **MistralAPIKey** secret type.
- **Detector** with regex [a-zA-Z0-9]{32} and keyword pairing (mistral, mistral_api).
- **Validator** using the read-only /v1/models endpoint for side-effect-free validation.
- Comprehensive **unit tests** for detection and validation.
- Registered in the global plugin list.

### Verification
- go test ./veles/secrets/mistralapikey/... 
- go test ./extractor/filesystem/list/... 
- golangci-lint 

Fixes #1480

CC: @erikvarga