### PR TITLE
feat(secrets): add bitwarden api key detector

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -111,6 +111,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/anthropicapikey"
 	"github.com/google/osv-scalibr/veles/secrets/azurestorageaccountaccesskey"
 	"github.com/google/osv-scalibr/veles/secrets/azuretoken"
+	"github.com/google/osv-scalibr/veles/secrets/bitwardenapikey"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
 	"github.com/google/osv-scalibr/veles/secrets/digitaloceanapikey"
@@ -313,6 +314,7 @@ var (
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
+		{bitwardenapikey.NewDetector(), "secrets/bitwardenapikey", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},
 		{slacktoken.NewAppConfigAccessTokenDetector(), "secrets/slackappconfigaccesstoken", 0},
 		{slacktoken.NewAppConfigRefreshTokenDetector(), "secrets/slackappconfigrefreshtoken", 0},

--- a/veles/secrets/bitwardenapikey/bitwardenapikey.go
+++ b/veles/secrets/bitwardenapikey/bitwardenapikey.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bitwardenapikey contains a Veles Secret type and a Detector for
+// [Bitwarden API Keys](https://bitwarden.com/help/public-api/#authentication).
+package bitwardenapikey
+
+// BitwardenAPIKey is a Veles Secret that holds relevant information for a
+// [Bitwarden API Key](https://bitwarden.com/help/public-api/#authentication).
+type BitwardenAPIKey struct {
+	ClientID     string
+	ClientSecret string
+}

--- a/veles/secrets/bitwardenapikey/detector.go
+++ b/veles/secrets/bitwardenapikey/detector.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bitwardenapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+const (
+	maxIDLength     = 100
+	maxSecretLength = 100
+	// maxDistance is the maximum distance between Client ID and Client Secret.
+	maxDistance = 1024
+)
+
+var (
+	// clientIDRe matches Bitwarden Client IDs (user. or organization. prefix).
+	clientIDRe = regexp.MustCompile(`\b((?:user|organization)\.[a-zA-Z0-9.-]{30,})\b`)
+	// clientSecretRe matches Bitwarden Client Secrets (random alphanumeric).
+	clientSecretRe = regexp.MustCompile(`\b([a-zA-Z0-9.]{30,})\b`)
+)
+
+// NewDetector returns a detector that matches Bitwarden Client ID and Secret pairs.
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: max(maxIDLength, maxSecretLength),
+		MaxDistance:   maxDistance,
+		FindA:         pair.FindAllMatches(clientIDRe),
+		FindB:         pair.FindAllMatches(clientSecretRe),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			return BitwardenAPIKey{
+				ClientID:     string(p.A.Value),
+				ClientSecret: string(p.B.Value),
+			}, true
+		},
+	}
+}

