### PR TITLE
PRP: Add AMQP/AMQPS credential validation for RabbitMQ URLs

### DIFF
--- a/veles/secrets/urlcreds/detector_test.go
+++ b/veles/secrets/urlcreds/detector_test.go
@@ -91,6 +91,20 @@ func TestDetector_truePositives(t *testing.T) {
 				urlcreds.Credentials{FullURL: "http://:pass%3Aword@example.com"},
 			},
 		},
+		{
+			name:  "amqp_url_with_credentials",
+			input: "amqp://guest:guest@rabbit.example.com:5672/myvhost",
+			want: []veles.Secret{
+				urlcreds.Credentials{FullURL: "amqp://guest:guest@rabbit.example.com:5672/myvhost"},
+			},
+		},
+		{
+			name:  "amqps_url_with_credentials",
+			input: "amqps://user:s3cret@mq.prod.example.com:5671/prod",
+			want: []veles.Secret{
+				urlcreds.Credentials{FullURL: "amqps://user:s3cret@mq.prod.example.com:5671/prod"},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/veles/secrets/urlcreds/validator.go
+++ b/veles/secrets/urlcreds/validator.go
@@ -70,6 +70,10 @@ func (v *Validator) Validate(ctx context.Context, secret Credentials) (veles.Val
 		validator = &validators.FTPValidator{}
 	case "sftp":
 		validator = &validators.SFTPValidator{}
+	case "amqp":
+		validator = &validators.AMQPValidator{UseTLS: false}
+	case "amqps":
+		validator = &validators.AMQPValidator{UseTLS: true}
 	default:
 		return veles.ValidationFailed, fmt.Errorf("scheme %q not supported", scheme)
 	}

--- a/veles/secrets/urlcreds/validator_test.go
+++ b/veles/secrets/urlcreds/validator_test.go
@@ -33,9 +33,11 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -55,6 +57,7 @@ func TestValidator(t *testing.T) {
 	digestHTTPSvrWithCookies := mockDigestHTTPServer(t, "admin", "pass", true)
 	ftpAddr := mockFTPServer(t, "user", "pass")
 	sftpAddr := mockSSHServer(t, "sshuser", "sshpass")
+	amqpAddr := mockAMQPServer(t, "mquser", "mqpass")
 
 	cases := []struct {
 		name string
@@ -112,6 +115,17 @@ func TestValidator(t *testing.T) {
 		{
 			name: "sftp_invalid",
 			url:  "sftp://sshuser:wrong@" + sftpAddr,
+			want: veles.ValidationInvalid,
+		},
+		// AMQP Tests
+		{
+			name: "amqp_valid",
+			url:  fmt.Sprintf("amqp://mquser:mqpass@%s/", amqpAddr),
+			want: veles.ValidationValid,
+		},
+		{
+			name: "amqp_invalid",
+			url:  fmt.Sprintf("amqp://mquser:wrong@%s/", amqpAddr),
 			want: veles.ValidationInvalid,
 		},
 	}
@@ -335,4 +349,187 @@ func mockDigestHTTPServer(t *testing.T, validUser, validPass string, testCookies
 
 	t.Cleanup(server.Close)
 	return server
+}
+
+// mockAMQPServer creates a minimal AMQP 0-9-1 server that validates credentials via SASL PLAIN.
+func mockAMQPServer(t *testing.T, validUser, validPass string) string {
+	t.Helper()
+
+	const (
+		classConnection = 10
+		methodStart     = 10
+		methodStartOK   = 11
+		methodTune      = 30
+		methodClose     = 50
+	)
+
+	l, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+
+				// Read AMQP protocol header (8 bytes: "AMQP" + 4 version bytes).
+				header := make([]byte, 8)
+				if _, err := io.ReadFull(c, header); err != nil {
+					return
+				}
+				if string(header[:4]) != "AMQP" {
+					return
+				}
+
+				// Send Connection.Start.
+				if err := amqpWriteMethodFrame(c, methodStart, amqpConnectionStartPayload()); err != nil {
+					return
+				}
+
+				// Read Connection.Start-Ok.
+				classID, methodID, payload, err := amqpTestReadMethodFrame(c)
+				if err != nil || classID != classConnection || methodID != methodStartOK {
+					return
+				}
+
+				// Parse SASL credentials from the Start-Ok payload.
+				user, pass, ok := amqpParseSASLPlain(payload)
+				if !ok {
+					_ = amqpWriteMethodFrame(c, methodClose, amqpConnectionClosePayload(403, "ACCESS_REFUSED"))
+					return
+				}
+
+				if user == validUser && pass == validPass {
+					// Send Connection.Tune (authentication succeeded).
+					_ = amqpWriteMethodFrame(c, methodTune, amqpConnectionTunePayload())
+				} else {
+					// Send Connection.Close (authentication failed).
+					_ = amqpWriteMethodFrame(c, methodClose, amqpConnectionClosePayload(403, "ACCESS_REFUSED"))
+				}
+			}(conn)
+		}
+	}()
+	return l.Addr().String()
+}
+
+// amqpWriteMethodFrame writes a single AMQP Connection-class method frame.
+func amqpWriteMethodFrame(w io.Writer, methodID uint16, args []byte) error {
+	const classConnection uint16 = 10
+	payloadSize := 4 + len(args)
+	frame := make([]byte, 7+payloadSize+1)
+	frame[0] = 1 // method frame
+	binary.BigEndian.PutUint16(frame[1:3], 0)
+	binary.BigEndian.PutUint32(frame[3:7], uint32(payloadSize))
+	binary.BigEndian.PutUint16(frame[7:9], classConnection)
+	binary.BigEndian.PutUint16(frame[9:11], methodID)
+	copy(frame[11:], args)
+	frame[len(frame)-1] = 0xCE
+	_, err := w.Write(frame)
+	return err
+}
+
+// amqpTestReadMethodFrame reads a single AMQP method frame.
+func amqpTestReadMethodFrame(r io.Reader) (classID, methodID uint16, payload []byte, err error) {
+	header := make([]byte, 7)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return 0, 0, nil, err
+	}
+	size := binary.BigEndian.Uint32(header[3:7])
+	buf := make([]byte, size+1)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return 0, 0, nil, err
+	}
+	if len(buf) < 5 {
+		return 0, 0, nil, errors.New("payload too short")
+	}
+	classID = binary.BigEndian.Uint16(buf[0:2])
+	methodID = binary.BigEndian.Uint16(buf[2:4])
+	return classID, methodID, buf[4:size], nil
+}
+
+// amqpConnectionStartPayload builds a minimal Connection.Start payload.
+func amqpConnectionStartPayload() []byte {
+	// version_major(1) + version_minor(1) + server_properties(table, empty=4) +
+	// mechanisms(long-string "PLAIN") + locales(long-string "en_US")
+	mechanism := "PLAIN"
+	locale := "en_US"
+	size := 2 + 4 + 4 + len(mechanism) + 4 + len(locale)
+	buf := make([]byte, size)
+	buf[0] = 0 // version_major
+	buf[1] = 9 // version_minor
+	offset := 2
+	binary.BigEndian.PutUint32(buf[offset:], 0) // empty server_properties table
+	offset += 4
+	binary.BigEndian.PutUint32(buf[offset:], uint32(len(mechanism)))
+	offset += 4
+	copy(buf[offset:], mechanism)
+	offset += len(mechanism)
+	binary.BigEndian.PutUint32(buf[offset:], uint32(len(locale)))
+	offset += 4
+	copy(buf[offset:], locale)
+	return buf
+}
+
+// amqpConnectionTunePayload builds a minimal Connection.Tune payload.
+func amqpConnectionTunePayload() []byte {
+	// channel_max(2) + frame_max(4) + heartbeat(2)
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint16(buf[0:2], 2047)   // channel_max
+	binary.BigEndian.PutUint32(buf[2:6], 131072) // frame_max
+	binary.BigEndian.PutUint16(buf[6:8], 60)     // heartbeat
+	return buf
+}
+
+// amqpConnectionClosePayload builds a minimal Connection.Close payload.
+func amqpConnectionClosePayload(code uint16, text string) []byte {
+	// reply_code(2) + reply_text(short-string) + class_id(2) + method_id(2)
+	size := 2 + 1 + len(text) + 4
+	buf := make([]byte, size)
+	binary.BigEndian.PutUint16(buf[0:2], code)
+	buf[2] = byte(len(text))
+	copy(buf[3:], text)
+	offset := 3 + len(text)
+	binary.BigEndian.PutUint16(buf[offset:], 0)   // class_id
+	binary.BigEndian.PutUint16(buf[offset+2:], 0) // method_id
+	return buf
+}
+
+// amqpParseSASLPlain extracts username and password from a Connection.Start-Ok payload.
+// The payload format is: client_properties(table) + mechanism(short-string) + response(long-string) + locale(short-string).
+// The SASL PLAIN response is: \x00username\x00password.
+func amqpParseSASLPlain(payload []byte) (user, pass string, ok bool) {
+	if len(payload) < 4 {
+		return "", "", false
+	}
+	// Skip client_properties table.
+	tableSize := binary.BigEndian.Uint32(payload[0:4])
+	offset := 4 + int(tableSize)
+	if offset >= len(payload) {
+		return "", "", false
+	}
+	// Skip mechanism short-string.
+	mechLen := int(payload[offset])
+	offset += 1 + mechLen
+	if offset+4 > len(payload) {
+		return "", "", false
+	}
+	// Read response long-string.
+	respLen := binary.BigEndian.Uint32(payload[offset : offset+4])
+	offset += 4
+	if offset+int(respLen) > len(payload) {
+		return "", "", false
+	}
+	response := string(payload[offset : offset+int(respLen)])
+	// SASL PLAIN format: \x00username\x00password
+	parts := strings.SplitN(response, "\x00", 3)
+	if len(parts) != 3 || parts[0] != "" {
+		return "", "", false
+	}
+	return parts[1], parts[2], true
 }

