### PR TITLE
fix(java/pomxml): support non-utf8 encoded files

### DIFF
--- a/extractor/filesystem/language/java/pomxml/pomxml.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml.go
@@ -17,7 +17,6 @@ package pomxml
 
 import (
 	"context"
-	"encoding/xml"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -27,6 +26,7 @@ import (
 
 	"deps.dev/util/maven"
 
+	"github.com/google/osv-scalibr/clients/datasource"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/javalockfile"
@@ -86,7 +86,7 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
 	var project *maven.Project
 
-	if err := xml.NewDecoder(input.Reader).Decode(&project); err != nil {
+	if err := datasource.NewMavenDecoder(input.Reader).Decode(&project); err != nil {
 		err := fmt.Errorf("could not extract pom from %s: %w", input.Path, err)
 		log.Errorf(err.Error())
 		return inventory.Inventory{}, err

--- a/extractor/filesystem/language/java/pomxml/pomxml_test.go
+++ b/extractor/filesystem/language/java/pomxml/pomxml_test.go
@@ -157,6 +157,26 @@ func TestExtractor_Extract(t *testing.T) {
 			},
 		},
 		{
+			Name: "different_encoding",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/encoding.xml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:      "junit:junit",
+					Version:   "4.12",
+					PURLType:  purl.TypeMaven,
+					Locations: []string{"testdata/encoding.xml"},
+					Metadata: &javalockfile.Metadata{
+						ArtifactID:   "junit",
+						GroupID:      "junit",
+						IsTransitive: false,
+						DepGroupVals: []string{},
+					},
+				},
+			},
+		},
+		{
 			Name: "with dependency management",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/with-dependency-management.xml",

--- a/extractor/filesystem/language/java/pomxml/testdata/encoding.xml
+++ b/extractor/filesystem/language/java/pomxml/testdata/encoding.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0.0</version>
+
+  <name>my-app</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/extractor/filesystem/language/java/pomxmlnet/pomxmlnet_test.go
+++ b/extractor/filesystem/language/java/pomxmlnet/pomxmlnet_test.go
@@ -148,6 +148,26 @@ func TestExtractor_Extract(t *testing.T) {
 			},
 		},
 		{
+			Name: "different_encoding",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/maven/encoding.xml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:      "junit:junit",
+					Version:   "4.12",
+					PURLType:  purl.TypeMaven,
+					Locations: []string{"testdata/maven/encoding.xml"},
+					Metadata: &javalockfile.Metadata{
+						ArtifactID:   "junit",
+						GroupID:      "junit",
+						IsTransitive: false,
+						DepGroupVals: []string{},
+					},
+				},
+			},
+		},
+		{
 			Name: "with dependency management",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/maven/with-dependency-management.xml",

--- a/extractor/filesystem/language/java/pomxmlnet/testdata/maven/encoding.xml
+++ b/extractor/filesystem/language/java/pomxmlnet/testdata/maven/encoding.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0.0</version>
+
+  <name>my-app</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+    </dependency>
+  </dependencies>
+
+</project>


### PR DESCRIPTION
`NewMavenDecoder` creates an xml decoder with a charset reader assigned allowing it to decode non UTF-8 files