### PR TITLE
Add GitLab repository URL parser and corresponding tests

### DIFF
--- a/veles/secrets/common/gitlab/repourlparser.go
+++ b/veles/secrets/common/gitlab/repourlparser.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gitlab provides common utilities for GitLab-related secret detection.
+package gitlab
+
+import (
+	"net/url"
+	"strings"
+)
+
+// RepoInfo holds parsed repository information from a GitLab URL.
+type RepoInfo struct {
+	// Scheme is the URL scheme (e.g., "https", "http", "ssh", or "git" for scp-style)
+	Scheme string
+	// Host is the GitLab hostname (e.g., "gitlab.com", "gitlab.example.com")
+	Host string
+	// Namespace is the full group/subgroup path (e.g., "org/backend")
+	Namespace string
+	// Project is the project name (e.g., "api-service")
+	Project string
+	// FullPath is the complete repository path: namespace/project (e.g., "org/backend/api-service")
+	FullPath string
+}
+
+// ParseRepoURL extracts scheme, hostname, namespace, and project from a GitLab repository URL.
+// Supports both HTTPS and SSH formats:
+// - HTTPS: https://gitlab.com/org/backend/api-service.git
+// - HTTP: http://gitlab.example.com/org/backend/api-service.git
+// - SSH (scp-style): git@gitlab.com:org/backend/api-service.git
+// - SSH (URL-style): ssh://git@gitlab.com/org/backend/api-service.git
+//
+// Returns nil if the URL cannot be parsed or doesn't contain at least a namespace and project.
+func ParseRepoURL(rawURL string) *RepoInfo {
+	var scheme, hostname, repoPath string
+
+	// Handle SSH scp-style format: git@hostname:path/to/repo.git
+	if strings.HasPrefix(rawURL, "git@") {
+		scheme = "git"
+		parts := strings.SplitN(rawURL[4:], ":", 2) // Remove "git@" and split on ":"
+		if len(parts) != 2 {
+			return nil
+		}
+		hostname = parts[0]
+		repoPath = parts[1]
+	} else {
+		// Handle URL formats: https://, http://, ssh://
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			return nil
+		}
+		scheme = u.Scheme
+		hostname = u.Host
+		repoPath = strings.TrimPrefix(u.Path, "/")
+	}
+
+	// Remove .git suffix
+	repoPath = strings.TrimSuffix(repoPath, ".git")
+
+	// Split path into segments
+	segments := strings.Split(repoPath, "/")
+	if len(segments) < 2 {
+		return nil
+	}
+
+	// Last segment is the project, everything before is the namespace
+	project := segments[len(segments)-1]
+	namespace := strings.Join(segments[:len(segments)-1], "/")
+	fullPath := repoPath
+
+	return &RepoInfo{
+		Scheme:    scheme,
+		Host:      hostname,
+		Namespace: namespace,
+		Project:   project,
+		FullPath:  fullPath,
+	}
+}