--- a/veles/secrets/urlcreds/validators/amqp.go
+++ b/veles/secrets/urlcreds/validators/amqp.go
@@ -1,0 +1,225 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/google/osv-scalibr/veles"
+)
+
+const (
+	// AMQP 0-9-1 frame constants.
+	amqpFrameMethod = 1
+	amqpFrameEnd    = 0xCE
+
+	// Connection class and methods.
+	amqpClassConnection = 10
+	amqpMethodStart     = 10
+	amqpMethodStartOK   = 11
+	amqpMethodTune      = 30
+	amqpMethodClose     = 50
+	amqpMethodSecure    = 20
+
+	// Default ports.
+	defaultAMQPPort  = "5672"
+	defaultAMQPSPort = "5671"
+)
+
+// amqpProtocolHeader is the AMQP 0-9-1 protocol header sent by the client to initiate the connection.
+var amqpProtocolHeader = []byte{'A', 'M', 'Q', 'P', 0, 0, 9, 1}
+
+// AMQPValidator validates AMQP URL credentials by performing the AMQP 0-9-1 handshake.
+type AMQPValidator struct {
+	UseTLS bool
+}
+
+// Validate connects to the AMQP server and attempts SASL PLAIN authentication.
+func (a *AMQPValidator) Validate(ctx context.Context, u *url.URL) (veles.ValidationStatus, error) {
+	timeout := 10 * time.Second
+	addr := amqpHostWithDefaultPort(u.Host, a.defaultPort())
+
+	dialer := &net.Dialer{Timeout: timeout}
+	rawConn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return veles.ValidationFailed, err
+	}
+	defer rawConn.Close()
+
+	if err := rawConn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return veles.ValidationFailed, errors.New("error setting connection deadline")
+	}
+
+	var conn io.ReadWriter = rawConn
+	if a.UseTLS {
+		tlsConn := tls.Client(rawConn, &tls.Config{InsecureSkipVerify: true})
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			return veles.ValidationFailed, fmt.Errorf("TLS handshake failed: %w", err)
+		}
+		conn = tlsConn
+	}
+
+	// Send AMQP 0-9-1 protocol header.
+	if _, err := conn.Write(amqpProtocolHeader); err != nil {
+		return veles.ValidationFailed, fmt.Errorf("error sending protocol header: %w", err)
+	}
+
+	// Read Connection.Start from the server.
+	classID, methodID, err := amqpReadMethodFrame(conn)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("error reading Connection.Start: %w", err)
+	}
+	if classID != amqpClassConnection || methodID != amqpMethodStart {
+		return veles.ValidationFailed, fmt.Errorf("expected Connection.Start, got class=%d method=%d", classID, methodID)
+	}
+
+	// Send Connection.Start-Ok with SASL PLAIN credentials.
+	pass, _ := u.User.Password()
+	if err := amqpWriteStartOK(conn, u.User.Username(), pass); err != nil {
+		return veles.ValidationFailed, fmt.Errorf("error sending Connection.Start-Ok: %w", err)
+	}
+
+	// Read the server response.
+	// Connection.Tune means authentication succeeded.
+	// Connection.Close means authentication failed (ACCESS_REFUSED).
+	// Connection.Secure means the server wants additional SASL steps (treat as failed).
+	classID, methodID, err = amqpReadMethodFrame(conn)
+	if err != nil {
+		// If the server closes the connection, authentication failed.
+		return veles.ValidationInvalid, nil
+	}
+	if classID == amqpClassConnection && methodID == amqpMethodTune {
+		return veles.ValidationValid, nil
+	}
+	if classID == amqpClassConnection && (methodID == amqpMethodClose || methodID == amqpMethodSecure) {
+		return veles.ValidationInvalid, nil
+	}
+	return veles.ValidationFailed, fmt.Errorf("unexpected response: class=%d method=%d", classID, methodID)
+}
+
+func (a *AMQPValidator) defaultPort() string {
+	if a.UseTLS {
+		return defaultAMQPSPort
+	}
+	return defaultAMQPPort
+}
+
+// amqpHostWithDefaultPort adds a default port to the host if none is specified.
+func amqpHostWithDefaultPort(host, defaultPort string) string {
+	if _, _, err := net.SplitHostPort(host); err != nil {
+		return net.JoinHostPort(host, defaultPort)
+	}
+	return host
+}
+
+// amqpReadMethodFrame reads a single AMQP 0-9-1 method frame and returns the class and method IDs.
+func amqpReadMethodFrame(r io.Reader) (classID, methodID uint16, err error) {
+	// Frame header: type(1) + channel(2) + size(4) = 7 bytes.
+	header := make([]byte, 7)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return 0, 0, fmt.Errorf("error reading frame header: %w", err)
+	}
+
+	frameType := header[0]
+	if frameType != amqpFrameMethod {
+		return 0, 0, fmt.Errorf("expected method frame (type 1), got type %d", frameType)
+	}
+
+	size := binary.BigEndian.Uint32(header[3:7])
+
+	// Read payload + frame end byte.
+	buf := make([]byte, size+1)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return 0, 0, fmt.Errorf("error reading frame payload: %w", err)
+	}
+
+	if buf[size] != amqpFrameEnd {
+		return 0, 0, errors.New("invalid frame end marker")
+	}
+
+	if size < 4 {
+		return 0, 0, errors.New("payload too short for method frame")
+	}
+
+	classID = binary.BigEndian.Uint16(buf[0:2])
+	methodID = binary.BigEndian.Uint16(buf[2:4])
+	return classID, methodID, nil
+}
+
+// amqpWriteStartOK writes a Connection.Start-Ok method frame with SASL PLAIN authentication.
+func amqpWriteStartOK(w io.Writer, username, password string) error {
+	// SASL PLAIN response: \x00username\x00password
+	saslResponse := "\x00" + username + "\x00" + password
+	mechanism := "PLAIN"
+	locale := "en_US"
+
+	// Method payload:
+	//   class_id(2) + method_id(2)
+	//   + client_properties: empty table = uint32(0)
+	//   + mechanism: short-string
+	//   + response: long-string
+	//   + locale: short-string
+	payloadSize := 4 + // class_id + method_id
+		4 + // empty client_properties table
+		1 + len(mechanism) + // short-string: mechanism
+		4 + len(saslResponse) + // long-string: SASL response
+		1 + len(locale) // short-string: locale
+
+	frame := make([]byte, 7+payloadSize+1)
+	frame[0] = amqpFrameMethod
+	binary.BigEndian.PutUint16(frame[1:3], 0)                   // channel 0
+	binary.BigEndian.PutUint32(frame[3:7], uint32(payloadSize)) // payload size
+	offset := 7
+
+	binary.BigEndian.PutUint16(frame[offset:], amqpClassConnection)
+	offset += 2
+	binary.BigEndian.PutUint16(frame[offset:], amqpMethodStartOK)
+	offset += 2
+
+	// Empty client_properties table.
+	binary.BigEndian.PutUint32(frame[offset:], 0)
+	offset += 4
+
+	// Mechanism: short-string "PLAIN".
+	frame[offset] = byte(len(mechanism))
+	offset++
+	copy(frame[offset:], mechanism)
+	offset += len(mechanism)
+
+	// SASL response: long-string.
+	binary.BigEndian.PutUint32(frame[offset:], uint32(len(saslResponse)))
+	offset += 4
+	copy(frame[offset:], saslResponse)
+	offset += len(saslResponse)
+
+	// Locale: short-string "en_US".
+	frame[offset] = byte(len(locale))
+	offset++
+	copy(frame[offset:], locale)
+	offset += len(locale)
+
+	frame[offset] = amqpFrameEnd
+
+	_, err := w.Write(frame)
+	return err
+}


