### PR TITLE
feat: make `semantic` versions exported

### DIFF
--- a/semantic/parse.go
+++ b/semantic/parse.go
@@ -51,71 +51,71 @@ func Parse(str string, ecosystem string) (Version, error) {
 	// TODO(#457): support more ecosystems
 	switch ecosystem {
 	case "AlmaLinux":
-		return parseRedHatVersion(str), nil
+		return ParseRedHatVersion(str), nil
 	case "Alpaquita":
-		return parseAlpineVersion(str)
+		return ParseAlpineVersion(str)
 	case "Alpine":
-		return parseAlpineVersion(str)
+		return ParseAlpineVersion(str)
 	case "BellSoft Hardened Containers":
-		return parseAlpineVersion(str)
+		return ParseAlpineVersion(str)
 	case "Bitnami":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "Bioconductor":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "Chainguard":
-		return parseAlpineVersion(str)
+		return ParseAlpineVersion(str)
 	case "ConanCenter":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "CRAN":
-		return parseCRANVersion(str)
+		return ParseCRANVersion(str)
 	case "crates.io":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "Debian":
-		return parseDebianVersion(str)
+		return ParseDebianVersion(str)
 	case "GHC":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "Go":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "Hackage":
-		return parseHackageVersion(str)
+		return ParseHackageVersion(str)
 	case "Hex":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "Julia":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "Mageia":
-		return parseRedHatVersion(str), nil
+		return ParseRedHatVersion(str), nil
 	case "Maven":
-		return parseMavenVersion(str), nil
+		return ParseMavenVersion(str), nil
 	case "MinimOS":
-		return parseAlpineVersion(str)
+		return ParseAlpineVersion(str)
 	case "npm":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "NuGet":
-		return parseNuGetVersion(str), nil
+		return ParseNuGetVersion(str), nil
 	case "openEuler":
-		return parseRedHatVersion(str), nil
+		return ParseRedHatVersion(str), nil
 	case "openSUSE":
-		return parseRedHatVersion(str), nil
+		return ParseRedHatVersion(str), nil
 	case "Packagist":
-		return parsePackagistVersion(str), nil
+		return ParsePackagistVersion(str), nil
 	case "Pub":
-		return parsePubVersion(str), nil
+		return ParsePubVersion(str), nil
 	case "PyPI":
-		return parsePyPIVersion(str)
+		return ParsePyPIVersion(str)
 	case "Red Hat":
-		return parseRedHatVersion(str), nil
+		return ParseRedHatVersion(str), nil
 	case "Rocky Linux":
-		return parseRedHatVersion(str), nil
+		return ParseRedHatVersion(str), nil
 	case "RubyGems":
 		return parseRubyGemsVersion(str), nil
 	case "SUSE":
-		return parseRedHatVersion(str), nil
+		return ParseRedHatVersion(str), nil
 	case "SwiftURL":
-		return parseSemverVersion(str), nil
+		return ParseSemverVersion(str), nil
 	case "Ubuntu":
-		return parseDebianVersion(str)
+		return ParseDebianVersion(str)
 	case "Wolfi":
-		return parseAlpineVersion(str)
+		return ParseAlpineVersion(str)
 	}
 
 	return nil, fmt.Errorf("%w %s", ErrUnsupportedEcosystem, ecosystem)

--- a/semantic/version-cran.go
+++ b/semantic/version-cran.go
@@ -20,18 +20,20 @@ import (
 	"strings"
 )
 
-// cranVersion is the representation of a version of a package that is held
+// CRANVersion is the representation of a version of a package that is held
 // in the CRAN ecosystem (https://cran.r-project.org/).
 //
 // A version is a sequence of at least two non-negative integers separated by
 // either a period or a dash.
 //
 // See https://astrostatistics.psu.edu/su07/R/html/base/html/package_version.html
-type cranVersion struct {
+type CRANVersion struct {
 	components components
 }
 
-func (v cranVersion) compare(w cranVersion) int {
+var _ Version = CRANVersion{}
+
+func (v CRANVersion) compare(w CRANVersion) int {
 	if diff := v.components.Cmp(w.components); diff != 0 {
 		return diff
 	}
@@ -49,8 +51,17 @@ func (v cranVersion) compare(w cranVersion) int {
 	return -1
 }
 
-func (v cranVersion) CompareStr(str string) (int, error) {
-	w, err := parseCRANVersion(str)
+// Compare compares the given version to the receiver.
+func (v CRANVersion) Compare(w Version) (int, error) {
+	if w, ok := w.(CRANVersion); ok {
+		return v.compare(w), nil
+	}
+	return 0, ErrNotSameEcosystem
+}
+
+// CompareStr compares the given string to the receiver.
+func (v CRANVersion) CompareStr(str string) (int, error) {
+	w, err := ParseCRANVersion(str)
 
 	if err != nil {
 		return 0, err
@@ -59,10 +70,11 @@ func (v cranVersion) CompareStr(str string) (int, error) {
 	return v.compare(w), nil
 }
 
-func parseCRANVersion(str string) (cranVersion, error) {
+// ParseCRANVersion parses the given string as a CRAN version.
+func ParseCRANVersion(str string) (CRANVersion, error) {
 	// for now, treat an empty version string as valid
 	if str == "" {
-		return cranVersion{}, nil
+		return CRANVersion{}, nil
 	}
 
 	// dashes and periods have the same weight, so we can just normalize to periods
@@ -74,11 +86,11 @@ func parseCRANVersion(str string) (cranVersion, error) {
 		v, ok := new(big.Int).SetString(s, 10)
 
 		if !ok {
-			return cranVersion{}, fmt.Errorf("%w: '%s' is not allowed", ErrInvalidVersion, str)
+			return CRANVersion{}, fmt.Errorf("%w: '%s' is not allowed", ErrInvalidVersion, str)
 		}
 
 		comps = append(comps, v)
 	}
 
-	return cranVersion{comps}, nil
+	return CRANVersion{comps}, nil
 }

--- a/semantic/version-nuget.go
+++ b/semantic/version-nuget.go
@@ -16,22 +16,38 @@ package semantic
 
 import "strings"
 
-type nuGetVersion struct {
+// NuGetVersion is the representation of a version of a package that is held
+// in the NuGet ecosystem.
+//
+// See https://learn.microsoft.com/en-us/nuget/concepts/package-versioning
+type NuGetVersion struct {
 	semverLikeVersion
 }
 
-func (v nuGetVersion) compare(w nuGetVersion) int {
-	if diff := v.Components.Cmp(w.Components); diff != 0 {
+var _ Version = NuGetVersion{}
+
+func (v NuGetVersion) compare(w NuGetVersion) int {
+	if diff := v.components.Cmp(w.components); diff != 0 {
 		return diff
 	}
 
-	return compareBuildComponents(strings.ToLower(v.Build), strings.ToLower(w.Build))
+	return compareBuildComponents(strings.ToLower(v.build), strings.ToLower(w.build))
 }
 
-func (v nuGetVersion) CompareStr(str string) (int, error) {
-	return v.compare(parseNuGetVersion(str)), nil
+// Compare compares the given version to the receiver.
+func (v NuGetVersion) Compare(w Version) (int, error) {
+	if w, ok := w.(NuGetVersion); ok {
+		return v.compare(w), nil
+	}
+	return 0, ErrNotSameEcosystem
 }
 
-func parseNuGetVersion(str string) nuGetVersion {
-	return nuGetVersion{parseSemverLikeVersion(str, 4)}
+// CompareStr compares the given string to the receiver.
+func (v NuGetVersion) CompareStr(str string) (int, error) {
+	return v.compare(ParseNuGetVersion(str)), nil
+}
+
+// ParseNuGetVersion parses the given string as a NuGet version.
+func ParseNuGetVersion(str string) NuGetVersion {
+	return NuGetVersion{parseSemverLikeVersion(str, 4)}
 }

--- a/semantic/version-packagist.go
+++ b/semantic/version-packagist.go
@@ -123,22 +123,36 @@ func comparePackagistComponents(a, b []string) int {
 	return 0
 }
 
-type packagistVersion struct {
-	Original   string
-	Components []string
+// PackagistVersion is the representation of a version of a package that is held
+// in the Packagist ecosystem.
+type PackagistVersion struct {
+	original   string
+	components []string
 }
 
-func parsePackagistVersion(str string) packagistVersion {
-	return packagistVersion{
+var _ Version = PackagistVersion{}
+
+// ParsePackagistVersion parses the given string as a Packagist version.
+func ParsePackagistVersion(str string) PackagistVersion {
+	return PackagistVersion{
 		str,
 		strings.Split(canonicalizePackagistVersion(str), "."),
 	}
 }
 
-func (v packagistVersion) compare(w packagistVersion) int {
-	return comparePackagistComponents(v.Components, w.Components)
+func (v PackagistVersion) compare(w PackagistVersion) int {
+	return comparePackagistComponents(v.components, w.components)
 }
 
-func (v packagistVersion) CompareStr(str string) (int, error) {
-	return v.compare(parsePackagistVersion(str)), nil
+// Compare compares the given version to the receiver.
+func (v PackagistVersion) Compare(w Version) (int, error) {
+	if w, ok := w.(PackagistVersion); ok {
+		return v.compare(w), nil
+	}
+	return 0, ErrNotSameEcosystem
+}
+
+// CompareStr compares the given string to the receiver.
+func (v PackagistVersion) CompareStr(str string) (int, error) {
+	return v.compare(ParsePackagistVersion(str)), nil
 }

--- a/semantic/version-rubygems.go
+++ b/semantic/version-rubygems.go
@@ -114,22 +114,35 @@ func compareRubyGemsComponents(a, b []string) int {
 	return 0
 }
 
-type rubyGemsVersion struct {
-	Original string
-	Segments []string
+// RubyGemsVersion is the representation of a version of a package that is held
+// in the RubyGems ecosystem.
+type RubyGemsVersion struct {
+	original string
+	segments []string
 }
 
-func parseRubyGemsVersion(str string) rubyGemsVersion {
-	return rubyGemsVersion{
+var _ Version = RubyGemsVersion{}
+
+func parseRubyGemsVersion(str string) RubyGemsVersion {
+	return RubyGemsVersion{
 		str,
 		canonicalSegments(strings.Split(canonicalizeRubyGemVersion(str), ".")),
 	}
 }
 
-func (v rubyGemsVersion) compare(w rubyGemsVersion) int {
-	return compareRubyGemsComponents(v.Segments, w.Segments)
+func (v RubyGemsVersion) compare(w RubyGemsVersion) int {
+	return compareRubyGemsComponents(v.segments, w.segments)
 }
 
-func (v rubyGemsVersion) CompareStr(str string) (int, error) {
+// Compare compares the given version to the receiver.
+func (v RubyGemsVersion) Compare(w Version) (int, error) {
+	if w, ok := w.(RubyGemsVersion); ok {
+		return v.compare(w), nil
+	}
+	return 0, ErrNotSameEcosystem
+}
+
+// CompareStr compares the given string to the receiver.
+func (v RubyGemsVersion) CompareStr(str string) (int, error) {
 	return v.compare(parseRubyGemsVersion(str)), nil
 }

--- a/semantic/version-semver-like.go
+++ b/semantic/version-semver-like.go
@@ -24,23 +24,23 @@ import (
 // Semantic Version specification, except with potentially unlimited numeric
 // components and a leading "v"
 type semverLikeVersion struct {
-	LeadingV   bool
-	Components components
-	Build      string
-	Original   string
+	leadingV   bool
+	components components
+	build      string
+	original   string
 }
 
 func (v *semverLikeVersion) fetchComponentsAndBuild(maxComponents int) (components, string) {
-	if maxComponents == -1 || len(v.Components) <= maxComponents {
-		return v.Components, v.Build
+	if maxComponents == -1 || len(v.components) <= maxComponents {
+		return v.components, v.build
 	}
 
-	comps := v.Components[:maxComponents]
-	extra := v.Components[maxComponents:]
+	comps := v.components[:maxComponents]
+	extra := v.components[maxComponents:]
 
 	var build strings.Builder
 
-	build.WriteString(v.Build)
+	build.WriteString(v.build)
 
 	for _, c := range extra {
 		fmt.Fprintf(&build, ".%d", c)
@@ -55,10 +55,10 @@ func parseSemverLikeVersion(line string, maxComponents int) semverLikeVersion {
 	comps, build := v.fetchComponentsAndBuild(maxComponents)
 
 	return semverLikeVersion{
-		LeadingV:   v.LeadingV,
-		Components: comps,
-		Build:      build,
-		Original:   v.Original,
+		leadingV:   v.leadingV,
+		components: comps,
+		build:      build,
+		original:   v.original,
 	}
 }
 
@@ -124,9 +124,9 @@ func parseSemverLike(line string) semverLikeVersion {
 	}
 
 	return semverLikeVersion{
-		LeadingV:   leadingV,
-		Components: comps,
-		Build:      currentCom,
-		Original:   originStr,
+		leadingV:   leadingV,
+		components: comps,
+		build:      currentCom,
+		original:   originStr,
 	}
 }

--- a/semantic/version-semver.go
+++ b/semantic/version-semver.go
@@ -96,22 +96,37 @@ func compareSemverBuildComponents(a, b []string) int {
 	return 0
 }
 
-type semverVersion struct {
+// SemverVersion is the representation of a Semver 2.0.0 version.
+//
+// See https://semver.org/spec/v2.0.0.html
+type SemverVersion struct {
 	semverLikeVersion
 }
 
-func parseSemverVersion(str string) semverVersion {
-	return semverVersion{parseSemverLikeVersion(str, 3)}
+var _ Version = SemverVersion{}
+
+// ParseSemverVersion parses the given string as a Semver version.
+func ParseSemverVersion(str string) SemverVersion {
+	return SemverVersion{parseSemverLikeVersion(str, 3)}
 }
 
-func (v semverVersion) compare(w semverVersion) int {
-	if diff := v.Components.Cmp(w.Components); diff != 0 {
+func (v SemverVersion) compare(w SemverVersion) int {
+	if diff := v.components.Cmp(w.components); diff != 0 {
 		return diff
 	}
 
-	return compareBuildComponents(v.Build, w.Build)
+	return compareBuildComponents(v.build, w.build)
 }
 
-func (v semverVersion) CompareStr(str string) (int, error) {
-	return v.compare(parseSemverVersion(str)), nil
+// Compare compares the given version to the receiver.
+func (v SemverVersion) Compare(w Version) (int, error) {
+	if w, ok := w.(SemverVersion); ok {
+		return v.compare(w), nil
+	}
+	return 0, ErrNotSameEcosystem
+}
+
+// CompareStr compares the given string to the receiver.
+func (v SemverVersion) CompareStr(str string) (int, error) {
+	return v.compare(ParseSemverVersion(str)), nil
 }

--- a/semantic/version.go
+++ b/semantic/version.go
@@ -15,11 +15,24 @@
 package semantic
 
 import (
+	"errors"
 	"math/big"
 )
 
+// ErrNotSameEcosystem is returned when comparing two versions of different ecosystems.
+var ErrNotSameEcosystem = errors.New("version is not of the same ecosystem")
+
 // Version provides an interface for sortable version strings.
 type Version interface {
+	// Compare returns an integer representing the sort order of the given Version
+	// relative to the subject Version.
+	//
+	// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
+	//
+	// ErrNotSameEcosystem is returned if the given Version is not of the same
+	// ecosystem as the subject Version.
+	Compare(v Version) (int, error)
+
 	// CompareStr returns an integer representing the sort order of the given string
 	// when parsed as the concrete Version relative to the subject Version.
 	//


### PR DESCRIPTION
I want to start migrating things in OSV.dev to go, and having access to these go implementations of version comparers would be useful.

Made all the `ParseXXXVersion` functions and `XXXVersion` structs exported (and made sure all their field were unexported). Also added a `Compare(version Version) (int, error)` to the Version interface, so we don't need to keep re-parsing strings.

I've also tried to add missing reference URLs for most of the ecosystems that were missing them.