--- a/veles/secrets/bitwardenapikey/detector_test.go
+++ b/veles/secrets/bitwardenapikey/detector_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bitwardenapikey_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/bitwardenapikey"
+)
+
+const (
+	testID     = "user.12345678-abcd-1234-abcd-1234567890ab"
+	testSecret = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+)
+
+func TestDetector_Detect(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{bitwardenapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		{
+			name:  "empty_input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "valid_pair_in_env_format",
+			input: "BW_CLIENTID=" + testID + "\nBW_CLIENTSECRET=" + testSecret,
+			want: []veles.Secret{
+				bitwardenapikey.BitwardenAPIKey{
+					ClientID:     testID,
+					ClientSecret: testSecret,
+				},
+			},
+		},
+		{
+			name:  "valid_pair_in_json_format",
+			input: `{"client_id": "` + testID + `", "client_secret": "` + testSecret + `"}`,
+			want: []veles.Secret{
+				bitwardenapikey.BitwardenAPIKey{
+					ClientID:     testID,
+					ClientSecret: testSecret,
+				},
+			},
+		},
+		{
+			name:  "invalid_id_format",
+			input: "BW_CLIENTID=wrong." + testID[5:] + "\nBW_CLIENTSECRET=" + testSecret,
+			want:  nil,
+		},
+		{
+			name:  "secret_too_short",
+			input: "BW_CLIENTID=" + testID + "\nBW_CLIENTSECRET=short",
+			want:  nil,
+		},
+		{
+			name: "far_apart_pair",
+			input: "BW_CLIENTID=" + testID + strings.Repeat("\nfiller", 200) + "\nBW_CLIENTSECRET=" + testSecret,
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/bitwardenapikey/validator.go
+++ b/veles/secrets/bitwardenapikey/validator.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bitwardenapikey
+
+import (
+	"net/http"
+	"net/url"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+const (
+	bitwardenIdentityEndpoint = "https://identity.bitwarden.com/connect/token"
+)
+
+// NewValidator creates a new Validator that validates the BitwardenAPIKey via
+// the Bitwarden Identity Server.
+//
+// It performs a POST request to the token endpoint.
+// - 200 OK: Valid Secret.
+// - 400 Bad Request / 401 Unauthorized: Invalid Secret.
+func NewValidator() *sv.Validator[BitwardenAPIKey] {
+	return &sv.Validator[BitwardenAPIKey]{
+		Endpoint:   bitwardenIdentityEndpoint,
+		HTTPMethod: http.MethodPost,
+		HTTPHeaders: func(s BitwardenAPIKey) map[string]string {
+			return map[string]string{
+				"Content-Type": "application/x-www-form-urlencoded",
+			}
+		},
+		Body: func(s BitwardenAPIKey) (string, error) {
+			data := url.Values{}
+			data.Set("grant_type", "client_credentials")
+			data.Set("scope", "api")
+			data.Set("client_id", s.ClientID)
+			data.Set("client_secret", s.ClientSecret)
+			data.Set("deviceIdentifier", "0")
+			data.Set("deviceType", "0")
+			data.Set("deviceName", "scalibr")
+			return data.Encode(), nil
+		},
+		ValidResponseCodes:   []int{http.StatusOK},
+		InvalidResponseCodes: []int{http.StatusBadRequest, http.StatusUnauthorized},
+	}
+}

--- a/veles/secrets/bitwardenapikey/validator_test.go
+++ b/veles/secrets/bitwardenapikey/validator_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bitwardenapikey_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/bitwardenapikey"
+)
+
+func mockBitwardenServer(t *testing.T, expectedID, expectedSecret string, statusCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/connect/token") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		if r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+			t.Errorf("expected Content-Type application/x-www-form-urlencoded, got: %s", r.Header.Get("Content-Type"))
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "client_id="+expectedID) {
+			t.Errorf("expected body to contain client_id=%s, got: %s", expectedID, string(body))
+		}
+		if !strings.Contains(string(body), "client_secret="+expectedSecret) {
+			t.Errorf("expected body to contain client_secret=%s, got: %s", expectedSecret, string(body))
+		}
+
+		w.WriteHeader(statusCode)
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		want       veles.ValidationStatus
+	}{
+		{
+			name:       "valid_credentials",
+			statusCode: http.StatusOK,
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "invalid_client_id_or_secret",
+			statusCode: http.StatusBadRequest,
+			want:       veles.ValidationInvalid,
+		},
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			want:       veles.ValidationInvalid,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := mockBitwardenServer(t, testID, testSecret, tc.statusCode)
+			defer server.Close()
+
+			client := &http.Client{
+				Transport: &mockTransport{testServer: server},
+			}
+
+			validator := bitwardenapikey.NewValidator()
+			validator.HTTPC = client
+
+			secret := bitwardenapikey.BitwardenAPIKey{
+				ClientID:     testID,
+				ClientSecret: testSecret,
+			}
+			got, err := validator.Validate(t.Context(), secret)
+
+			if err != nil {
+				t.Errorf("Validate() unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Host, "bitwarden.com") {
+		req.URL.Scheme = "http"
+		req.URL.Host = m.testServer.Listener.Addr().String()
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}


### PR DESCRIPTION
This PR adds a secret detector for Bitwarden API Keys as requested in issue #1453.

### Features
- **BitwardenAPIKey** secret type.
- **Detector**: A paired detector for ClientID (user./organization. prefix) and ClientSecret (30+ alphanumeric chars).
- **Validator**: Authenticates via the official Bitwarden identity server (/connect/token) using form-encoded POST requests.
- **Tests**: Comprehensive coverage for various formats and mock server validation.
- Registered in the global plugin list.

### Verification
- go test ./veles/secrets/bitwardenapikey/... 
- go test ./extractor/filesystem/list/... 
- golangci-lint 

Fixes #1453

CC: @erikvarga