### PR DESCRIPTION
## Description

This PR adds AMQP and AMQPS protocol support to the existing `urlcreds` validator, enabling validation of RabbitMQ credentials embedded in `amqp://` and `amqps://` URLs.

The existing `urlcreds` detector already identifies AMQP URLs with embedded credentials. This PR adds the missing validation step by implementing a minimal AMQP 0-9-1 handshake with SASL PLAIN authentication.

## Changes

- **`validators/amqp.go`**: New `AMQPValidator` that performs the AMQP 0-9-1 protocol handshake:
  1. Sends the AMQP protocol header
  2. Reads `Connection.Start` from the server
  3. Sends `Connection.Start-Ok` with SASL PLAIN credentials
  4. Reads the response: `Connection.Tune` = valid, `Connection.Close` = invalid
  - Supports both plaintext AMQP (port 5672) and TLS-encrypted AMQPS (port 5671)
  - Adds default port resolution when the URL omits the port

- **`validator.go`**: Routes `amqp` and `amqps` URL schemes to the new `AMQPValidator`

- **`validator_test.go`**: Adds a mock AMQP server and test cases for both valid and invalid credentials

- **`detector_test.go`**: Adds detection test cases for `amqp://` and `amqps://` URLs

## Testing

- All existing tests pass (14 test cases across detector + validator)
- New AMQP tests: `amqp_valid`, `amqp_invalid` — both pass
- New detection tests: `amqp_url_with_credentials`, `amqps_url_with_credentials` — both pass
- golangci-lint: 0 issues
- Tests run twice to verify no flaky failures

## References

- RabbitMQ URI Specification: https://www.rabbitmq.com/docs/uri-spec
- AMQP 0-9-1 Protocol: https://www.rabbitmq.com/docs/amqp-0-9-1-reference

Fixes #1019