### PR TITLE
feat: Add CleanStart OS ecosystem support for APK package scanning

### DIFF
--- a/extractor/filesystem/os/ecosystem/ecosystem.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem.go
@@ -46,6 +46,9 @@ func MakeEcosystem(metadata any) osvecosystem.Parsed {
 		if m.OSID == "alpaquita" {
 			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemAlpaquita, Suffix: m.OSVersionID}
 		}
+		if m.OSID == "clnstrt" || m.OSID == "cleanstart" {
+			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemCleanStart, Suffix: ""}
+		}
 		if m.OSID == "bellsoft-hardened-containers" {
 			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemBellSoftHardenedContainers, Suffix: m.OSVersionID}
 		}

--- a/inventory/osvecosystem/parsed.go
+++ b/inventory/osvecosystem/parsed.go
@@ -99,6 +99,7 @@ func (p Parsed) GetValidity() error {
 		osvconstants.EcosystemAlpaquita,
 		osvconstants.EcosystemAlpine,
 		osvconstants.EcosystemAndroid,
+		osvconstants.EcosystemCleanStart,
 		osvconstants.EcosystemBellSoftHardenedContainers,
 		osvconstants.EcosystemBioconductor,
 		osvconstants.EcosystemBitnami,


### PR DESCRIPTION
Adds recognition for CleanStart OS, with security advisories already published on osv.dev under the CleanStart ecosystem.