### PR TITLE
fix(transitivedependency/pomxml): do not return error for single file failure

### DIFF
--- a/enricher/transitivedependency/pomxml/pomxml.go
+++ b/enricher/transitivedependency/pomxml/pomxml.go
@@ -124,12 +124,8 @@ func New(cfg *cpb.PluginConfig) (enricher.Enricher, error) {
 func (e Enricher) Enrich(ctx context.Context, input *enricher.ScanInput, inv *inventory.Inventory) error {
 	pkgGroups := internal.GroupPackagesFromPlugin(inv.Packages, pomxml.Name)
 
-	paths := slices.Collect(maps.Keys(pkgGroups))
-	slices.Sort(paths)
-
 	var errs error
-	for _, path := range paths {
-		pkgMap := pkgGroups[path]
+	for path, pkgMap := range pkgGroups {
 		f, err := input.ScanRoot.FS.Open(path)
 
 		if err != nil {

--- a/enricher/transitivedependency/requirements/requirements.go
+++ b/enricher/transitivedependency/requirements/requirements.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 
 	"deps.dev/util/pypi"
@@ -103,12 +102,8 @@ func New(cfg *cpb.PluginConfig) (enricher.Enricher, error) {
 func (e Enricher) Enrich(ctx context.Context, input *enricher.ScanInput, inv *inventory.Inventory) error {
 	pkgGroups := internal.GroupPackagesFromPlugin(inv.Packages, requirements.Name)
 
-	paths := slices.Collect(maps.Keys(pkgGroups))
-	slices.Sort(paths)
-
 	var errs error
-	for _, path := range paths {
-		pkgMap := pkgGroups[path]
+	for path, pkgMap := range pkgGroups {
 		packages := make([]internal.PackageWithIndex, 0, len(pkgMap))
 		for _, indexPkg := range pkgMap {
 			packages = append(packages, indexPkg)


### PR DESCRIPTION
The `transitivedependency/pomxml` enricher will return an error and stop completely if a single pom.xml failed resolution and this led to inconsistent results across different scans if there are multiple files failing the scan. 

This PR fixes the above issue:
   - Updated the `transitivedependency/pomxml` enricher to log a warning and continue processing other files instead of returning an error on the first failure. This aligns the behavior with the requirements.txt enricher and ensures that a failure in one module doesn't wipe out transitive results for the rest files of a project.
   - Both enrichers now use `errors.Join` to collect all manifest-level errors and the joined error is returned at the end of the enrichement.