### PR TITLE
fix(transitivedependency/pomxml): remove leading '/' from paths

### DIFF
--- a/enricher/transitivedependency/pomxml/pomxml.go
+++ b/enricher/transitivedependency/pomxml/pomxml.go
@@ -120,6 +120,8 @@ func (e Enricher) Enrich(ctx context.Context, input *enricher.ScanInput, inv *in
 	pkgGroups := internal.GroupPackagesFromPlugin(inv.Packages, pomxml.Name)
 
 	for path, pkgMap := range pkgGroups {
+		// Remove leading '/' since SCALIBR fs paths don't include that.
+		path = strings.TrimPrefix(path, "/")
 		f, err := input.ScanRoot.FS.Open(path)
 
 		if err != nil {


### PR DESCRIPTION
I won't say I understand this entirely, but it does look to match similar logic in the annotators, and locally seems to improve (if not fix) the integration with Scalibr (see https://github.com/google/osv-scanner/pull/2466).

Ultimately since this has just been introduced I don't see it making things _worse_