### PR TITLE
refactor: use packagist version parser directly

### DIFF
--- a/detector/cve/untested/cve202338408/cve202338408.go
+++ b/detector/cve/untested/cve202338408/cve202338408.go
@@ -271,7 +271,7 @@ type fileLocations struct {
 
 func versionLessEqual(lower, upper string) (bool, error) {
 	// Version format looks like this: 3.7.1p2, 3.7, 3.2.3, 2.9p2
-	r, err := semantic.MustParse(lower, "Packagist").CompareStr(upper)
+	r, err := semantic.ParsePackagistVersion(lower).CompareStr(upper)
 
 	return r <= 0, err
 }


### PR DESCRIPTION
Now that this function is public we can use it directly, which is in theory better because `MustParse` imports all version parsers