### PR TITLE
tempdir: add temporary directory management utility and migrate embeddedfs extractors to use it

### DIFF
--- a/extractor/filesystem/embeddedfs/archive/archive.go
+++ b/extractor/filesystem/embeddedfs/archive/archive.go
@@ -29,6 +29,7 @@ import (
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -94,10 +95,21 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		return inventory.Inventory{}, errors.New("input.Reader is nil")
 	}
 
-	var tempDir string
-	var err error
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS sets temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── archive
+	// |						└── valid.tar 					<--- A directory with the name set to the file discovered by the extractor
+	// │				        	├── bin						<--- A folder containing archive data
+	// │				        	│				└── bash	<--- A file inside /bin directory
+	pluginDir, pluginRoot, err := tempdir.CreateExtractorDir("archive", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
 	if strings.HasSuffix(input.Path, ".tar") {
-		tempDir, err = common.TARToTempDir(input.Reader)
+		err = common.TARToTempDir(pluginDir, pluginRoot, input.Reader)
 		if err != nil {
 			return inventory.Inventory{}, fmt.Errorf("common.TARToTempDir(%q): %w", input.Path, err)
 		}
@@ -106,7 +118,7 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		if err != nil {
 			return inventory.Inventory{}, fmt.Errorf("gzip.NewReader(%q): %w", input.Path, err)
 		}
-		tempDir, err = common.TARToTempDir(reader)
+		err = common.TARToTempDir(pluginDir, pluginRoot, reader)
 		if err != nil {
 			return inventory.Inventory{}, fmt.Errorf("common.TARToTempDir(%q): %w", input.Path, err)
 		}
@@ -118,9 +130,10 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var refMu sync.Mutex
 	getEmbeddedFS := func(ctx context.Context) (scalibrfs.FS, error) {
 		return &common.EmbeddedDirFS{
-			FS:       scalibrfs.DirFS(tempDir),
+			FS:       &common.RootFSWrapper{Root: pluginRoot, FS: pluginRoot.FS()},
+			Root:     pluginRoot,
 			File:     nil,
-			TmpPaths: []string{tempDir},
+			TmpPaths: []string{pluginDir},
 			RefCount: &refCount,
 			RefMu:    &refMu,
 		}, nil

--- a/extractor/filesystem/embeddedfs/common/common.go
+++ b/extractor/filesystem/embeddedfs/common/common.go
@@ -38,6 +38,7 @@ import (
 	"github.com/dsoprea/go-exfat"
 	"github.com/google/osv-scalibr/artifact/image/symlink"
 	scalibrfs "github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/tempdir"
 	"github.com/masahiro331/go-ext4-filesystem/ext4"
 	"www.velocidex.com/golang/go-ntfs/parser"
 )
@@ -132,8 +133,16 @@ func filterEntriesNtfs(entries []*parser.FileInfo) []*parser.FileInfo {
 	return filtered
 }
 
+// isInvalidEntry checks for ".", "..", "$"-prefixed, and "/"-containing entries in ExFAT.
+func isInvalidEntry(entry string) bool {
+	if entry == "" || entry == "." || entry == ".." || strings.HasPrefix(entry, "$") || strings.Contains(entry, "/") {
+		return true
+	}
+	return false
+}
+
 // ExtractAllRecursiveExt extracts all files from an ext4 filesystem to a temporary directory recursively.
-func ExtractAllRecursiveExt(fs *ext4.FileSystem, srcPath, destPath string) error {
+func ExtractAllRecursiveExt(fs *ext4.FileSystem, srcPath string, destRoot *os.Root) error {
 	srcPath = normalizePath(srcPath)
 	entries, err := fs.ReadDir(srcPath)
 	if err != nil {
@@ -143,23 +152,22 @@ func ExtractAllRecursiveExt(fs *ext4.FileSystem, srcPath, destPath string) error
 
 	entries = filterEntriesExt(entries)
 
-	if err := os.MkdirAll(destPath, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", destPath, err)
-	}
-
 	for _, entry := range entries {
 		srcFullPath := path.Join(srcPath, entry.Name())
-		destFullPath := filepath.Join(destPath, entry.Name())
+		destName := entry.Name()
 
 		if entry.IsDir() {
-			if err := os.MkdirAll(destFullPath, 0755); err != nil {
-				fmt.Printf("Warning: Failed to create directory %s: %v\n", destFullPath, err)
+			subRoot, err := destRoot.OpenRoot(destName)
+			if err != nil {
+				fmt.Printf("Warning: Failed to create subdir %s: %v\n", destName, err)
 				continue
 			}
-			if err := ExtractAllRecursiveExt(fs, srcFullPath, destFullPath); err != nil {
+			if err := ExtractAllRecursiveExt(fs, srcFullPath, subRoot); err != nil {
+				subRoot.Close()
 				fmt.Printf("Warning: Failed to extract directory %s: %v\n", srcFullPath, err)
 				continue
 			}
+			subRoot.Close()
 		} else {
 			file, err := fs.Open(srcFullPath)
 			if err != nil {
@@ -168,15 +176,15 @@ func ExtractAllRecursiveExt(fs *ext4.FileSystem, srcPath, destPath string) error
 			}
 			defer file.Close()
 
-			destFile, err := os.Create(destFullPath)
+			destFile, err := destRoot.Create(destName)
 			if err != nil {
-				fmt.Printf("Warning: Failed to create file %s: %v\n", destFullPath, err)
+				fmt.Printf("Warning: Failed to create file %s: %v\n", destName, err)
 				continue
 			}
 			defer destFile.Close()
 
 			if _, err := io.Copy(destFile, file); err != nil {
-				fmt.Printf("Warning: Failed to copy file %s to %s: %v\n", srcFullPath, destFullPath, err)
+				fmt.Printf("Warning: Failed to copy file %s: %v\n", srcFullPath, err)
 				continue
 			}
 		}
@@ -185,11 +193,12 @@ func ExtractAllRecursiveExt(fs *ext4.FileSystem, srcPath, destPath string) error
 }
 
 // ExtractAllRecursiveFat32 extracts all files from a FAT32 filesystem to a temporary directory recursively.
-func ExtractAllRecursiveFat32(fs *fat32.FileSystem, srcPath, destPath string) error {
+func ExtractAllRecursiveFat32(fs *fat32.FileSystem, srcPath string, destRoot *os.Root) error {
 	if srcPath == "" || srcPath == "." {
 		srcPath = "/"
 	}
 	srcPath = normalizePath(srcPath)
+
 	entries, err := fs.ReadDir(srcPath)
 	if err != nil {
 		fmt.Printf("Warning: Failed to list directory %s: %v\n", srcPath, err)
@@ -198,23 +207,22 @@ func ExtractAllRecursiveFat32(fs *fat32.FileSystem, srcPath, destPath string) er
 
 	entries = filterEntriesFat32(entries)
 
-	if err := os.MkdirAll(destPath, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", destPath, err)
-	}
-
 	for _, entry := range entries {
 		srcFullPath := path.Join(srcPath, entry.Name())
-		destFullPath := filepath.Join(destPath, entry.Name())
+		destName := entry.Name()
 
 		if entry.IsDir() {
-			if err := os.MkdirAll(destFullPath, 0755); err != nil {
-				fmt.Printf("Warning: Failed to create directory %s: %v\n", destFullPath, err)
+			subRoot, err := destRoot.OpenRoot(destName)
+			if err != nil {
+				fmt.Printf("Warning: Failed to create subdir %s: %v\n", destName, err)
 				continue
 			}
-			if err := ExtractAllRecursiveFat32(fs, srcFullPath, destFullPath); err != nil {
+			if err := ExtractAllRecursiveFat32(fs, srcFullPath, subRoot); err != nil {
+				subRoot.Close()
 				fmt.Printf("Warning: Failed to extract directory %s: %v\n", srcFullPath, err)
 				continue
 			}
+			subRoot.Close()
 		} else {
 			file, err := fs.OpenFile(srcFullPath, os.O_RDONLY)
 			if err != nil {
@@ -223,15 +231,15 @@ func ExtractAllRecursiveFat32(fs *fat32.FileSystem, srcPath, destPath string) er
 			}
 			defer file.Close()
 
-			destFile, err := os.Create(destFullPath)
+			destFile, err := destRoot.Create(destName)
 			if err != nil {
-				fmt.Printf("Warning: Failed to create file %s: %v\n", destFullPath, err)
+				fmt.Printf("Warning: Failed to create file %s: %v\n", destName, err)
 				continue
 			}
 			defer destFile.Close()
 
 			if _, err := io.Copy(destFile, file); err != nil {
-				fmt.Printf("Warning: Failed to copy file %s to %s: %v\n", srcFullPath, destFullPath, err)
+				fmt.Printf("Warning: Failed to copy file %s: %v\n", srcFullPath, err)
 				continue
 			}
 		}
@@ -240,7 +248,7 @@ func ExtractAllRecursiveFat32(fs *fat32.FileSystem, srcPath, destPath string) er
 }
 
 // ExtractAllRecursiveNtfs extracts all files from a NTFS filesystem to a temporary directory recursively.
-func ExtractAllRecursiveNtfs(fs *parser.NTFSContext, srcPath, destPath string) error {
+func ExtractAllRecursiveNtfs(fs *parser.NTFSContext, srcPath string, destRoot *os.Root) error {
 	srcPath = normalizePath(srcPath)
 	if srcPath == "" || srcPath == "." {
 		srcPath = "/"
@@ -259,23 +267,22 @@ func ExtractAllRecursiveNtfs(fs *parser.NTFSContext, srcPath, destPath string) e
 	entries := parser.ListDir(fs, entry)
 	entries = filterEntriesNtfs(entries)
 
-	if err := os.MkdirAll(destPath, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", destPath, err)
-	}
-
 	for _, entryInfo := range entries {
 		srcFullPath := path.Join(srcPath, entryInfo.Name)
-		destFullPath := filepath.Join(destPath, entryInfo.Name)
+		destName := entryInfo.Name
 
 		if entryInfo.IsDir {
-			if err := os.MkdirAll(destFullPath, 0755); err != nil {
-				fmt.Printf("Warning: Failed to create directory %s: %v\n", destFullPath, err)
+			subRoot, err := destRoot.OpenRoot(destName)
+			if err != nil {
+				fmt.Printf("Warning: Failed to create subdir %s: %v\n", destName, err)
 				continue
 			}
-			if err := ExtractAllRecursiveNtfs(fs, srcFullPath, destFullPath); err != nil {
+			if err := ExtractAllRecursiveNtfs(fs, srcFullPath, subRoot); err != nil {
+				subRoot.Close()
 				fmt.Printf("Warning: Failed to extract directory %s: %v\n", srcFullPath, err)
 				continue
 			}
+			subRoot.Close()
 		} else {
 			fileEntry, err := dir.Open(fs, srcFullPath)
 			if err != nil {
@@ -292,15 +299,15 @@ func ExtractAllRecursiveNtfs(fs *parser.NTFSContext, srcPath, destPath string) e
 			// Convert io.ReaderAt to io.Reader using io.NewSectionReader
 			fileReader := io.NewSectionReader(fileReaderAt, 0, entryInfo.Size)
 
-			destFile, err := os.Create(destFullPath)
+			destFile, err := destRoot.Create(destName)
 			if err != nil {
-				fmt.Printf("Warning: Failed to create file %s: %v\n", destFullPath, err)
+				fmt.Printf("Warning: Failed to create file %s: %v\n", destName, err)
 				continue
 			}
 			defer destFile.Close()
 
 			if _, err := io.Copy(destFile, fileReader); err != nil {
-				fmt.Printf("Warning: Failed to copy file %s to %s: %v\n", srcFullPath, destFullPath, err)
+				fmt.Printf("Warning: Failed to copy file %s: %v\n", srcFullPath, err)
 				continue
 			}
 		}
@@ -309,7 +316,7 @@ func ExtractAllRecursiveNtfs(fs *parser.NTFSContext, srcPath, destPath string) e
 }
 
 // ExtractAllRecursiveExFAT extracts all files from an exFAT filesystem to a temporary directory recursively.
-func ExtractAllRecursiveExFAT(section *io.SectionReader, dst string) error {
+func ExtractAllRecursiveExFAT(section *io.SectionReader, destRoot *os.Root) error {
 	er := exfat.NewExfatReader(section)
 	if err := er.Parse(); err != nil {
 		return fmt.Errorf("failed to parse exfat filesystem: %w", err)
@@ -328,30 +335,34 @@ func ExtractAllRecursiveExFAT(section *io.SectionReader, dst string) error {
 	for _, relPath := range files {
 		node := nodes[relPath]
 		resPath := strings.ReplaceAll(relPath, "\\", string(os.PathSeparator))
-		outPath := filepath.Join(dst, resPath)
+
+		if isInvalidEntry(resPath) {
+			continue
+		}
 
 		sde := node.StreamDirectoryEntry()
 		if node.IsDirectory() {
-			if err := os.MkdirAll(outPath, 0o755); err != nil {
-				return fmt.Errorf("failed to create directory %s: %w", outPath, err)
+			if err := destRoot.MkdirAll(resPath, 0o755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", resPath, err)
 			}
 			continue
 		}
 
-		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
-			return fmt.Errorf("failed to create parent directories for %s: %w", outPath, err)
+		if err := destRoot.MkdirAll(filepath.Dir(resPath), 0o755); err != nil {
+			return fmt.Errorf("failed to create parent directories for %s: %w", resPath, err)
 		}
 
-		outFile, err := os.Create(outPath)
+		outFile, err := destRoot.Create(resPath)
 		if err != nil {
-			return fmt.Errorf("failed to create file %s: %w", outPath, err)
+			return fmt.Errorf("failed to create file %s: %w", resPath, err)
 		}
 
 		useFat := !sde.GeneralSecondaryFlags.NoFatChain()
 		if _, _, err := er.WriteFromClusterChain(sde.FirstCluster, sde.ValidDataLength, useFat, outFile); err != nil {
 			// Ignore this error because we're going to manually truncate the file at the end
 			if !strings.Contains(err.Error(), "written bytes do not equal data-size") {
-				return fmt.Errorf("failed to write cluster chain %s: %w", outPath, err)
+				outFile.Close()
+				return fmt.Errorf("failed to write cluster chain %s: %w", resPath, err)
 			}
 		}
 
@@ -361,7 +372,7 @@ func ExtractAllRecursiveExFAT(section *io.SectionReader, dst string) error {
 		}
 
 		if err := outFile.Close(); err != nil {
-			return fmt.Errorf("failed to close file %s: %w", outPath, err)
+			return fmt.Errorf("failed to close file %s: %w", resPath, err)
 		}
 	}
 
@@ -376,13 +387,13 @@ type CloserWithTmpPaths interface {
 }
 
 // GetDiskPartitions opens a raw disk image and returns its partitions along with the disk handle.
-func GetDiskPartitions(tmpRawPath string) ([]part.Partition, *disk.Disk, error) {
+func GetDiskPartitions(rawDiskIMGPath string) ([]part.Partition, *disk.Disk, error) {
 	// Open the raw disk image with go-diskfs
-	disk, err := diskfs.Open(tmpRawPath, diskfs.WithOpenMode(diskfs.ReadOnly))
+	disk, err := diskfs.Open(rawDiskIMGPath, diskfs.WithOpenMode(diskfs.ReadOnly))
 	if err != nil {
 		disk.Close()
-		os.Remove(tmpRawPath)
-		return nil, nil, fmt.Errorf("failed to open raw disk image %s: %w", tmpRawPath, err)
+		os.Remove(rawDiskIMGPath)
+		return nil, nil, fmt.Errorf("failed to open raw disk image %s: %w", rawDiskIMGPath, err)
 	}
 
 	partitions, err := disk.GetPartitionTable()
@@ -399,35 +410,59 @@ func GetDiskPartitions(tmpRawPath string) ([]part.Partition, *disk.Disk, error) 
 }
 
 // NewPartitionEmbeddedFSGetter creates a lazy getter function for an embedded filesystem from a disk partition.
-func NewPartitionEmbeddedFSGetter(pluginName string, partitionIndex int, p part.Partition, disk *disk.Disk, tmpRawPath string, refMu *sync.Mutex, refCount *int32) func(context.Context) (scalibrfs.FS, error) {
+func NewPartitionEmbeddedFSGetter(pluginName string, partitionIndex int, p part.Partition, disk *disk.Disk, pluginDir string, pluginRoot *os.Root, rawDiskIMGPath string, refMu *sync.Mutex, refCount *int32) func(context.Context) (scalibrfs.FS, error) {
 	return func(ctx context.Context) (scalibrfs.FS, error) {
 		// Get partition offset and size (already multiplied by sector size)
 		offset := p.GetStart()
 		size := p.GetSize()
 
 		// Open raw image for filesystem parsers
-		f, err := os.Open(tmpRawPath)
+		f, err := os.Open(rawDiskIMGPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open raw image %s: %w", tmpRawPath, err)
+			return nil, fmt.Errorf("failed to open raw image %s: %w", rawDiskIMGPath, err)
 		}
 
 		section := io.NewSectionReader(f, offset, size)
 		fsType := DetectFilesystem(section, 0)
 
-		// Create a temporary directory for extracted files
-		tempDir, err := os.MkdirTemp("", fmt.Sprintf("scalibr-%s-part-%s-%d-", pluginName, fsType, partitionIndex))
+		// Creates a temporary directory for extracted files
+		// Disk layout will be similar to the following in the OS set temporary directory:
+		// ├── osv-scalibr-run-953505549
+		// │				└── extractor
+		// │				    └── vdi
+		// |						└── valid.vdi 								<--- File discovered by the extractor (pluginRoot parameter points here)
+		// │				        	├── partition-1-ext4					<--- A folder containing partition data
+		// │				        	│				└── private-key1.pem
+		// │				        	├── partition-2-exfat
+		// │				        	│				└── private-key2.pem
+		// │				        	├── partition-3-fat32
+		// │				        	│				└── private-key3.pem
+		// │				        	├── partition-4-ntfs
+		// │				        	│				└── private-key4.pem
+		// │				        	└── vdi-12345.raw 						<--- Converted disk image
+		partitionSubDir := fmt.Sprintf("partition-%d-%s", partitionIndex, strings.ToLower(fsType))
+		// Ensure dir exists
+		if err := pluginRoot.MkdirAll(partitionSubDir, 0o755); err != nil && !os.IsExist(err) {
+			return nil, fmt.Errorf("failed to create partition directory %s: %w", partitionSubDir, err)
+		}
+		partitionRoot, err := pluginRoot.OpenRoot(partitionSubDir)
 		if err != nil {
 			f.Close()
-			return nil, fmt.Errorf("failed to create temporary directory for %s partition %d: %w", fsType, partitionIndex, err)
+			return nil, fmt.Errorf("failed to open partition directory %s: %w", partitionSubDir, err)
 		}
 
+		rootPath, err := tempdir.GetRootPath()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get scalibr per run directory: %w", err)
+		}
 		params := generateFSParams{
 			File:           f,
 			Disk:           disk,
 			Section:        section,
 			PartitionIndex: partitionIndex,
-			TempDir:        tempDir,
-			TmpRawPath:     tmpRawPath,
+			TempDir:        filepath.Join(rootPath, pluginDir, partitionSubDir),
+			PartitionRoot:  partitionRoot,
+			RawDiskIMGPath: rawDiskIMGPath,
 			RefMu:          refMu,
 			RefCount:       refCount,
 		}
@@ -446,10 +481,13 @@ func NewPartitionEmbeddedFSGetter(pluginName string, partitionIndex int, p part.
 			fsys, err = nil, fmt.Errorf("unsupported filesystem type %s for partition %d", fsType, partitionIndex)
 		}
 		if err != nil {
+			partitionRoot.Close()
 			if fsType != "FAT32" {
 				f.Close()
 			}
-			os.RemoveAll(tempDir)
+			if errRemove := pluginRoot.RemoveAll(partitionSubDir); errRemove != nil {
+				return nil, fmt.Errorf("%w; %w", err, errRemove)
+			}
 			return nil, err
 		}
 		return fsys, nil
@@ -462,8 +500,9 @@ type generateFSParams struct {
 	Disk           *disk.Disk
 	Section        *io.SectionReader
 	PartitionIndex int
+	PartitionRoot  *os.Root
 	TempDir        string
-	TmpRawPath     string
+	RawDiskIMGPath string
 	RefMu          *sync.Mutex
 	RefCount       *int32
 }
@@ -474,16 +513,17 @@ func generateEXTFS(params generateFSParams) (*EmbeddedDirFS, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ext4 filesystem for partition %d: %w", params.PartitionIndex, err)
 	}
-	if err := ExtractAllRecursiveExt(fs, "/", params.TempDir); err != nil {
+	if err := ExtractAllRecursiveExt(fs, "/", params.PartitionRoot); err != nil {
 		return nil, fmt.Errorf("failed to extract ext4 files for partition %d: %w", params.PartitionIndex, err)
 	}
 	params.RefMu.Lock()
 	*params.RefCount++
 	params.RefMu.Unlock()
 	return &EmbeddedDirFS{
-		FS:       scalibrfs.DirFS(params.TempDir),
+		FS:       &RootFSWrapper{Root: params.PartitionRoot, FS: params.PartitionRoot.FS()},
+		Root:     params.PartitionRoot,
 		File:     params.File,
-		TmpPaths: []string{params.TempDir, params.TmpRawPath},
+		TmpPaths: []string{params.TempDir, params.RawDiskIMGPath},
 		RefCount: params.RefCount,
 		RefMu:    params.RefMu,
 	}, nil
@@ -501,11 +541,11 @@ func generateFAT32FS(params generateFSParams) (*EmbeddedDirFS, error) {
 	if !ok {
 		return nil, fmt.Errorf("partition %d is not a FAT32 filesystem", params.PartitionIndex)
 	}
-	f, err := os.Open(params.TmpRawPath)
+	f, err := os.Open(params.RawDiskIMGPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to reopen raw image %s: %w", params.TmpRawPath, err)
+		return nil, fmt.Errorf("failed to reopen raw image %s: %w", params.RawDiskIMGPath, err)
 	}
-	if err := ExtractAllRecursiveFat32(fat32fs, "/", params.TempDir); err != nil {
+	if err := ExtractAllRecursiveFat32(fat32fs, "/", params.PartitionRoot); err != nil {
 		f.Close()
 		return nil, fmt.Errorf("failed to extract FAT32 files for partition %d: %w", params.PartitionIndex, err)
 	}
@@ -513,9 +553,10 @@ func generateFAT32FS(params generateFSParams) (*EmbeddedDirFS, error) {
 	*params.RefCount++
 	params.RefMu.Unlock()
 	return &EmbeddedDirFS{
-		FS:       scalibrfs.DirFS(params.TempDir),
+		FS:       &RootFSWrapper{Root: params.PartitionRoot, FS: params.PartitionRoot.FS()},
+		Root:     params.PartitionRoot,
 		File:     f,
-		TmpPaths: []string{params.TempDir, params.TmpRawPath},
+		TmpPaths: []string{params.TempDir, params.RawDiskIMGPath},
 		RefCount: params.RefCount,
 		RefMu:    params.RefMu,
 	}, nil
@@ -523,16 +564,17 @@ func generateFAT32FS(params generateFSParams) (*EmbeddedDirFS, error) {
 
 // generateEXFATFS generates an exFAT filesystem and extracts files to a temporary directory.
 func generateEXFATFS(params generateFSParams) (*EmbeddedDirFS, error) {
-	if err := ExtractAllRecursiveExFAT(params.Section, params.TempDir); err != nil {
+	if err := ExtractAllRecursiveExFAT(params.Section, params.PartitionRoot); err != nil {
 		return nil, fmt.Errorf("failed to extract exFAT files for partition %d: %w", params.PartitionIndex, err)
 	}
 	params.RefMu.Lock()
 	*params.RefCount++
 	params.RefMu.Unlock()
 	return &EmbeddedDirFS{
-		FS:       scalibrfs.DirFS(params.TempDir),
+		FS:       &RootFSWrapper{Root: params.PartitionRoot, FS: params.PartitionRoot.FS()},
+		Root:     params.PartitionRoot,
 		File:     params.File,
-		TmpPaths: []string{params.TempDir, params.TmpRawPath},
+		TmpPaths: []string{params.TempDir, params.RawDiskIMGPath},
 		RefCount: params.RefCount,
 		RefMu:    params.RefMu,
 	}, nil
@@ -548,16 +590,17 @@ func generateNTFSFS(params generateFSParams) (*EmbeddedDirFS, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create NTFS filesystem for partition %d: %w", params.PartitionIndex, err)
 	}
-	if err := ExtractAllRecursiveNtfs(fs, "/", params.TempDir); err != nil {
+	if err := ExtractAllRecursiveNtfs(fs, "/", params.PartitionRoot); err != nil {
 		return nil, fmt.Errorf("failed to extract NTFS files for partition %d: %w", params.PartitionIndex, err)
 	}
 	params.RefMu.Lock()
 	*params.RefCount++
 	params.RefMu.Unlock()
 	return &EmbeddedDirFS{
-		FS:       scalibrfs.DirFS(params.TempDir),
+		FS:       &RootFSWrapper{Root: params.PartitionRoot, FS: params.PartitionRoot.FS()},
+		Root:     params.PartitionRoot,
 		File:     params.File,
-		TmpPaths: []string{params.TempDir, params.TmpRawPath},
+		TmpPaths: []string{params.TempDir, params.RawDiskIMGPath},
 		RefCount: params.RefCount,
 		RefMu:    params.RefMu,
 	}, nil
@@ -566,6 +609,7 @@ func generateNTFSFS(params generateFSParams) (*EmbeddedDirFS, error) {
 // EmbeddedDirFS wraps scalibrfs.DirFS to include reference counting and cleanup.
 type EmbeddedDirFS struct {
 	FS       scalibrfs.FS
+	Root     *os.Root
 	File     *os.File
 	TmpPaths []string
 	RefCount *int32
@@ -605,6 +649,13 @@ func (e *EmbeddedDirFS) Stat(name string) (fs.FileInfo, error) {
 func (e *EmbeddedDirFS) Close() error {
 	e.RefMu.Lock()
 	defer e.RefMu.Unlock()
+
+	// Close the partition root if it's not nil
+	if e.Root != nil {
+		e.Root.Close()
+		e.Root = nil
+	}
+
 	if e.File == nil {
 		return nil // Already closed
 	}
@@ -622,6 +673,35 @@ func (e *EmbeddedDirFS) Close() error {
 // TempPaths returns the temporary paths associated with the filesystem for cleanup.
 func (e *EmbeddedDirFS) TempPaths() []string {
 	return e.TmpPaths
+}
+
+// RootFSWrapper wraps os.Root.FS() to satisfy scalibrfs.FS interface.
+type RootFSWrapper struct {
+	Root *os.Root
+	FS   fs.FS
+}
+
+// Open opens a file from the underlying filesystem.
+func (w *RootFSWrapper) Open(name string) (fs.File, error) {
+	return w.FS.Open(name)
+}
+
+// ReadDir lists directory entries for the given path.
+// It normalizes root paths ("/", "") to "." for compatibility.
+func (w *RootFSWrapper) ReadDir(name string) ([]fs.DirEntry, error) {
+	if name == "/" || name == "" {
+		name = "."
+	}
+	return fs.ReadDir(w.FS, name)
+}
+
+// Stat returns file information for the given path.
+// For root paths ("/", "", "."), it returns a synthetic directory.
+func (w *RootFSWrapper) Stat(name string) (fs.FileInfo, error) {
+	if name == "/" || name == "" || name == "." {
+		return &fileInfo{name: name, isDir: true, modTime: time.Now()}, nil
+	}
+	return fs.Stat(w.FS, name)
 }
 
 // fileInfo is a simple implementation of fs.FileInfo for the root directory.
@@ -660,13 +740,7 @@ func (fi *fileInfo) Sys() any {
 
 // TARToTempDir extracts a tar file into a temporary directory
 // that can be used to traverse its contents recursively.
-func TARToTempDir(reader io.Reader) (string, error) {
-	// Create a temporary directory for extracted files
-	tempDir, err := os.MkdirTemp("", "scalibr-archive-")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temporary directory: %w", err)
-	}
-
+func TARToTempDir(pluginDir string, pluginRoot *os.Root, reader io.Reader) error {
 	// Extract the tar archive
 	var extractErr error
 	tr := tar.NewReader(reader)
@@ -686,27 +760,25 @@ loop:
 			break
 		}
 
-		target := filepath.Join(tempDir, hdr.Name)
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0755); err != nil {
-				extractErr = fmt.Errorf("failed to create directory %s: %w", target, err)
+			if err := pluginRoot.MkdirAll(hdr.Name, 0755); err != nil {
+				extractErr = fmt.Errorf("failed to create directory %s: %w", hdr.Name, err)
 				break loop
 			}
 		case tar.TypeReg:
-			dir := filepath.Dir(target)
-			if err := os.MkdirAll(dir, 0755); err != nil {
-				extractErr = fmt.Errorf("failed to create directory %s: %w", dir, err)
+			if err := pluginRoot.MkdirAll(filepath.Dir(hdr.Name), 0755); err != nil {
+				extractErr = fmt.Errorf("failed to create directory %s: %w", hdr.Name, err)
 				break loop
 			}
-			outFile, err := os.Create(target)
+			outFile, err := pluginRoot.Create(hdr.Name)
 			if err != nil {
-				extractErr = fmt.Errorf("failed to create file %s: %w", target, err)
+				extractErr = fmt.Errorf("failed to create file %s: %w", hdr.Name, err)
 				break loop
 			}
 			if _, err := io.Copy(outFile, tr); err != nil {
 				outFile.Close()
-				extractErr = fmt.Errorf("failed to copy file %s: %w", target, err)
+				extractErr = fmt.Errorf("failed to copy file %s: %w", hdr.Name, err)
 				break loop
 			}
 			outFile.Close()
@@ -716,9 +788,11 @@ loop:
 	}
 
 	if extractErr != nil {
-		os.Remove(tempDir)
-		return "", extractErr
+		if err := tempdir.RemoveAll(pluginDir); err != nil {
+			return fmt.Errorf("%w; %w", extractErr, err)
+		}
+		return extractErr
 	}
 
-	return tempDir, nil
+	return nil
 }

--- a/extractor/filesystem/embeddedfs/ova/ova.go
+++ b/extractor/filesystem/embeddedfs/ova/ova.go
@@ -28,6 +28,7 @@ import (
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -96,7 +97,18 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		return inventory.Inventory{}, errors.New("input.Reader is nil")
 	}
 
-	tempDir, err := common.TARToTempDir(input.Reader)
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS sets temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── ova
+	// |						└── valid.ova 					<--- A directory with the name set to the file discovered by the extractor
+	pluginDir, pluginRoot, err := tempdir.CreateExtractorDir("ova", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
+	err = common.TARToTempDir(pluginDir, pluginRoot, input.Reader)
 	if err != nil {
 		return inventory.Inventory{}, fmt.Errorf("common.TARToTempDir(%q): %w", input.Path, err)
 	}
@@ -105,9 +117,10 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var refMu sync.Mutex
 	getEmbeddedFS := func(ctx context.Context) (scalibrfs.FS, error) {
 		return &common.EmbeddedDirFS{
-			FS:       scalibrfs.DirFS(tempDir),
+			FS:       &common.RootFSWrapper{Root: pluginRoot, FS: pluginRoot.FS()},
+			Root:     pluginRoot,
 			File:     nil,
-			TmpPaths: []string{tempDir},
+			TmpPaths: []string{pluginDir},
 			RefCount: &refCount,
 			RefMu:    &refMu,
 		}, nil

--- a/extractor/filesystem/embeddedfs/qcow2/qcow2.go
+++ b/extractor/filesystem/embeddedfs/qcow2/qcow2.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -113,23 +114,42 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		}()
 	}
 
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS sets temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── qcow2
+	// |						└── valid.qcow2 							<--- File discovered by the extractor
+	// │				        	├── partition-1-ext4					<--- A folder containing partition data
+	// │				        	│				└── private-key1.pem
+	// │				        	├── partition-2-exfat
+	// │				        	│				└── private-key2.pem
+	// │				        	├── partition-3-fat32
+	// │				        	│				└── private-key3.pem
+	// │				        	├── partition-4-ntfs
+	// │				        	│				└── private-key4.pem
+	// │				        	└── qcow2-12345.raw						<--- Converted disk image
+	pluginDir, pluginRoot, err := tempdir.CreateExtractorDir("qcow2", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
 	// Create a temporary file for the raw disk image
-	tmpRaw, err := os.CreateTemp("", "scalibr-qcow2-raw-*.raw")
+	rawDiskIMGPath, _, err := tempdir.CreateFile(pluginDir, "qcow2-*.raw")
 	if err != nil {
 		return inventory.Inventory{}, fmt.Errorf("failed to create temporary raw file: %w", err)
 	}
-	tmpRawPath := tmpRaw.Name()
 
 	// Convert QCOW2 to raw
-	if err := convertQCOW2ToRaw(qcow2Path, tmpRawPath, e.password); err != nil {
-		os.Remove(tmpRawPath)
+	if err := convertQCOW2ToRaw(qcow2Path, rawDiskIMGPath, e.password); err != nil {
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, fmt.Errorf("failed to convert %s to raw image: %w", input.Path, err)
 	}
 
 	// Retrieve all partitions and the associated disk handle from the raw disk image.
-	partitionList, disk, err := common.GetDiskPartitions(tmpRawPath)
+	partitionList, disk, err := common.GetDiskPartitions(rawDiskIMGPath)
 	if err != nil {
-		os.Remove(tmpRawPath)
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, err
 	}
 
@@ -141,7 +161,7 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var embeddedFSs []*inventory.EmbeddedFS
 	for i, p := range partitionList {
 		partitionIndex := i + 1 // go-diskfs uses 1-based indexing
-		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("qcow2", partitionIndex, p, disk, tmpRawPath, &refMu, &refCount)
+		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("qcow2", partitionIndex, p, disk, pluginDir, pluginRoot, rawDiskIMGPath, &refMu, &refCount)
 		embeddedFSs = append(embeddedFSs, &inventory.EmbeddedFS{
 			Path:          fmt.Sprintf("%s:%d", input.Path, partitionIndex),
 			GetEmbeddedFS: getEmbeddedFS,

--- a/extractor/filesystem/embeddedfs/vdi/vdi.go
+++ b/extractor/filesystem/embeddedfs/vdi/vdi.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/common"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -129,23 +130,42 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		return inventory.Inventory{}, errors.New("input.Reader is nil")
 	}
 
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS sets temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── vdi
+	// |						└── valid.vdi 								<--- A directory with the name set to the file discovered by the extractor
+	// │				        	├── partition-1-ext4					<--- A folder containing partition data
+	// │				        	│				└── private-key1.pem
+	// │				        	├── partition-2-exfat
+	// │				        	│				└── private-key2.pem
+	// │				        	├── partition-3-fat32
+	// │				        	│				└── private-key3.pem
+	// │				        	├── partition-4-ntfs
+	// │				        	│				└── private-key4.pem
+	// │				        	└── vdi-1234.raw						<--- Converted disk image
+	pluginDir, pluginRoot, err := tempdir.CreateExtractorDir("vdi", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
 	// Create a temporary file for the raw disk image
-	tmpRaw, err := os.CreateTemp("", "scalibr-vdi-raw-*.raw")
+	rawDiskIMGPath, tmpRaw, err := tempdir.CreateFile(pluginDir, "vdi-*.raw")
 	if err != nil {
 		return inventory.Inventory{}, fmt.Errorf("failed to create temporary raw file: %w", err)
 	}
-	tmpRawPath := tmpRaw.Name()
 
 	// Convert VDI to raw
 	if err := convertVDIToRaw(input.Reader, tmpRaw); err != nil {
-		os.Remove(tmpRawPath)
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, fmt.Errorf("failed to convert %s to raw image: %w", input.Path, err)
 	}
 
 	// Retrieve all partitions and the associated disk handle from the raw disk image.
-	partitionList, disk, err := common.GetDiskPartitions(tmpRawPath)
+	partitionList, disk, err := common.GetDiskPartitions(rawDiskIMGPath)
 	if err != nil {
-		os.Remove(tmpRawPath)
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, err
 	}
 
@@ -157,7 +177,7 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var embeddedFSs []*inventory.EmbeddedFS
 	for i, p := range partitionList {
 		partitionIndex := i + 1 // go-diskfs uses 1-based indexing
-		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("vdi", partitionIndex, p, disk, tmpRawPath, &refMu, &refCount)
+		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("vdi", partitionIndex, p, disk, pluginDir, pluginRoot, rawDiskIMGPath, &refMu, &refCount)
 		embeddedFSs = append(embeddedFSs, &inventory.EmbeddedFS{
 			Path:          fmt.Sprintf("%s:%d", input.Path, partitionIndex),
 			GetEmbeddedFS: getEmbeddedFS,

--- a/extractor/filesystem/embeddedfs/vmdk/vmdk.go
+++ b/extractor/filesystem/embeddedfs/vmdk/vmdk.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/common"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -147,23 +148,42 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		}()
 	}
 
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS set temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── vmdk
+	// |						└── valid.vmdk 								<--- A directory with the name set to the file discovered by the extractor
+	// │				        	├── partition-1-ext4					<--- A folder containing partition data
+	// │				        	│				└── private-key1.pem
+	// │				        	├── partition-2-exfat
+	// │				        	│				└── private-key2.pem
+	// │				        	├── partition-3-fat32
+	// │				        	│				└── private-key3.pem
+	// │				        	├── partition-4-ntfs
+	// │				        	│				└── private-key4.pem
+	// │				        	└── vmdk-12345.raw						<--- Converted disk image
+	pluginDir, pluginRoot, err := tempdir.CreateExtractorDir("vmdk", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
 	// Create a temporary file for the raw disk image
-	tmpRaw, err := os.CreateTemp("", "scalibr-vmdk-raw-*.raw")
+	rawDiskIMGPath, _, err := tempdir.CreateFile(pluginDir, "vmdk-*.raw")
 	if err != nil {
 		return inventory.Inventory{}, fmt.Errorf("failed to create temporary raw file: %w", err)
 	}
-	tmpRawPath := tmpRaw.Name()
 
 	// Convert VMDK to raw
-	if err := convertVMDKToRaw(vmdkPath, tmpRawPath); err != nil {
-		os.Remove(tmpRawPath)
+	if err := convertVMDKToRaw(vmdkPath, rawDiskIMGPath); err != nil {
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, fmt.Errorf("failed to convert %s to raw image: %w", vmdkPath, err)
 	}
 
 	// Retrieve all partitions and the associated disk handle from the raw disk image.
-	partitionList, disk, err := common.GetDiskPartitions(tmpRawPath)
+	partitionList, disk, err := common.GetDiskPartitions(rawDiskIMGPath)
 	if err != nil {
-		os.Remove(tmpRawPath)
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, err
 	}
 
@@ -175,7 +195,7 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var embeddedFSs []*inventory.EmbeddedFS
 	for i, p := range partitionList {
 		partitionIndex := i + 1 // go-diskfs uses 1-based indexing
-		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("vmdk", partitionIndex, p, disk, tmpRawPath, &refMu, &refCount)
+		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("vmdk", partitionIndex, p, disk, pluginDir, pluginRoot, rawDiskIMGPath, &refMu, &refCount)
 		embeddedFSs = append(embeddedFSs, &inventory.EmbeddedFS{
 			Path:          fmt.Sprintf("%s:%d", vmdkPath, partitionIndex),
 			GetEmbeddedFS: getEmbeddedFS,

--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -39,6 +39,7 @@ import (
 	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 var (
@@ -183,6 +184,10 @@ func runOnScanRoot(ctx context.Context, config *Config, scanRoot *scalibrfs.Scan
 
 	// Process embedded filesystems
 	var additionalInv inventory.Inventory
+	// seenMap is used for deduplication
+	seenMap := map[string]struct{}{}
+	// rawDiskImageFiles contains raw disk image files to be deleted
+	var rawDiskImageFiles []string
 	for _, embeddedFS := range inv.EmbeddedFSs {
 		// Mount the embedded filesystem
 		mountedFS, err := embeddedFS.GetEmbeddedFS(ctx)
@@ -247,7 +252,56 @@ func runOnScanRoot(ctx context.Context, config *Config, scanRoot *scalibrfs.Scan
 
 		// Collect temporary directories and raw files after traversal for removal.
 		if c, ok := mountedFS.(common.CloserWithTmpPaths); ok {
-			embeddedFS.TempPaths = c.TempPaths()
+			paths := c.TempPaths()
+
+			for _, p := range paths {
+				if p == "" {
+					continue
+				}
+
+				// Normalize path: ensure absolute
+				if !filepath.IsAbs(p) {
+					root, err := tempdir.GetRootPath()
+					if err != nil {
+						log.Infof("failed to get tempdir root path: %v", err)
+						continue
+					}
+					p = filepath.Join(root, p)
+				}
+
+				// Dedup check
+				if _, seen := seenMap[p]; seen {
+					continue
+				}
+
+				info, err := os.Stat(p)
+				if err != nil {
+					log.Infof("failed to stat temp path %s: %v", p, err)
+					continue
+				}
+
+				if info.IsDir() {
+					// Remove directory immediately
+					if err := tempdir.RemoveAll(p); err != nil {
+						log.Infof("failed to remove temp directory %s: %v", p, err)
+					}
+				} else {
+					// A single disk image may contain multiple partitions, so the raw disk image file
+					// must not be deleted prematurely. Removing it prematurely can lead to mount failures
+					// or runtime issues (e.g., nil pointer dereference).
+					// Therefore, this cleanup will be deferred until all embedded filesystems have been handled.
+					rawDiskImageFiles = append(rawDiskImageFiles, p)
+				}
+
+				seenMap[p] = struct{}{}
+			}
+		}
+	}
+
+	// Remove all converted raw disk image files created during embeddedFS extraction.
+	for _, rawDiskImage := range rawDiskImageFiles {
+		if err := tempdir.RemoveAll(rawDiskImage); err != nil {
+			log.Infof("failed to remove temp raw file %s: %v", rawDiskImage, err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv-scalibr
 
-go 1.24.6
+go 1.25
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.14

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -46,12 +46,6 @@ type EmbeddedFS struct {
 	// with the partition index from which the filesystem was extracted.
 	Path string
 
-	// TempPaths holds temporary files or directories created during extraction.
-	// These should be cleaned up once all extractors, annotators, and detectors
-	// have completed their operations.
-	// TempPaths will be set when there are temporary directories to clean up.
-	TempPaths []string
-
 	// GetEmbeddedFS is a function that mounts or initializes the underlying
 	// embedded filesystem and returns a scalibrfs.FS interface for accessing it.
 	// The returned filesystem should be closed or cleaned up by the caller

--- a/scalibr.go
+++ b/scalibr.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"runtime"
 	"slices"
@@ -48,6 +47,7 @@ import (
 	pl "github.com/google/osv-scalibr/plugin/list"
 	"github.com/google/osv-scalibr/result"
 	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/tempdir"
 	"github.com/google/osv-scalibr/version"
 	"go.uber.org/multierr"
 
@@ -242,16 +242,10 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 
 	sro.Inventory = inv
 	// Defer cleanup of all temporary files and directories created during extraction.
-	// This function iterates over all EmbeddedFS entries in the inventory and
-	// removes their associated TempPaths.
-	// Any failures during removal are logged but do not interrupt execution.
 	defer func() {
-		for _, embeddedFS := range sro.Inventory.EmbeddedFSs {
-			for _, tmpPath := range embeddedFS.TempPaths {
-				if err := os.RemoveAll(tmpPath); err != nil {
-					log.Infof("Failed to remove %s", tmpPath)
-				}
-			}
+		// Remove the root temporary directory and all it's subdirectories that we created for this run of scalibr.
+		if err := tempdir.RemoveRoot(); err != nil {
+			log.Infof("Failed to remove tempdir root: %v", err)
 		}
 	}()
 	sro.PluginStatus = append(sro.PluginStatus, extractorStatus...)

--- a/tempdir/tempdir.go
+++ b/tempdir/tempdir.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tempdir provides a single root temporary directory for the lifetime
+// of the process with automatic signal-based cleanup and optional debug mode.
+package tempdir
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+)
+
+var (
+	root     *os.Root
+	errRoot  error
+	once     sync.Once
+	debug    bool
+	rootPath string
+)
+
+// SetDebug disables automatic cleanup when enabled.
+func SetDebug(enabled bool) {
+	debug = enabled
+}
+
+// initRoot creates the root directory once.
+func initRoot() {
+	rootPath, errRoot = os.MkdirTemp("", "osv-scalibr-run-*")
+	if errRoot != nil {
+		return
+	}
+	root, errRoot = os.OpenRoot(rootPath)
+	if errRoot != nil {
+		return
+	}
+	setupSignalCleanup()
+}
+
+// Root returns the root directory for the current run.
+func Root() (*os.Root, error) {
+	once.Do(initRoot)
+	if errRoot != nil {
+		return nil, errRoot
+	}
+	return root, nil
+}
+
+// GetRootPath returns the root directory path for the current run.
+func GetRootPath() (string, error) {
+	_, err := Root()
+	if err != nil {
+		return "", err
+	}
+	return rootPath, nil
+}
+
+// CreateDir creates and opens a subdirectory as a new os.Root (chroot-like).
+func CreateDir(name string) (string, *os.Root, error) {
+	r, err := Root()
+	if err != nil {
+		return "", nil, err
+	}
+	// Ensure dir exists
+	if err := r.MkdirAll(name, 0o755); err != nil && !os.IsExist(err) {
+		return "", nil, err
+	}
+
+	newRoot, err := r.OpenRoot(name)
+	if err != nil {
+		return "", nil, err
+	}
+	return name, newRoot, nil
+}
+
+// CreateExtractorDir returns a sub-root for the extractor.
+// Layout: <SCALIBR-TMP-ROOT>/extractor/<plugin>/<filename>
+func CreateExtractorDir(plugin, filename string) (string, *os.Root, error) {
+	dir := filepath.Join("extractor", plugin, filepath.Base(filename))
+	return CreateDir(dir)
+}
+
+// CreateEnricherDir returns a sub-root for the enricher.
+// Layout: <SCALIBR-TMP-ROOT>/enricher/<plugin>/<filename>
+func CreateEnricherDir(plugin, filename string) (string, *os.Root, error) {
+	dir := filepath.Join("enricher", plugin, filepath.Base(filename))
+	return CreateDir(dir)
+}
+
+// CreateDetectorDir returns a sub-root for the detector.
+// Layout: <SCALIBR-TMP-ROOT>/enricher/<plugin>/<filename>
+func CreateDetectorDir(plugin, filename string) (string, *os.Root, error) {
+	dir := filepath.Join("detector", plugin, filepath.Base(filename))
+	return CreateDir(dir)
+}
+
+// CreateFile creates a temp file under the given (sub)directory using os.Root.
+// Since os.Root does not have CreateTemp yet, we implement it manually.
+func CreateFile(dir, pattern string) (string, *os.File, error) {
+	r, err := Root()
+	if err != nil {
+		return "", nil, err
+	}
+
+	targetDir := "."
+	if dir != "" {
+		targetDir = dir
+		if err := r.MkdirAll(targetDir, 0o755); err != nil {
+			return "", nil, fmt.Errorf("failed to create dir %s: %w", targetDir, err)
+		}
+	}
+
+	// os.Root.CreateTemp is not available
+	f, err := os.CreateTemp("", pattern) // temporary in default temp
+	if err != nil {
+		return "", nil, err
+	}
+	fname := f.Name()
+	f.Close()
+
+	// Move it under our root (safer than CreateTemp with full path)
+	newName := filepath.Join(rootPath, targetDir, filepath.Base(fname))
+	if err := os.Rename(fname, newName); err != nil {
+		os.Remove(fname)
+		return "", nil, err
+	}
+
+	finalF, err := r.OpenFile(filepath.Join(targetDir, filepath.Base(newName)), os.O_RDWR, 0o666)
+	if err != nil {
+		os.Remove(newName)
+		return "", nil, err
+	}
+
+	return newName, finalF, nil
+}
+
+// RemoveAll removes a specific subdirectory
+func RemoveAll(name string) error {
+	r, err := Root()
+	if err != nil {
+		return err
+	}
+	if debug {
+		return nil
+	}
+	if filepath.IsAbs(name) {
+		err = os.RemoveAll(name)
+		return err
+	}
+	return r.RemoveAll(name)
+}
+
+// RemoveRoot removes the entire temp root.
+func RemoveRoot() error {
+	if debug {
+		return nil
+	}
+	if root == nil {
+		return nil
+	}
+	root.Close()
+	err := os.RemoveAll(rootPath)
+	return err
+}
+
+// CloseRoot for manual
+func CloseRoot() error {
+	if root != nil {
+		return root.Close()
+	}
+	return nil
+}
+
+// setupSignalCleanup automatically cleans temp directory on interrupts.
+func setupSignalCleanup() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
+	go func() {
+		<-c
+		if !debug && rootPath != "" {
+			os.RemoveAll(rootPath)
+		}
+	}()
+}

--- a/tempdir/tempdir_test.go
+++ b/tempdir/tempdir_test.go
@@ -1,0 +1,212 @@
+package tempdir_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/tempdir"
+)
+
+func TestRootCreation(t *testing.T) {
+	root, err := tempdir.Root()
+	if err != nil {
+		t.Fatalf("Root() returned error: %v", err)
+	}
+	if root == nil {
+		t.Fatal("Root() returned nil")
+	}
+
+	info, err := os.Stat(rootPathHelper(t))
+	if err != nil {
+		t.Fatalf("Root directory does not exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("Root path is not a directory")
+	}
+}
+
+func TestRootIsSingleton(t *testing.T) {
+	root1, err1 := tempdir.Root()
+	root2, err2 := tempdir.Root()
+	if err1 != nil || err2 != nil {
+		t.Fatalf("Root() failed: %v, %v", err1, err2)
+	}
+	if root1 != root2 {
+		t.Fatal("Expected same *os.Root instance")
+	}
+}
+
+func TestCreateDir(t *testing.T) {
+	// Get the scalibr root path for current run.
+	rootPath, err := tempdir.GetRootPath()
+	if err != nil {
+		t.Fatalf("failed to get scalibr rootPath")
+	}
+
+	name := "testdir"
+	path, root, err := tempdir.CreateDir(name)
+	if err != nil {
+		t.Fatalf("CreateDir() failed: %v", err)
+	}
+	defer root.Close()
+
+	if path == "" {
+		t.Fatal("CreateDir returned empty path")
+	}
+
+	info, err := os.Stat(filepath.Join(rootPath, path))
+	if err != nil {
+		t.Fatalf("Directory does not exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("Path is not a directory")
+	}
+}
+
+func TestCreateNestedDir(t *testing.T) {
+	name := "nested/testdir"
+	_, root, err := tempdir.CreateDir(name)
+	if err != nil {
+		t.Fatalf("CreateDir() failed: %v", err)
+	}
+	defer root.Close()
+
+	if _, err := os.Stat(filepath.Join(rootPathHelper(t), name)); err != nil {
+		t.Fatalf("Nested directory not created: %v", err)
+	}
+}
+
+func TestCreateExtractorDir(t *testing.T) {
+	plugin := "qcow2"
+	filename := "test.img"
+
+	path, root, err := tempdir.CreateExtractorDir(plugin, filename)
+	if err != nil {
+		t.Fatalf("CreateExtractorDir() failed: %v", err)
+	}
+	defer root.Close()
+
+	if _, err := os.Stat(filepath.Join(rootPathHelper(t), path)); err != nil {
+		t.Fatalf("Directory not created: %v", err)
+	}
+
+	expectedSuffix := filepath.Join("extractor", plugin, filepath.Base(filename))
+	if !strings.HasSuffix(path, expectedSuffix) {
+		t.Fatalf("Unexpected directory structure: got %s, expected suffix %s", path, expectedSuffix)
+	}
+}
+
+func TestCreateEnricherDir(t *testing.T) {
+	plugin := "osv"
+	filename := "package.json"
+
+	path, root, err := tempdir.CreateEnricherDir(plugin, filename)
+	if err != nil {
+		t.Fatalf("CreateEnricherDir() failed: %v", err)
+	}
+	defer root.Close()
+
+	if _, err := os.Stat(filepath.Join(rootPathHelper(t), path)); err != nil {
+		t.Fatalf("Directory not created: %v", err)
+	}
+}
+
+func TestCreateDetectorDir(t *testing.T) {
+	plugin := "secrets"
+	filename := "dump.txt"
+
+	path, root, err := tempdir.CreateDetectorDir(plugin, filename)
+	if err != nil {
+		t.Fatalf("CreateDetectorDir() failed: %v", err)
+	}
+	defer root.Close()
+
+	if _, err := os.Stat(filepath.Join(rootPathHelper(t), path)); err != nil {
+		t.Fatalf("Directory not created: %v", err)
+	}
+}
+
+func TestCreateFile_DefaultRoot(t *testing.T) {
+	path, file, err := tempdir.CreateFile("", "test-*.txt")
+	if err != nil {
+		t.Fatalf("CreateFile() failed: %v", err)
+	}
+	defer file.Close()
+
+	if path == "" {
+		t.Fatal("Empty file path returned")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Temp file does not exist: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatal("Expected file, got directory")
+	}
+}
+
+func TestCreateFile_InSubDir(t *testing.T) {
+	dir := "subdir1/subdir2"
+	path, file, err := tempdir.CreateFile(dir, "nested-*.log")
+	if err != nil {
+		t.Fatalf("CreateFile() failed: %v", err)
+	}
+	defer file.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Temp file does not exist: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatal("Expected file, got directory")
+	}
+}
+
+func TestRemoveAll(t *testing.T) {
+	name := "cleanup_test"
+	_, root, err := tempdir.CreateDir(name)
+	if err != nil {
+		t.Fatalf("CreateDir failed: %v", err)
+	}
+	root.Close()
+
+	err = tempdir.RemoveAll(name)
+	if err != nil {
+		t.Fatalf("RemoveAll() failed: %v", err)
+	}
+
+	fullPath := filepath.Join(rootPathHelper(t), name)
+	if _, err := os.Stat(fullPath); !os.IsNotExist(err) {
+		t.Fatalf("Directory still exists after removal")
+	}
+}
+
+func TestRemoveRoot(t *testing.T) {
+	_, root, err := tempdir.CreateDir("root_cleanup_test")
+	if err != nil {
+		t.Fatalf("CreateDir failed: %v", err)
+	}
+	root.Close()
+
+	err = tempdir.RemoveRoot()
+	if err != nil {
+		t.Fatalf("RemoveRoot() failed: %v", err)
+	}
+
+	if _, err := os.Stat(rootPathHelper(t)); !os.IsNotExist(err) {
+		t.Fatalf("Root directory still exists after cleanup")
+	}
+}
+
+// Helper to get root path safely
+func rootPathHelper(t *testing.T) string {
+	t.Helper()
+	path, err := tempdir.GetRootPath()
+	if err != nil {
+		t.Fatalf("GetRootPath failed: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
Introduce a tempdir package to manage temporary directories for a program run.

The package creates a root directory (osv-scalibr-run-*) in the system temp location on first use and allows packages to create named subdirectories under it. This ensures all temporary artifacts generated during execution
are grouped under a single root.

Features:
- Lazy initialization using sync.Once
- Cross-platform temp directory creation
- Subdirectory creation via CreateDir()
- Plugin specific directory creation via CreateExtractorDir(), CreateEnricherDir(), and CreateDetectorDir()
- Cleanup via RemoveAll()
- File creation via CreateFile()
- Root directory cleanup via RemoveRoot()
- Optional debug mode to preserve artifacts
- Signal-based cleanup on program interruption

This simplifies temporary file management across multiple packages and
ensures consistent cleanup behavior.

Closes: https://github.com/google/osv-scalibr/issues/1637