### PR TITLE
fix: indent-error-flow lint error in salesforceoauth2jwt validator

### DIFF
--- a/veles/secrets/salesforceoauth2jwt/validator.go
+++ b/veles/secrets/salesforceoauth2jwt/validator.go
@@ -140,7 +140,6 @@ func parsePrivateKey(input string) (crypto.PrivateKey, error) {
 
 	if pemParsed {
 		return nil, errors.New("PEM parsed but could not parse private key")
-	} else {
-		return nil, errors.New("could not parse private key")
 	}
+	return nil, errors.New("could not parse private key")
 }


### PR DESCRIPTION
This PR addresses a linting issue reported in `veles/secrets/salesforceoauth2jwt/validator.go`.