### PR TITLE
feat(secrets): add square api secret detector

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -142,6 +142,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/recaptchakey"
 	"github.com/google/osv-scalibr/veles/secrets/rubygemsapikey"
 	"github.com/google/osv-scalibr/veles/secrets/slacktoken"
+	"github.com/google/osv-scalibr/veles/secrets/squareapikey"
 	"github.com/google/osv-scalibr/veles/secrets/stripeapikeys"
 	"github.com/google/osv-scalibr/veles/secrets/telegrambotapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/tinkkeyset"
@@ -310,6 +311,7 @@ var (
 		{anthropicapikey.NewDetector(), "secrets/anthropicapikey", 0},
 		{azuretoken.NewDetector(), "secrets/azuretoken", 0},
 		{azurestorageaccountaccesskey.NewDetector(), "secrets/azurestorageaccountaccesskey", 0},
+		{squareapikey.NewDetector(), "secrets/squareapikey", 0},
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},

--- a/veles/secrets/squareapikey/detector.go
+++ b/veles/secrets/squareapikey/detector.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squareapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+const (
+	maxKeyLength = 124
+	// maxDistance is the maximum distance between Square API Key and keywords
+	// to be considered for pairing.
+	maxDistance = 50
+)
+
+var (
+	// tokenRe matches both Square Personal Access Tokens (EAAA...)
+	// and OAuth Application Secrets (sq0csp-...).
+	tokenRe = regexp.MustCompile(`\b(EAAA[\w\-\+\=]{60}|sq0csp-[A-Za-z0-9_-]{43})\b`)
+
+	// keywordRe matches Square related keywords.
+	keywordRe = regexp.MustCompile(`(?i)(square|SQUARE_ACCESS_TOKEN|SQUARE_APPLICATION_SECRET)`)
+)
+
+// NewDetector returns a detector that matches Square keywords and API Key secret.
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: maxKeyLength,
+		MaxDistance:   maxDistance,
+		FindA:         pair.FindAllMatches(tokenRe),
+		FindB:         pair.FindAllMatches(keywordRe),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			return SquareAPIKey{Key: string(p.A.Value)}, true
+		},
+	}
+}

--- a/veles/secrets/squareapikey/detector_test.go
+++ b/veles/secrets/squareapikey/detector_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squareapikey_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/squareapikey"
+)
+
+func TestDetector_Detect(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{squareapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		{
+			name:  "empty_input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "valid_personal_access_token",
+			input: "square_access_token: EAAA" + strings.Repeat("a", 60),
+			want: []veles.Secret{
+				squareapikey.SquareAPIKey{
+					Key: "EAAA" + strings.Repeat("a", 60),
+				},
+			},
+		},
+		{
+			name:  "valid_oauth_application_secret",
+			input: "SQUARE_APPLICATION_SECRET: sq0csp-" + strings.Repeat("b", 43),
+			want: []veles.Secret{
+				squareapikey.SquareAPIKey{
+					Key: "sq0csp-" + strings.Repeat("b", 43),
+				},
+			},
+		},
+		{
+			name:  "false_positive_no_keyword",
+			input: "config: EAAA" + strings.Repeat("a", 60),
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/squareapikey/squareapikey.go
+++ b/veles/secrets/squareapikey/squareapikey.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package squareapikey contains a Veles Secret type and a Detector for
+// [Square API Secrets](https://developer.squareup.com/docs).
+package squareapikey
+
+// SquareAPIKey is a Veles Secret that holds relevant information for a
+// [Square API Secret](https://developer.squareup.com/docs).
+type SquareAPIKey struct {
+	Key string
+}

--- a/veles/secrets/squareapikey/validator.go
+++ b/veles/secrets/squareapikey/validator.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squareapikey
+
+import (
+	"net/http"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+const (
+	squareMerchantsEndpoint = "https://connect.squareup.com/v2/merchants"
+)
+
+// NewValidator creates a new Validator that validates the SquareAPIKey via
+// the Square API.
+//
+// It performs a GET request to the merchants endpoint.
+// - 200 OK: Valid Secret.
+// - 401 Unauthorized: Invalid Secret.
+func NewValidator() *sv.Validator[SquareAPIKey] {
+	return &sv.Validator[SquareAPIKey]{
+		Endpoint:   squareMerchantsEndpoint,
+		HTTPMethod: http.MethodGet,
+		HTTPHeaders: func(s SquareAPIKey) map[string]string {
+			return map[string]string{"Authorization": "Bearer " + s.Key}
+		},
+		ValidResponseCodes:   []int{http.StatusOK},
+		InvalidResponseCodes: []int{http.StatusUnauthorized},
+	}
+}

--- a/veles/secrets/squareapikey/validator_test.go
+++ b/veles/secrets/squareapikey/validator_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package squareapikey_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/squareapikey"
+)
+
+const (
+	validatorTestKey = "EAAA" + "testtokenmatching60characterslongalphanumericsymbolshehe"
+)
+
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Host, "squareup.com") {
+		req.URL.Scheme = "http"
+		req.URL.Host = m.testServer.Listener.Addr().String()
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func mockSquareAPIServer(t *testing.T, expectedKey string, statusCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/v2/merchants") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		auth := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + expectedKey
+		if auth != expectedAuth {
+			t.Errorf("expected Authorization header %q, got: %q", expectedAuth, auth)
+		}
+
+		w.WriteHeader(statusCode)
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		want       veles.ValidationStatus
+	}{
+		{
+			name:       "valid_key",
+			statusCode: http.StatusOK,
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "invalid_key",
+			statusCode: http.StatusUnauthorized,
+			want:       veles.ValidationInvalid,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := mockSquareAPIServer(t, validatorTestKey, tc.statusCode)
+			defer server.Close()
+
+			client := &http.Client{
+				Transport: &mockTransport{testServer: server},
+			}
+
+			validator := squareapikey.NewValidator()
+			validator.HTTPC = client
+
+			secret := squareapikey.SquareAPIKey{Key: validatorTestKey}
+			got, err := validator.Validate(t.Context(), secret)
+
+			if err != nil {
+				t.Errorf("Validate() unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a secret detector for Square API Secrets as requested in issue #1656.

### Features
- **SquareAPIKey** secret type.
- **Detector** for:
  - Personal Access Tokens (prefix EAAA)
  - OAuth Application Secrets (prefix sq0csp-)
- **Validator** using the /v2/merchants endpoint for side-effect-free validation.
- Comprehensive **unit tests** and plugin registration.

### Verification
- go test ./veles/secrets/squareapikey/... 
- go test ./extractor/filesystem/list/... 
- golangci-lint 

Fixes #1656

CC: @erikvarga