### PR TITLE
jwt: add context-aware ExtractTokensWithContext and tests

### DIFF
--- a/veles/secrets/common/jwt/jwt.go
+++ b/veles/secrets/common/jwt/jwt.go
@@ -89,6 +89,55 @@ func ExtractTokens(data []byte) ([]Token, []int) {
 	return tokens, positions
 }
 
+// ExtractTokensWithContext scans input data using a context-aware regexp.
+//
+// The provided regexp should contain at least one capturing group where the
+// first group represents the JWT value. The returned Token is parsed from
+// that first capturing group, while the returned position corresponds to the
+// start of the full regex match (including surrounding context).
+//
+// Example regexp:
+//
+//	(?i)\baccess[_-]?token\b\s*[:=]?\s*(eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b
+//
+// For input:
+//
+//	access_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+//
+// The returned position will point to the beginning of "access_token",
+// while the parsed token will be extracted only from the captured JWT.
+func ExtractTokensWithContext(data []byte, r *regexp.Regexp) ([]Token, []int) {
+	var tokens []Token
+	var positions []int
+
+	matches := r.FindAllSubmatchIndex(data, -1)
+
+	// idx layout:
+	// [fullStart, fullEnd, g1Start, g1End, g2Start, g2End, ...]
+	for _, idx := range matches {
+		// Ensure first capturing group exists and matched
+		if len(idx) < 4 || idx[2] < 0 || idx[3] < 0 {
+			continue
+		}
+
+		// Extract JWT from first capturing group
+		jwtBytes := data[idx[2]:idx[3]]
+		if len(jwtBytes) > MaxTokenLength {
+			continue
+		}
+
+		token := parseToken(string(jwtBytes))
+		if !token.isValid() {
+			continue
+		}
+
+		tokens = append(tokens, token)
+		positions = append(positions, idx[0]) // full context span start
+	}
+
+	return tokens, positions
+}
+
 // parseToken splits and decode a JWT string into a Token.
 func parseToken(token string) Token {
 	sections := strings.Split(token, ".")

--- a/veles/secrets/common/jwt/jwt_test.go
+++ b/veles/secrets/common/jwt/jwt_test.go
@@ -16,6 +16,7 @@ package jwt_test
 
 import (
 	"encoding/base64"
+	"regexp"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -161,6 +162,130 @@ func TestExtractTokens_invalidTokens(t *testing.T) {
 
 			if len(gotPos) != 0 {
 				t.Errorf("ExtractTokens(): diff returned %d positions; want 0", len(gotPos))
+			}
+		})
+	}
+}
+
+// TestExtractTokensWithContext_validTokens tests context-aware extraction
+// where the JWT is captured as group 1 but the position spans the full match.
+func TestExtractTokensWithContext_validTokens(t *testing.T) {
+	re := regexp.MustCompile(
+		`(?i)\baccess[_-]?token\b\s*[:=]?\s*(eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b`,
+	)
+
+	cases := []struct {
+		name        string
+		input       []byte
+		wantRaw     []string
+		wantPayload []map[string]any
+		wantPos     []int
+	}{
+		{
+			name: "single_match_with_prefix_suffix",
+			input: []byte("prefix access_token: " +
+				"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+				"eyJzdWIiOiIxMjMifQ.signature suffix"),
+			wantRaw: []string{
+				"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+					"eyJzdWIiOiIxMjMifQ.signature",
+			},
+			wantPayload: []map[string]any{
+				{"sub": "123"},
+			},
+			wantPos: []int{7}, // start of "access_token"
+		},
+		{
+			name: "multiple_matches",
+			input: []byte(
+				"access_token=" +
+					"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+					"eyJmb28iOiJiYXIifQ.sig1" +
+					"\naccess_token=" +
+					"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+					"eyJiYXoiOiJxdXgifQ.sig2",
+			),
+			wantRaw: []string{
+				"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+					"eyJmb28iOiJiYXIifQ.sig1",
+				"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+					"eyJiYXoiOiJxdXgifQ.sig2",
+			},
+			wantPayload: []map[string]any{
+				{"foo": "bar"},
+				{"baz": "qux"},
+			},
+			wantPos: []int{
+				0, // first "access_token"
+				len("access_token=" +
+					"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+					"eyJmb28iOiJiYXIifQ.sig1\n"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTokens, gotPos := jwt.ExtractTokensWithContext(tc.input, re)
+
+			if diff := cmp.Diff(tc.wantPos, gotPos); diff != "" {
+				t.Errorf("ExtractTokensWithContext(): position mismatch (-want +got):\n%s", diff)
+			}
+
+			if len(gotTokens) != len(tc.wantRaw) {
+				t.Fatalf("ExtractTokensWithContext(): got %d tokens, want %d",
+					len(gotTokens), len(tc.wantRaw))
+			}
+
+			for i, got := range gotTokens {
+				if got.Raw() != tc.wantRaw[i] {
+					t.Errorf("ExtractTokensWithContext(): %d Raw() = %q; want %q",
+						i, got.Raw(), tc.wantRaw[i])
+				}
+
+				if diff := cmp.Diff(tc.wantPayload[i], got.Payload(), cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("ExtractTokensWithContext(): %d Payload mismatch (-want +got):\n%s",
+						i, diff)
+				}
+			}
+		})
+	}
+}
+
+// TestExtractTokensWithContext_invalidCases ensures invalid captures are ignored.
+func TestExtractTokensWithContext_invalidCases(t *testing.T) {
+	re := regexp.MustCompile(
+		`(?i)\baccess_token\b\s*[:=]?\s*(eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b`,
+	)
+
+	cases := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "no capture group match",
+			input: []byte("access_token: not_a_jwt"),
+		},
+		{
+			name:  "invalid base64 payload",
+			input: []byte("access_token: eyJhbGciOiJSUzI1NiJ9.invalid!.sig"),
+		},
+		{
+			name:  "missing token completely",
+			input: []byte("nothing here"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTokens, gotPos := jwt.ExtractTokensWithContext(tc.input, re)
+
+			if len(gotTokens) != 0 {
+				t.Errorf("ExtractTokensWithContext(): got %d tokens, want 0", len(gotTokens))
+			}
+
+			if len(gotPos) != 0 {
+				t.Errorf("ExtractTokensWithContext(): got %d positions, want 0", len(gotPos))
 			}
 		})
 	}


### PR DESCRIPTION
Introduce ExtractTokensWithContext to support context-based JWT extraction using a caller-provided regular expression with capture groups.

Unlike ExtractTokens, which scans for standalone JWTs using a built-in pattern, this variant allows callers to detect JWTs embedded in contextual patterns such as:

    access_token: <jwt>
    refresh_token=<jwt>
    Authorization: Bearer <jwt>

Behavior:
- The first capturing group is treated as the JWT value.
- The returned position corresponds to the start of the full match span.
- Tokens are parsed and validated using existing parseToken logic.

This helps in reducing false positives in secret detection where contextual signals are required, without reimplementing JWT parsing logic.

Add comprehensive table-driven tests covering:
- Single contextual match
- Multiple contextual matches
- Position correctness (full match span)
- Payload decoding verification

This change improves flexibility for detectors that require context-aware JWT detection (e.g., access/refresh tokens).