### PR TITLE
feat: restrict pomxml transitive dependency enricher behind `allow-unsafe-plugins` flag

### DIFF
--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -167,6 +167,7 @@ func (m *MavenRegistryAPIClient) updateDefaultRegistry(ctx context.Context, regi
 	if err != nil {
 		return err
 	}
+	log.Infof("The default Maven registry is being overwritten from %s to %s", m.defaultRegistry.URL, registry.URL)
 	registry.Parsed = u
 	m.defaultRegistry = registry
 	if registry.Parsed.Scheme == artifactRegistryScheme {

--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -285,11 +285,13 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Finds vulns in Go source with reachability data using govulncheck. Requires a vulnmatch enricher to be enabled. | `reachability/go/source`            |
 | Performs reachability analysis for Java code.                              | `reachability/java`                 |
 | Performs reachability analysis for Rust code. (Linux-only) *               | `reachability/rust`                 |
-| Resolves transitive dependencies for Python pip packages.                  | `transitivedependency/requirements` |
+| Resolves transitive dependencies for Java pom.xml files. *                 | `transitivedependency/pomxml`       |
+| Resolves transitive dependencies for Python requirements.txt.              | `transitivedependency/requirements` |
 | Queries the OSV.dev API to find vulnerabilities in the inventory packages. | `vulnmatch/osvdev`                  |
 | Adds license data to software packages                                     | `license/depsdev`                   |
 | Checks if package versions are deprecated (e.g. yanked, unpublished).      | `packagedeprecation/depsdev`        |
 
-Warning: Plugins marked with * use or mimic native toolchains.
-Any scripts or build-time logic defined within the project will run as-is.
-Please ensure you trust the source code before proceeding.
+Warning: Plugins marked with * are considered "unsafe" and require the `--allow-unsafe-plugins` flag.
+These plugins can be risky when run on untrusted artifacts as they may execute build-time logic
+defined within the project or follow external registries specified in the scanned artifacts.
+Please ensure you trust the source code and artifacts before proceeding.

--- a/enricher/transitivedependency/pomxml/pomxml.go
+++ b/enricher/transitivedependency/pomxml/pomxml.go
@@ -67,6 +67,9 @@ func (Enricher) Requirements() *plugin.Capabilities {
 	return &plugin.Capabilities{
 		Network:  plugin.NetworkOnline,
 		DirectFS: true,
+		// This enricher follows registries defined in pom.xml, which can be risky if
+		// they point to malicious registries.
+		AllowUnsafePlugins: true,
 	}
 }
 


### PR DESCRIPTION
https://github.com/google/osv-scalibr/issues/1867

Currently, the pomxml transitive dependency enricher follows registries defined in `pom.xml` files. While this is consistent with `mvn` behavior, it poses a security risk if a project points to a malicious registry. This PR introduces improvements to manage this risk and improve visibility for users.
 -  Restricted the `transitivedependency/pomxml` enricher to only run when the `--allow-unsafe-plugins` flag is enabled.
 -  Added a log to the Maven client that triggers whenever the default registry is overwritten by a repository defined in `pom.xml`.
 -  Added `transitivedependency/pomxml` to the supported enrichers list in `docs/supported_inventory_types.md`.
 - Refined the security warning for "unsafe" plugins to explicitly mention the risks of artifact-defined registries and the requirement of the `--allow-unsafe-plugins` flag.