### PR TITLE
fix: Allow homebrew plugin to run on MacOS and Linux

### DIFF
--- a/annotator/misc/brewsource/brewsource.go
+++ b/annotator/misc/brewsource/brewsource.go
@@ -55,7 +55,7 @@ func (Annotator) Version() int { return 0 }
 
 // Requirements returns the requirements of the annotator.
 func (Annotator) Requirements() *plugin.Capabilities {
-	return &plugin.Capabilities{}
+	return &plugin.Capabilities{OS: plugin.OSUnix}
 }
 
 // Annotate adds repository source code identifiers for extracted Homebrew packages.

--- a/extractor/filesystem/os/homebrew/homebrew.go
+++ b/extractor/filesystem/os/homebrew/homebrew.go
@@ -68,7 +68,9 @@ func (e Extractor) Name() string { return Name }
 func (e Extractor) Version() int { return 0 }
 
 // Requirements of the extractor.
-func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{OS: plugin.OSMac} }
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{OS: plugin.OSUnix}
+}
 
 // FileRequired returns true if the specified file path matches the homebrew path.
 func (e Extractor) FileRequired(api filesystem.FileAPI) bool {

--- a/plugin/list/list_test.go
+++ b/plugin/list/list_test.go
@@ -94,7 +94,7 @@ func TestEnricherNamesUnique(t *testing.T) {
 func TestFromCapabilities(t *testing.T) {
 	capab := &plugin.Capabilities{OS: plugin.OSLinux}
 	want := []string{"os/snap", "weakcredentials/etcshadow"} // Available for Linux
-	dontWant := []string{"os/homebrew", "windows/dismpatch"} // Not available for Linux
+	dontWant := []string{"windows/dismpatch"}                // Not available for Linux
 	plugins, err := pl.FromCapabilities(capab, &cpb.PluginConfig{})
 	if err != nil {
 		t.Fatalf("pl.FromCapabilities(%v): %v", capab, err)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -121,7 +121,7 @@ func TestValidateRequirements(t *testing.T) {
 }
 
 func TestFilterByCapabilities(t *testing.T) {
-	capab := &plugin.Capabilities{OS: plugin.OSLinux}
+	capab := &plugin.Capabilities{OS: plugin.OSMac}
 	cfg := &cpb.PluginConfig{}
 	snap, err := snap.New(cfg)
 	if err != nil {
@@ -137,7 +137,7 @@ func TestFilterByCapabilities(t *testing.T) {
 		t.Fatalf("plugin.FilterCapabilities(%v, %v): want 1 plugin, got %d", pls, capab, len(got))
 	}
 	gotName := got[0].Name()
-	wantName := "os/snap" // os/homebrew is for Mac only
+	wantName := "os/homebrew" // os/snap is for Linux only
 	if gotName != wantName {
 		t.Fatalf("plugin.FilterCapabilities(%v, %v): want plugin %q, got %q", pls, capab, wantName, gotName)
 	}


### PR DESCRIPTION
Homebrew can be installed on Linux according to the [docs](https://docs.brew.sh/Homebrew-on-Linux)