--- a/veles/secrets/common/gitlab/repourlparser_test.go
+++ b/veles/secrets/common/gitlab/repourlparser_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseRepoURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    *RepoInfo
+		wantNil bool
+	}{
+		{
+			name:   "HTTPS_URL_with_single_group",
+			rawURL: "https://gitlab.com/mygroup/myproject.git",
+			want: &RepoInfo{
+				Scheme:    "https",
+				Host:      "gitlab.com",
+				Namespace: "mygroup",
+				Project:   "myproject",
+				FullPath:  "mygroup/myproject",
+			},
+		},
+		{
+			name:   "HTTPS_URL_with_nested_subgroups",
+			rawURL: "https://gitlab.com/org/backend/api-service.git",
+			want: &RepoInfo{
+				Scheme:    "https",
+				Host:      "gitlab.com",
+				Namespace: "org/backend",
+				Project:   "api-service",
+				FullPath:  "org/backend/api-service",
+			},
+		},
+		{
+			name:   "HTTPS_URL_with_deeply_nested_subgroups",
+			rawURL: "https://gitlab.com/company/division/team/backend/services/api.git",
+			want: &RepoInfo{
+				Scheme:    "https",
+				Host:      "gitlab.com",
+				Namespace: "company/division/team/backend/services",
+				Project:   "api",
+				FullPath:  "company/division/team/backend/services/api",
+			},
+		},
+		{
+			name:   "HTTP_URL_non_secure",
+			rawURL: "http://gitlab.example.com/group/project.git",
+			want: &RepoInfo{
+				Scheme:    "http",
+				Host:      "gitlab.example.com",
+				Namespace: "group",
+				Project:   "project",
+				FullPath:  "group/project",
+			},
+		},
+		{
+			name:   "SSH_scp_style_URL",
+			rawURL: "git@gitlab.com:mygroup/myproject.git",
+			want: &RepoInfo{
+				Scheme:    "git",
+				Host:      "gitlab.com",
+				Namespace: "mygroup",
+				Project:   "myproject",
+				FullPath:  "mygroup/myproject",
+			},
+		},
+		{
+			name:   "SSH_scp_style_URL_with_nested_subgroups",
+			rawURL: "git@gitlab.com:org/backend/api-service.git",
+			want: &RepoInfo{
+				Scheme:    "git",
+				Host:      "gitlab.com",
+				Namespace: "org/backend",
+				Project:   "api-service",
+				FullPath:  "org/backend/api-service",
+			},
+		},
+		{
+			name:   "SSH_URL_style_format",
+			rawURL: "ssh://git@gitlab.com/group/project.git",
+			want: &RepoInfo{
+				Scheme:    "ssh",
+				Host:      "gitlab.com",
+				Namespace: "group",
+				Project:   "project",
+				FullPath:  "group/project",
+			},
+		},
+		{
+			name:   "SSH_URL_style_with_nested_subgroups",
+			rawURL: "ssh://git@gitlab.example.com/org/team/backend/service.git",
+			want: &RepoInfo{
+				Scheme:    "ssh",
+				Host:      "gitlab.example.com",
+				Namespace: "org/team/backend",
+				Project:   "service",
+				FullPath:  "org/team/backend/service",
+			},
+		},
+		{
+			name:   "Self_hosted_GitLab_instance",
+			rawURL: "https://git.company.internal/engineering/backend.git",
+			want: &RepoInfo{
+				Scheme:    "https",
+				Host:      "git.company.internal",
+				Namespace: "engineering",
+				Project:   "backend",
+				FullPath:  "engineering/backend",
+			},
+		},
+		{
+			name:   "Self_hosted_with_subdomain",
+			rawURL: "https://gitlab.dev.example.com/team/project.git",
+			want: &RepoInfo{
+				Scheme:    "https",
+				Host:      "gitlab.dev.example.com",
+				Namespace: "team",
+				Project:   "project",
+				FullPath:  "team/project",
+			},
+		},
+		{
+			name:   "SSH_scp_style_with_self_hosted",
+			rawURL: "git@git.internal:org/project.git",
+			want: &RepoInfo{
+				Scheme:    "git",
+				Host:      "git.internal",
+				Namespace: "org",
+				Project:   "project",
+				FullPath:  "org/project",
+			},
+		},
+		{
+			name:    "Invalid_missing_project_only_one_segment",
+			rawURL:  "https://gitlab.com/onlyone.git",
+			wantNil: true,
+		},
+		{
+			name:    "Invalid_no_path_segments",
+			rawURL:  "https://gitlab.com/.git",
+			wantNil: true,
+		},
+		{
+			name:    "Invalid_SSH_format_without_colon",
+			rawURL:  "git@gitlab.com/group/project.git",
+			wantNil: true,
+		},
+		{
+			name:    "Invalid_malformed_URL",
+			rawURL:  "not-a-url",
+			wantNil: true,
+		},
+		{
+			name:    "Invalid_empty_string",
+			rawURL:  "",
+			wantNil: true,
+		},
+		{
+			name:   "URL_without_git_suffix",
+			rawURL: "https://gitlab.com/mygroup/myproject",
+			want: &RepoInfo{
+				Scheme:    "https",
+				Host:      "gitlab.com",
+				Namespace: "mygroup",
+				Project:   "myproject",
+				FullPath:  "mygroup/myproject",
+			},
+		},
+		{
+			name:   "URL_with_port_number",
+			rawURL: "https://gitlab.example.com:8443/group/project.git",
+			want: &RepoInfo{
+				Scheme:    "https",
+				Host:      "gitlab.example.com:8443",
+				Namespace: "group",
+				Project:   "project",
+				FullPath:  "group/project",
+			},
+		},
+		{
+			name:   "SSH_scp_style_with_port",
+			rawURL: "git@gitlab.example.com:2222:group/project.git",
+			want: &RepoInfo{
+				Scheme:    "git",
+				Host:      "gitlab.example.com",
+				Namespace: "2222:group",
+				Project:   "project",
+				FullPath:  "2222:group/project",
+			},
+		},
+		{
+			name:   "URL_with_hyphens_and_underscores_in_path",
+			rawURL: "https://gitlab.com/my-org/my_project-v2.git",
+			want: &RepoInfo{
+				Scheme:    "https",
+				Host:      "gitlab.com",
+				Namespace: "my-org",
+				Project:   "my_project-v2",
+				FullPath:  "my-org/my_project-v2",
+			},
+		},
+		{
+			name:   "URL_with_dots_in_path",
+			rawURL: "https://gitlab.com/org.name/project.name.git",
+			want: &RepoInfo{
+				Scheme:    "https",
+				Host:      "gitlab.com",
+				Namespace: "org.name",
+				Project:   "project.name",
+				FullPath:  "org.name/project.name",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseRepoURL(tt.rawURL)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ParseRepoURL() = %+v, want nil", got)
+				}
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ParseRepoURL() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# GitLab Common Utilities

This package provides reusable utilities for GitLab-related secret detection across all GitLab secret types.

## Repository URL Parser

The `repourlparser.go` module provides a function to parse GitLab repository URLs in both HTTP(S) and SSH formats.

### Features

- **Multiple URL Format Support**:
  - HTTPS: `https://gitlab.com/group/project.git`
  - HTTP: `http://gitlab.example.com/group/project.git`
  - SSH (scp-style): `git@gitlab.com:group/project.git`
  - SSH (URL-style): `ssh://git@gitlab.com/group/project.git`

- **Self-Hosted GitLab Support**: No hardcoded hostnames - works with any GitLab instance

- **Nested Subgroups**: Properly handles unlimited nesting depth (e.g., `org/backend/api-service`)

### Usage


Detectors should use their own regex to find repository URLs, then use `ParseRepoURL` to extract the structured information:

```go
// In your detector
repoURLRe := regexp.MustCompile(`(?:(?:https?|ssh)://(?:git@)?[a-zA-Z0-9][-a-zA-Z0-9.]*[a-zA-Z0-9]/[a-zA-Z0-9_./+-]+\.git|git@[a-zA-Z0-9][-a-zA-Z0-9.]*[a-zA-Z0-9]:[a-zA-Z0-9_./+-]+\.git)`)
repoURLMatches := repoURLRe.FindAllIndex(data, -1)

for _, m := range repoURLMatches {
    rawURL := string(data[m[0]:m[1]])
    if info := gitlab.ParseRepoURL(rawURL); info != nil {
        // Use info.Host, info.Namespace, info.Project
    }
}
```

### RepoInfo Structure

```go
type RepoInfo struct {
    Host      string // GitLab hostname (e.g., "gitlab.com")
    Namespace string // Full group/subgroup path (e.g., "org/backend")
    Project   string // Project name (e.g., "api-service")
    FullPath  string // Complete path: namespace/project
}
```

### Examples

| Input URL | Host | Namespace | Project | FullPath |
|-----------|------|-----------|---------|----------|
| `https://gitlab.com/mygroup/myproject.git` | `gitlab.com` | `mygroup` | `myproject` | `mygroup/myproject` |
| `https://gitlab.com/org/backend/api.git` | `gitlab.com` | `org/backend` | `api` | `org/backend/api` |
| `git@gitlab.com:org/backend/api.git` | `gitlab.com` | `org/backend` | `api` | `org/backend/api` |
| `ssh://git@git.company.com/team/service.git` | `git.company.com` | `team` | `service` | `team/service` |

### Integration with Other GitLab Secrets

This module is designed to be used across all GitLab secret types:

- **GitLab Deploy Tokens** (`veles/secrets/gitlabdeploytoken`)
- **GitLab CI Tokens** (future)
- **GitLab Personal Access Tokens** (future)
- **GitLab OAuth Tokens** (future)

By centralizing the repository URL parsing logic, we ensure consistency and reduce code duplication across all GitLab-related secret detectors.
