### PR TITLE
feat(secrets): add salesforce oauth detector

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -141,6 +141,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/pyxkeyv2"
 	"github.com/google/osv-scalibr/veles/secrets/recaptchakey"
 	"github.com/google/osv-scalibr/veles/secrets/rubygemsapikey"
+	"github.com/google/osv-scalibr/veles/secrets/salesforceoauth"
 	"github.com/google/osv-scalibr/veles/secrets/slacktoken"
 	"github.com/google/osv-scalibr/veles/secrets/stripeapikeys"
 	"github.com/google/osv-scalibr/veles/secrets/telegrambotapitoken"
@@ -337,6 +338,7 @@ var (
 		{postmanapikey.NewCollectionTokenDetector(), "secrets/postmancollectiontoken", 0},
 		{privatekey.NewDetector(), "secrets/privatekey", 0},
 		{rubygemsapikey.NewDetector(), "secrets/rubygemsapikey", 0},
+		{salesforceoauth.NewDetector(), "secrets/salesforceoauth", 0},
 		{tinkkeyset.NewDetector(), "secrets/tinkkeyset", 0},
 		{github.NewAppRefreshTokenDetector(), "secrets/githubapprefreshtoken", 0},
 		{github.NewAppS2STokenDetector(), "secrets/githubapps2stoken", 0},

--- a/veles/secrets/salesforceoauth/detector.go
+++ b/veles/secrets/salesforceoauth/detector.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package salesforceoauth
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+const (
+	maxIDLength     = 124
+	maxSecretLength = 64
+	// maxDistance is the maximum distance between Client ID and Client Secret.
+	maxDistance = 1024
+)
+
+var (
+	// clientIDRe matches Salesforce OAuth Client IDs (starts with 3MVG, 84+ chars).
+	clientIDRe = regexp.MustCompile(`\b3MVG[0-9A-Za-z]{80,}\b`)
+	// clientSecretRe matches generic high-entropy secrets (20-60 chars).
+	clientSecretRe = regexp.MustCompile(`\b[A-Za-z0-9._-]{20,60}\b`)
+)
+
+// NewDetector returns a detector that matches Salesforce Client ID and Secret pairs.
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: maxIDLength,
+		MaxDistance:   uint32(maxDistance),
+		FindA:         pair.FindAllMatches(clientIDRe),
+		FindB:         pair.FindAllMatches(clientSecretRe),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			return Credentials{
+				ClientID:     string(p.A.Value),
+				ClientSecret: string(p.B.Value),
+			}, true
+		},
+	}
+}

