### PR TITLE
Migrate EmbeddedFS extractors to use tempdir utility

### DIFF
--- a/extractor/filesystem/embeddedfs/archive/archive.go
+++ b/extractor/filesystem/embeddedfs/archive/archive.go
@@ -29,6 +29,7 @@ import (
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -94,10 +95,21 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		return inventory.Inventory{}, errors.New("input.Reader is nil")
 	}
 
-	var tempDir string
-	var err error
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS sets temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── archive
+	// |						└── valid.tar 					<--- A directory with the name set to the file discovered by the extractor
+	// │				        	├── bin						<--- A folder containing archive data
+	// │				        	│				└── bash	<--- A file inside /bin directory
+	pluginDir, err := tempdir.CreateExtractorDir("archive", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
 	if strings.HasSuffix(input.Path, ".tar") {
-		tempDir, err = common.TARToTempDir(input.Reader)
+		err = common.TARToTempDir(pluginDir, input.Reader)
 		if err != nil {
 			return inventory.Inventory{}, fmt.Errorf("common.TARToTempDir(%q): %w", input.Path, err)
 		}
@@ -106,7 +118,7 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		if err != nil {
 			return inventory.Inventory{}, fmt.Errorf("gzip.NewReader(%q): %w", input.Path, err)
 		}
-		tempDir, err = common.TARToTempDir(reader)
+		err = common.TARToTempDir(pluginDir, reader)
 		if err != nil {
 			return inventory.Inventory{}, fmt.Errorf("common.TARToTempDir(%q): %w", input.Path, err)
 		}
@@ -118,9 +130,9 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var refMu sync.Mutex
 	getEmbeddedFS := func(ctx context.Context) (scalibrfs.FS, error) {
 		return &common.EmbeddedDirFS{
-			FS:       scalibrfs.DirFS(tempDir),
+			FS:       scalibrfs.DirFS(pluginDir),
 			File:     nil,
-			TmpPaths: []string{tempDir},
+			TmpPaths: []string{pluginDir},
 			RefCount: &refCount,
 			RefMu:    &refMu,
 		}, nil

--- a/extractor/filesystem/embeddedfs/common/common.go
+++ b/extractor/filesystem/embeddedfs/common/common.go
@@ -38,6 +38,7 @@ import (
 	"github.com/dsoprea/go-exfat"
 	"github.com/google/osv-scalibr/artifact/image/symlink"
 	scalibrfs "github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/tempdir"
 	"github.com/masahiro331/go-ext4-filesystem/ext4"
 	"www.velocidex.com/golang/go-ntfs/parser"
 )
@@ -376,13 +377,13 @@ type CloserWithTmpPaths interface {
 }
 
 // GetDiskPartitions opens a raw disk image and returns its partitions along with the disk handle.
-func GetDiskPartitions(tmpRawPath string) ([]part.Partition, *disk.Disk, error) {
+func GetDiskPartitions(rawDiskIMGPath string) ([]part.Partition, *disk.Disk, error) {
 	// Open the raw disk image with go-diskfs
-	disk, err := diskfs.Open(tmpRawPath, diskfs.WithOpenMode(diskfs.ReadOnly))
+	disk, err := diskfs.Open(rawDiskIMGPath, diskfs.WithOpenMode(diskfs.ReadOnly))
 	if err != nil {
 		disk.Close()
-		os.Remove(tmpRawPath)
-		return nil, nil, fmt.Errorf("failed to open raw disk image %s: %w", tmpRawPath, err)
+		os.Remove(rawDiskIMGPath)
+		return nil, nil, fmt.Errorf("failed to open raw disk image %s: %w", rawDiskIMGPath, err)
 	}
 
 	partitions, err := disk.GetPartitionTable()
@@ -399,23 +400,37 @@ func GetDiskPartitions(tmpRawPath string) ([]part.Partition, *disk.Disk, error) 
 }
 
 // NewPartitionEmbeddedFSGetter creates a lazy getter function for an embedded filesystem from a disk partition.
-func NewPartitionEmbeddedFSGetter(pluginName string, partitionIndex int, p part.Partition, disk *disk.Disk, tmpRawPath string, refMu *sync.Mutex, refCount *int32) func(context.Context) (scalibrfs.FS, error) {
+func NewPartitionEmbeddedFSGetter(pluginName string, partitionIndex int, p part.Partition, disk *disk.Disk, pluginDir string, rawDiskIMGPath string, refMu *sync.Mutex, refCount *int32) func(context.Context) (scalibrfs.FS, error) {
 	return func(ctx context.Context) (scalibrfs.FS, error) {
 		// Get partition offset and size (already multiplied by sector size)
 		offset := p.GetStart()
 		size := p.GetSize()
 
 		// Open raw image for filesystem parsers
-		f, err := os.Open(tmpRawPath)
+		f, err := os.Open(rawDiskIMGPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open raw image %s: %w", tmpRawPath, err)
+			return nil, fmt.Errorf("failed to open raw image %s: %w", rawDiskIMGPath, err)
 		}
 
 		section := io.NewSectionReader(f, offset, size)
 		fsType := DetectFilesystem(section, 0)
 
 		// Create a temporary directory for extracted files
-		tempDir, err := os.MkdirTemp("", fmt.Sprintf("scalibr-%s-part-%s-%d-", pluginName, fsType, partitionIndex))
+		// Disk layout will be similar to the following in the OS set temporary directory:
+		// ├── osv-scalibr-run-953505549
+		// │				└── extractor
+		// │				    └── vdi
+		// |						└── valid.vdi 								<--- File discovered by the extractor
+		// │				        	├── partition-1-ext4					<--- A folder containing partition data
+		// │				        	│				└── private-key1.pem
+		// │				        	├── partition-2-exfat
+		// │				        	│				└── private-key2.pem
+		// │				        	├── partition-3-fat32
+		// │				        	│				└── private-key3.pem
+		// │				        	├── partition-4-ntfs
+		// │				        	│				└── private-key4.pem
+		// │				        	└── vdi-12345.raw 						<--- Converted disk image
+		tempDir, err := tempdir.CreateDir(filepath.Join(pluginDir, fmt.Sprintf("partition-%d-%s", partitionIndex, strings.ToLower(fsType))))
 		if err != nil {
 			f.Close()
 			return nil, fmt.Errorf("failed to create temporary directory for %s partition %d: %w", fsType, partitionIndex, err)
@@ -427,7 +442,7 @@ func NewPartitionEmbeddedFSGetter(pluginName string, partitionIndex int, p part.
 			Section:        section,
 			PartitionIndex: partitionIndex,
 			TempDir:        tempDir,
-			TmpRawPath:     tmpRawPath,
+			RawDiskIMGPath: rawDiskIMGPath,
 			RefMu:          refMu,
 			RefCount:       refCount,
 		}
@@ -463,7 +478,7 @@ type generateFSParams struct {
 	Section        *io.SectionReader
 	PartitionIndex int
 	TempDir        string
-	TmpRawPath     string
+	RawDiskIMGPath string
 	RefMu          *sync.Mutex
 	RefCount       *int32
 }
@@ -483,7 +498,7 @@ func generateEXTFS(params generateFSParams) (*EmbeddedDirFS, error) {
 	return &EmbeddedDirFS{
 		FS:       scalibrfs.DirFS(params.TempDir),
 		File:     params.File,
-		TmpPaths: []string{params.TempDir, params.TmpRawPath},
+		TmpPaths: []string{params.TempDir, params.RawDiskIMGPath},
 		RefCount: params.RefCount,
 		RefMu:    params.RefMu,
 	}, nil
@@ -501,9 +516,9 @@ func generateFAT32FS(params generateFSParams) (*EmbeddedDirFS, error) {
 	if !ok {
 		return nil, fmt.Errorf("partition %d is not a FAT32 filesystem", params.PartitionIndex)
 	}
-	f, err := os.Open(params.TmpRawPath)
+	f, err := os.Open(params.RawDiskIMGPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to reopen raw image %s: %w", params.TmpRawPath, err)
+		return nil, fmt.Errorf("failed to reopen raw image %s: %w", params.RawDiskIMGPath, err)
 	}
 	if err := ExtractAllRecursiveFat32(fat32fs, "/", params.TempDir); err != nil {
 		f.Close()
@@ -515,7 +530,7 @@ func generateFAT32FS(params generateFSParams) (*EmbeddedDirFS, error) {
 	return &EmbeddedDirFS{
 		FS:       scalibrfs.DirFS(params.TempDir),
 		File:     f,
-		TmpPaths: []string{params.TempDir, params.TmpRawPath},
+		TmpPaths: []string{params.TempDir, params.RawDiskIMGPath},
 		RefCount: params.RefCount,
 		RefMu:    params.RefMu,
 	}, nil
@@ -532,7 +547,7 @@ func generateEXFATFS(params generateFSParams) (*EmbeddedDirFS, error) {
 	return &EmbeddedDirFS{
 		FS:       scalibrfs.DirFS(params.TempDir),
 		File:     params.File,
-		TmpPaths: []string{params.TempDir, params.TmpRawPath},
+		TmpPaths: []string{params.TempDir, params.RawDiskIMGPath},
 		RefCount: params.RefCount,
 		RefMu:    params.RefMu,
 	}, nil
@@ -557,7 +572,7 @@ func generateNTFSFS(params generateFSParams) (*EmbeddedDirFS, error) {
 	return &EmbeddedDirFS{
 		FS:       scalibrfs.DirFS(params.TempDir),
 		File:     params.File,
-		TmpPaths: []string{params.TempDir, params.TmpRawPath},
+		TmpPaths: []string{params.TempDir, params.RawDiskIMGPath},
 		RefCount: params.RefCount,
 		RefMu:    params.RefMu,
 	}, nil
@@ -660,13 +675,7 @@ func (fi *fileInfo) Sys() any {
 
 // TARToTempDir extracts a tar file into a temporary directory
 // that can be used to traverse its contents recursively.
-func TARToTempDir(reader io.Reader) (string, error) {
-	// Create a temporary directory for extracted files
-	tempDir, err := os.MkdirTemp("", "scalibr-archive-")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temporary directory: %w", err)
-	}
-
+func TARToTempDir(pluginDir string, reader io.Reader) error {
 	// Extract the tar archive
 	var extractErr error
 	tr := tar.NewReader(reader)
@@ -686,7 +695,7 @@ loop:
 			break
 		}
 
-		target := filepath.Join(tempDir, hdr.Name)
+		target := filepath.Join(pluginDir, hdr.Name)
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, 0755); err != nil {
@@ -716,9 +725,9 @@ loop:
 	}
 
 	if extractErr != nil {
-		os.Remove(tempDir)
-		return "", extractErr
+		os.Remove(pluginDir)
+		return extractErr
 	}
 
-	return tempDir, nil
+	return nil
 }

--- a/extractor/filesystem/embeddedfs/ova/ova.go
+++ b/extractor/filesystem/embeddedfs/ova/ova.go
@@ -28,6 +28,7 @@ import (
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -96,7 +97,18 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		return inventory.Inventory{}, errors.New("input.Reader is nil")
 	}
 
-	tempDir, err := common.TARToTempDir(input.Reader)
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS sets temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── ova
+	// |						└── valid.ova 					<--- A directory with the name set to the file discovered by the extractor
+	pluginDir, err := tempdir.CreateExtractorDir("ova", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
+	err = common.TARToTempDir(pluginDir, input.Reader)
 	if err != nil {
 		return inventory.Inventory{}, fmt.Errorf("common.TARToTempDir(%q): %w", input.Path, err)
 	}
@@ -105,9 +117,9 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var refMu sync.Mutex
 	getEmbeddedFS := func(ctx context.Context) (scalibrfs.FS, error) {
 		return &common.EmbeddedDirFS{
-			FS:       scalibrfs.DirFS(tempDir),
+			FS:       scalibrfs.DirFS(pluginDir),
 			File:     nil,
-			TmpPaths: []string{tempDir},
+			TmpPaths: []string{pluginDir},
 			RefCount: &refCount,
 			RefMu:    &refMu,
 		}, nil

--- a/extractor/filesystem/embeddedfs/qcow2/qcow2.go
+++ b/extractor/filesystem/embeddedfs/qcow2/qcow2.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -113,23 +114,42 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		}()
 	}
 
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS sets temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── qcow2
+	// |						└── valid.qcow2 							<--- File discovered by the extractor
+	// │				        	├── partition-1-ext4					<--- A folder containing partition data
+	// │				        	│				└── private-key1.pem
+	// │				        	├── partition-2-exfat
+	// │				        	│				└── private-key2.pem
+	// │				        	├── partition-3-fat32
+	// │				        	│				└── private-key3.pem
+	// │				        	├── partition-4-ntfs
+	// │				        	│				└── private-key4.pem
+	// │				        	└── qcow2-12345.raw						<--- Converted disk image
+	pluginDir, err := tempdir.CreateExtractorDir("qcow2", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
 	// Create a temporary file for the raw disk image
-	tmpRaw, err := os.CreateTemp("", "scalibr-qcow2-raw-*.raw")
+	rawDiskIMGPath, _, err := tempdir.CreateFile(pluginDir, "qcow2-*.raw")
 	if err != nil {
 		return inventory.Inventory{}, fmt.Errorf("failed to create temporary raw file: %w", err)
 	}
-	tmpRawPath := tmpRaw.Name()
 
 	// Convert QCOW2 to raw
-	if err := convertQCOW2ToRaw(qcow2Path, tmpRawPath, e.password); err != nil {
-		os.Remove(tmpRawPath)
+	if err := convertQCOW2ToRaw(qcow2Path, rawDiskIMGPath, e.password); err != nil {
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, fmt.Errorf("failed to convert %s to raw image: %w", input.Path, err)
 	}
 
 	// Retrieve all partitions and the associated disk handle from the raw disk image.
-	partitionList, disk, err := common.GetDiskPartitions(tmpRawPath)
+	partitionList, disk, err := common.GetDiskPartitions(rawDiskIMGPath)
 	if err != nil {
-		os.Remove(tmpRawPath)
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, err
 	}
 
@@ -141,7 +161,7 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var embeddedFSs []*inventory.EmbeddedFS
 	for i, p := range partitionList {
 		partitionIndex := i + 1 // go-diskfs uses 1-based indexing
-		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("qcow2", partitionIndex, p, disk, tmpRawPath, &refMu, &refCount)
+		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("qcow2", partitionIndex, p, disk, pluginDir, rawDiskIMGPath, &refMu, &refCount)
 		embeddedFSs = append(embeddedFSs, &inventory.EmbeddedFS{
 			Path:          fmt.Sprintf("%s:%d", input.Path, partitionIndex),
 			GetEmbeddedFS: getEmbeddedFS,

--- a/extractor/filesystem/embeddedfs/vdi/vdi.go
+++ b/extractor/filesystem/embeddedfs/vdi/vdi.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/common"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -129,23 +130,42 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		return inventory.Inventory{}, errors.New("input.Reader is nil")
 	}
 
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS sets temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── vdi
+	// |						└── valid.vdi 								<--- A directory with the name set to the file discovered by the extractor
+	// │				        	├── partition-1-ext4					<--- A folder containing partition data
+	// │				        	│				└── private-key1.pem
+	// │				        	├── partition-2-exfat
+	// │				        	│				└── private-key2.pem
+	// │				        	├── partition-3-fat32
+	// │				        	│				└── private-key3.pem
+	// │				        	├── partition-4-ntfs
+	// │				        	│				└── private-key4.pem
+	// │				        	└── vdi-1234.raw						<--- Converted disk image
+	pluginDir, err := tempdir.CreateExtractorDir("vdi", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
 	// Create a temporary file for the raw disk image
-	tmpRaw, err := os.CreateTemp("", "scalibr-vdi-raw-*.raw")
+	rawDiskIMGPath, tmpRaw, err := tempdir.CreateFile(pluginDir, "vdi-*.raw")
 	if err != nil {
 		return inventory.Inventory{}, fmt.Errorf("failed to create temporary raw file: %w", err)
 	}
-	tmpRawPath := tmpRaw.Name()
 
 	// Convert VDI to raw
 	if err := convertVDIToRaw(input.Reader, tmpRaw); err != nil {
-		os.Remove(tmpRawPath)
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, fmt.Errorf("failed to convert %s to raw image: %w", input.Path, err)
 	}
 
 	// Retrieve all partitions and the associated disk handle from the raw disk image.
-	partitionList, disk, err := common.GetDiskPartitions(tmpRawPath)
+	partitionList, disk, err := common.GetDiskPartitions(rawDiskIMGPath)
 	if err != nil {
-		os.Remove(tmpRawPath)
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, err
 	}
 
@@ -157,7 +177,7 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var embeddedFSs []*inventory.EmbeddedFS
 	for i, p := range partitionList {
 		partitionIndex := i + 1 // go-diskfs uses 1-based indexing
-		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("vdi", partitionIndex, p, disk, tmpRawPath, &refMu, &refCount)
+		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("vdi", partitionIndex, p, disk, pluginDir, rawDiskIMGPath, &refMu, &refCount)
 		embeddedFSs = append(embeddedFSs, &inventory.EmbeddedFS{
 			Path:          fmt.Sprintf("%s:%d", input.Path, partitionIndex),
 			GetEmbeddedFS: getEmbeddedFS,

--- a/extractor/filesystem/embeddedfs/vmdk/vmdk.go
+++ b/extractor/filesystem/embeddedfs/vmdk/vmdk.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/common"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 const (
@@ -147,23 +148,42 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 		}()
 	}
 
+	// Create the plugin directory.
+	// Disk layout will be similar to the following in the OS set temporary directory:
+	// ├── osv-scalibr-run-953505549
+	// │				└── extractor
+	// │				    └── vmdk
+	// |						└── valid.vmdk 								<--- A directory with the name set to the file discovered by the extractor
+	// │				        	├── partition-1-ext4					<--- A folder containing partition data
+	// │				        	│				└── private-key1.pem
+	// │				        	├── partition-2-exfat
+	// │				        	│				└── private-key2.pem
+	// │				        	├── partition-3-fat32
+	// │				        	│				└── private-key3.pem
+	// │				        	├── partition-4-ntfs
+	// │				        	│				└── private-key4.pem
+	// │				        	└── vmdk-12345.raw						<--- Converted disk image
+	pluginDir, err := tempdir.CreateExtractorDir("vmdk", input.Path)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create plugin dir: %w", err)
+	}
+
 	// Create a temporary file for the raw disk image
-	tmpRaw, err := os.CreateTemp("", "scalibr-vmdk-raw-*.raw")
+	rawDiskIMGPath, _, err := tempdir.CreateFile(pluginDir, "vmdk-*.raw")
 	if err != nil {
 		return inventory.Inventory{}, fmt.Errorf("failed to create temporary raw file: %w", err)
 	}
-	tmpRawPath := tmpRaw.Name()
 
 	// Convert VMDK to raw
-	if err := convertVMDKToRaw(vmdkPath, tmpRawPath); err != nil {
-		os.Remove(tmpRawPath)
+	if err := convertVMDKToRaw(vmdkPath, rawDiskIMGPath); err != nil {
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, fmt.Errorf("failed to convert %s to raw image: %w", vmdkPath, err)
 	}
 
 	// Retrieve all partitions and the associated disk handle from the raw disk image.
-	partitionList, disk, err := common.GetDiskPartitions(tmpRawPath)
+	partitionList, disk, err := common.GetDiskPartitions(rawDiskIMGPath)
 	if err != nil {
-		os.Remove(tmpRawPath)
+		os.Remove(rawDiskIMGPath)
 		return inventory.Inventory{}, err
 	}
 
@@ -175,7 +195,7 @@ func (e *Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (i
 	var embeddedFSs []*inventory.EmbeddedFS
 	for i, p := range partitionList {
 		partitionIndex := i + 1 // go-diskfs uses 1-based indexing
-		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("vmdk", partitionIndex, p, disk, tmpRawPath, &refMu, &refCount)
+		getEmbeddedFS := common.NewPartitionEmbeddedFSGetter("vmdk", partitionIndex, p, disk, pluginDir, rawDiskIMGPath, &refMu, &refCount)
 		embeddedFSs = append(embeddedFSs, &inventory.EmbeddedFS{
 			Path:          fmt.Sprintf("%s:%d", vmdkPath, partitionIndex),
 			GetEmbeddedFS: getEmbeddedFS,

--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -39,6 +39,7 @@ import (
 	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/tempdir"
 )
 
 var (
@@ -180,6 +181,8 @@ func runOnScanRoot(ctx context.Context, config *Config, scanRoot *scalibrfs.Scan
 
 	// Process embedded filesystems
 	var additionalInv inventory.Inventory
+	// seenRawFiles contain raw disk image files which are deleted
+	seenRawFiles := map[string]struct{}{}
 	for _, embeddedFS := range inv.EmbeddedFSs {
 		// Mount the embedded filesystem
 		mountedFS, err := embeddedFS.GetEmbeddedFS(ctx)
@@ -231,9 +234,25 @@ func runOnScanRoot(ctx context.Context, config *Config, scanRoot *scalibrfs.Scan
 		additionalInv.Append(mountedInv)
 		status = plugin.DedupeStatuses(slices.Concat(status, mountedStatus))
 
-		// Collect temporary directories and raw files after traversal for removal.
 		if c, ok := mountedFS.(common.CloserWithTmpPaths); ok {
-			embeddedFS.TempPaths = c.TempPaths()
+			paths := c.TempPaths()
+
+			for _, p := range paths {
+				if p == "" {
+					continue
+				}
+
+				// Optional: deduplicate
+				if _, seen := seenRawFiles[p]; seen {
+					continue
+				}
+
+				if err := tempdir.RemoveAll(p); err != nil {
+					log.Infof("failed to remove temp path %s: %v", p, err)
+				}
+
+				seenRawFiles[p] = struct{}{}
+			}
 		}
 	}
 

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -46,12 +46,6 @@ type EmbeddedFS struct {
 	// with the partition index from which the filesystem was extracted.
 	Path string
 
-	// TempPaths holds temporary files or directories created during extraction.
-	// These should be cleaned up once all extractors, annotators, and detectors
-	// have completed their operations.
-	// TempPaths will be set when there are temporary directories to clean up.
-	TempPaths []string
-
 	// GetEmbeddedFS is a function that mounts or initializes the underlying
 	// embedded filesystem and returns a scalibrfs.FS interface for accessing it.
 	// The returned filesystem should be closed or cleaned up by the caller

--- a/scalibr.go
+++ b/scalibr.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"runtime"
 	"slices"
@@ -48,6 +47,7 @@ import (
 	pl "github.com/google/osv-scalibr/plugin/list"
 	"github.com/google/osv-scalibr/result"
 	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/tempdir"
 	"github.com/google/osv-scalibr/version"
 	"go.uber.org/multierr"
 
@@ -241,17 +241,11 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 	}
 
 	sro.Inventory = inv
-	// Defer cleanup of all temporary files and directories created during extraction.
-	// This function iterates over all EmbeddedFS entries in the inventory and
-	// removes their associated TempPaths.
-	// Any failures during removal are logged but do not interrupt execution.
+	// Defer cleanup of root temporary directory and all it's subdirectories created during extraction.
 	defer func() {
-		for _, embeddedFS := range sro.Inventory.EmbeddedFSs {
-			for _, tmpPath := range embeddedFS.TempPaths {
-				if err := os.RemoveAll(tmpPath); err != nil {
-					log.Infof("Failed to remove %s", tmpPath)
-				}
-			}
+		// Remove the root temporary directory and all it's subdirectories that we created for this run of scalibr.
+		if err := tempdir.RemoveRoot(); err != nil {
+			log.Infof("Failed to remove tempdir root: %v", err)
 		}
 	}()
 	sro.PluginStatus = append(sro.PluginStatus, extractorStatus...)


### PR DESCRIPTION
Requires:  https://github.com/google/osv-scalibr/pull/1904