### PR TITLE
fix: escape package names in manifest writer

### DIFF
--- a/guidedremediation/internal/manifest/npm/packagejson.go
+++ b/guidedremediation/internal/manifest/npm/packagejson.go
@@ -414,7 +414,8 @@ func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches
 			// Don't know what kind of dependency this is, so check them all.
 			// Check them in dev -> optional -> prod because that's the order npm seems to use when they conflict.
 			alreadyMatched := false
-			depStr := "devDependencies." + name
+			escapedName := gjson.Escape(name)
+			depStr := "devDependencies." + escapedName
 			if res := gjson.GetBytes(manif, depStr); res.Exists() {
 				ver := res.String()
 				if ver != origVer {
@@ -427,7 +428,7 @@ func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches
 				alreadyMatched = true
 			}
 
-			depStr = "optionalDependencies." + name
+			depStr = "optionalDependencies." + escapedName
 			if res := gjson.GetBytes(manif, depStr); res.Exists() {
 				ver := res.String()
 				if ver != origVer {
@@ -444,7 +445,7 @@ func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches
 				}
 			}
 
-			depStr = "dependencies." + name
+			depStr = "dependencies." + escapedName
 			if res := gjson.GetBytes(manif, depStr); res.Exists() {
 				ver := res.String()
 				if ver != origVer {

--- a/guidedremediation/internal/manifest/npm/packagejson_test.go
+++ b/guidedremediation/internal/manifest/npm/packagejson_test.go
@@ -122,6 +122,9 @@ func TestRead(t *testing.T) {
 		System: resolve.NPM,
 		Requirements: []resolve.RequirementVersion{
 			{
+				VersionKey: makeVK(t, "@scoped/pkg.name", "1.0.0", resolve.Requirement),
+			},
+			{
 				Type:       aliasType(t, "cliui"), // sorts on aliased name, not real package name
 				VersionKey: makeVK(t, "@isaacs/cliui", "^8.0.2", resolve.Requirement),
 			},
@@ -138,6 +141,9 @@ func TestRead(t *testing.T) {
 			},
 			{
 				VersionKey: makeVK(t, "lodash", "4.17.17", resolve.Requirement),
+			},
+			{
+				VersionKey: makeVK(t, "lodash.merge", "4.6.1", resolve.Requirement),
 			},
 			{
 				VersionKey: makeVK(t, "string-width", "^5.1.2", resolve.Requirement),
@@ -267,6 +273,18 @@ func TestWrite(t *testing.T) {
 					Name:        "lodash",
 					VersionFrom: "4.17.17",
 					VersionTo:   "^4.17.21",
+				},
+				// Test cases for names with dots to ensure they are escaped correctly.
+				// gjson/sjson use dots as path separators, so names with dots must be escaped.
+				{
+					Name:        "lodash.merge",
+					VersionFrom: "4.6.1",
+					VersionTo:   "4.6.2",
+				},
+				{
+					Name:        "@scoped/pkg.name",
+					VersionFrom: "1.0.0",
+					VersionTo:   "1.1.0",
 				},
 				{
 					Name:        "eslint",

--- a/guidedremediation/internal/manifest/npm/testdata/package.json
+++ b/guidedremediation/internal/manifest/npm/testdata/package.json
@@ -12,6 +12,8 @@
     "cliui": "npm:@isaacs/cliui@^8.0.2",
     "jquery": "latest",
     "lodash": "4.17.17",
+    "lodash.merge": "4.6.1",
+    "@scoped/pkg.name": "1.0.0",
     "string-width": "^5.1.2",
     "string-width-aliased": "npm:string-width@^4.2.3"
   },

--- a/guidedremediation/internal/manifest/npm/testdata/write_want.package.json
+++ b/guidedremediation/internal/manifest/npm/testdata/write_want.package.json
@@ -12,6 +12,8 @@
     "cliui": "npm:@isaacs/cliui@^9.0.0",
     "jquery": "~0.0.1",
     "lodash": "^4.17.21",
+    "lodash.merge": "4.6.2",
+    "@scoped/pkg.name": "1.1.0",
     "string-width": "^7.1.0",
     "string-width-aliased": "npm:string-width@^6.1.0"
   },


### PR DESCRIPTION
https://github.com/google/osv-scalibr/issues/1868

`package.json` manifest writer uses `gjson` and `sjson` libraries to locate and update dependency versions. By default, these libraries use the . character as a path separator but npm package names may contain dots. 

When a package name contained a dot, it was being misinterpreted as a nested JSON path rather than a single key. This caused the version lookups and updates to fail, reporting a successful fix while leaving the package.json file unchanged.

To fix this issue, this PR:
   - Utilized `gjson.Escape` to properly escape the package name before constructing the JSON path string. 
   - Applied this escaping to all types of dependency lookups in the `Write` method.