--- a/veles/secrets/salesforceoauth/detector_test.go
+++ b/veles/secrets/salesforceoauth/detector_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package salesforceoauth_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/salesforceoauth"
+)
+
+const (
+	testID     = "3MVG" + "thisisaverylongsalesforceclientidtestthatshouldbeatleast84charstolongenoughverylongindeed"
+	testSecret = "somerandomsalesforcesecret123"
+)
+
+func TestDetector_Detect(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{salesforceoauth.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		{
+			name:  "empty_input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "valid_pair",
+			input: "SF_CLIENT_ID=" + testID + "\nSF_CLIENT_SECRET=" + testSecret,
+			want: []veles.Secret{
+				salesforceoauth.Credentials{
+					ClientID:     testID,
+					ClientSecret: testSecret,
+				},
+			},
+		},
+		{
+			name:  "id_too_short",
+			input: "SF_CLIENT_ID=3MVGshort\nSF_CLIENT_SECRET=" + testSecret,
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/salesforceoauth/salesforceoauth.go
+++ b/veles/secrets/salesforceoauth/salesforceoauth.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package salesforceoauth contains a Veles Secret type and a Detector for
+// [Salesforce OAuth](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5).
+package salesforceoauth
+
+// Credentials holds relevant information for a Salesforce OAuth Client ID and Secret pair.
+type Credentials struct {
+	ClientID     string
+	ClientSecret string
+}

--- a/veles/secrets/salesforceoauth/validator.go
+++ b/veles/secrets/salesforceoauth/validator.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package salesforceoauth
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+const (
+	salesforceTokenEndpoint = "https://login.salesforce.com/services/oauth2/token"
+)
+
+// NewValidator creates a new Validator that validates the Salesforce OAuth credentials.
+//
+// It performs a POST request to the token endpoint.
+// - 200 OK: Valid Secret.
+// - 400 Bad Request / 401 Unauthorized: Invalid Secret.
+func NewValidator() *sv.Validator[Credentials] {
+	return &sv.Validator[Credentials]{
+		Endpoint:   salesforceTokenEndpoint,
+		HTTPMethod: http.MethodPost,
+		HTTPHeaders: func(s Credentials) map[string]string {
+			auth := base64.StdEncoding.EncodeToString([]byte(s.ClientID + ":" + s.ClientSecret))
+			return map[string]string{
+				"Authorization": "Basic " + auth,
+				"Content-Type":  "application/x-www-form-urlencoded",
+			}
+		},
+		Body: func(s Credentials) (string, error) {
+			data := url.Values{}
+			data.Set("grant_type", "client_credentials")
+			return data.Encode(), nil
+		},
+		ValidResponseCodes:   []int{http.StatusOK},
+		InvalidResponseCodes: []int{http.StatusBadRequest, http.StatusUnauthorized},
+	}
+}

--- a/veles/secrets/salesforceoauth/validator_test.go
+++ b/veles/secrets/salesforceoauth/validator_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package salesforceoauth_test
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/salesforceoauth"
+)
+
+func mockSalesforceServer(t *testing.T, expectedID, expectedSecret string, statusCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/services/oauth2/token") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		authHeader := r.Header.Get("Authorization")
+		expectedAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(expectedID+":"+expectedSecret))
+		if authHeader != expectedAuth {
+			t.Errorf("expected Authorization header %q, got: %q", expectedAuth, authHeader)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "grant_type=client_credentials") {
+			t.Errorf("expected body to contain grant_type=client_credentials, got: %s", string(body))
+		}
+
+		w.WriteHeader(statusCode)
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		want       veles.ValidationStatus
+	}{
+		{
+			name:       "valid_credentials",
+			statusCode: http.StatusOK,
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "invalid_credentials",
+			statusCode: http.StatusUnauthorized,
+			want:       veles.ValidationInvalid,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := mockSalesforceServer(t, testID, testSecret, tc.statusCode)
+			defer server.Close()
+
+			client := &http.Client{
+				Transport: &mockTransport{testServer: server},
+			}
+
+			validator := salesforceoauth.NewValidator()
+			validator.HTTPC = client
+
+			secret := salesforceoauth.Credentials{
+				ClientID:     testID,
+				ClientSecret: testSecret,
+			}
+			got, err := validator.Validate(t.Context(), secret)
+
+			if err != nil {
+				t.Errorf("Validate() unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Host, "salesforce.com") {
+		req.URL.Scheme = "http"
+		req.URL.Host = m.testServer.Listener.Addr().String()
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}


### PR DESCRIPTION
This PR adds a secret detector for Salesforce OAuth Client ID and Secret pairs as requested in issue #1380.

### Features
- **SalesforceOAuth** secret type.
- **Detector**: A paired detector for ClientID (starting with 3MVG, 84+ chars) and ClientSecret (20-60 random chars).
- **Validator**: Authenticates via https://login.salesforce.com/services/oauth2/token using the client_credentials flow.
- **Tests**: Comprehensive coverage for detection and mock server validation.
- Registered in the global plugin list.

### Verification
- go test ./veles/secrets/salesforceoauth/... 
- go test ./extractor/filesystem/list/... 
- golangci-lint 

Fixes #1380

CC: @erikvarga