### PR TITLE
feat(sbom): migrate extractors to use `PluginConfig`

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -243,8 +243,8 @@ var (
 	}
 	// SBOM extractors.
 	SBOM = InitMap{
-		cdx.Name:  {noCFG(cdx.New)},
-		spdx.Name: {noCFG(spdx.New)},
+		cdx.Name:  {cdx.New},
+		spdx.Name: {spdx.New},
 	}
 	// DotnetSource extractors for Dotnet (.NET).
 	DotnetSource = InitMap{

--- a/extractor/filesystem/sbom/cdx/cdx.go
+++ b/extractor/filesystem/sbom/cdx/cdx.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/CycloneDX/cyclonedx-go"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	cdxmeta "github.com/google/osv-scalibr/extractor/filesystem/sbom/cdx/metadata"
@@ -41,7 +42,7 @@ const (
 type Extractor struct{}
 
 // New returns a new instance of the extractor.
-func New() filesystem.Extractor { return &Extractor{} }
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
 
 // Name of the extractor.
 func (e Extractor) Name() string { return Name }

--- a/extractor/filesystem/sbom/spdx/spdx.go
+++ b/extractor/filesystem/sbom/spdx/spdx.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	spdxmeta "github.com/google/osv-scalibr/extractor/filesystem/sbom/spdx/metadata"
@@ -45,7 +46,7 @@ const (
 type Extractor struct{}
 
 // New returns a new instance of the extractor.
-func New() filesystem.Extractor { return &Extractor{} }
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
 
 // Name of the extractor.
 func (e Extractor) Name() string { return Name }


### PR DESCRIPTION
These are the last two scalibr extractors `osv-scanner` is using that have not been migrated 🎉 