### PR TITLE
Enable macOS rust reachability support

### DIFF
--- a/enricher/reachability/rust/rust.go
+++ b/enricher/reachability/rust/rust.go
@@ -49,7 +49,7 @@ const (
 	rustLibExtension = ".rcgu.o/"
 )
 
-// Regex used for fuzzy funcion matching
+// Regex used for fuzzy function matching
 var antiLeadingSpecCharRegex = regexp.MustCompile(`\W*(.+)`)
 
 // ErrNoRustToolchain is returned when the cargo is not found in the system.
@@ -71,7 +71,7 @@ func (*Enricher) Requirements() *plugin.Capabilities {
 	return &plugin.Capabilities{
 		DirectFS:      true,
 		Network:       plugin.NetworkOnline,
-		OS:            plugin.OSLinux,
+		OS:            plugin.OSUnix,
 		RunningSystem: true,
 		// Rust Reachability uses native toolchains and thus any scripts or build-time logic defined
 		// within the scanned project will run as-is. Make sure you trust the source code before

--- a/enricher/reachability/rust/rust_test.go
+++ b/enricher/reachability/rust/rust_test.go
@@ -17,7 +17,6 @@ package rust_test
 import (
 	"errors"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -37,10 +36,6 @@ var extractedSymbolsFile = "testdata/mock_data/mock_extractedsymbols.json"
 var testProjPath = "testdata/real-rust-project"
 
 func Test_Enrich(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skipf("Test skipped, OS unsupported: %v", runtime.GOOS)
-	}
-
 	tests := []struct {
 		name          string
 		vulnFile      string


### PR DESCRIPTION
Partially fixes #1600 

- Enable Rust reachability enricher on macOS by adding Mach-O DWARF parsing support
- Update plugin requirements from Linux-only to Unix (`OSUnix`) so it can run on macOS
- Remove Linux-only test skip so Rust reachability tests run on macOS too
- One limitation that I could think of was if binaries have split debug info (`.dSYM`) not embedded in Mach-O, additional handling might be needed, since it might become a more of a discovery issue then parsing

