### PR TITLE
PRP: Add Clojars Deploy Token secret detector

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -133,6 +133,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Composer Packagist credentials              | `secrets/composerpackagist`            |
 | CircleCI Personal Access Token              | `secrets/circlecipat`                  |
 | CircleCI Project Token                      | `secrets/circleciproject`              |
+| Clojars Deploy Token                        | `secrets/clojarsdeploytoken`           |
 | Cloudflare API Token                        | `secrets/cloudflareapitoken`           |
 | Crates.io API Token                         | `secrets/cratesioapitoken`             |
 | Cursor API key                              | `secrets/cursorapikey`                 |

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -126,6 +126,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/azurestorageaccountaccesskey"
 	"github.com/google/osv-scalibr/veles/secrets/azuretoken"
 	"github.com/google/osv-scalibr/veles/secrets/circleci"
+	"github.com/google/osv-scalibr/veles/secrets/clojarsdeploytoken"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
@@ -364,6 +365,7 @@ var (
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
+		{clojarsdeploytoken.NewDetector(), "secrets/clojarsdeploytoken", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},
 		{npmjsaccesstoken.NewDetector(), "secrets/npmjsaccesstoken", 0},
 		{slacktoken.NewAppConfigAccessTokenDetector(), "secrets/slackappconfigaccesstoken", 0},

--- a/veles/secrets/clojarsdeploytoken/clojarsdeploytoken.go
+++ b/veles/secrets/clojarsdeploytoken/clojarsdeploytoken.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clojarsdeploytoken contains a Veles Secret type and a Detector for
+// [Clojars Deploy Tokens](https://github.com/clojars/clojars-web/wiki/Deploy-Tokens).
+package clojarsdeploytoken
+
+// ClojarsDeployToken is a Veles Secret that holds relevant information for a
+// [Clojars Deploy Token](https://github.com/clojars/clojars-web/wiki/Deploy-Tokens).
+type ClojarsDeployToken struct {
+	Token string
+}

--- a/veles/secrets/clojarsdeploytoken/detector.go
+++ b/veles/secrets/clojarsdeploytoken/detector.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clojarsdeploytoken
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+// maxTokenLength is the maximum size of a Clojars Deploy Token.
+// The format is "CLOJARS_" (8 chars) + 60 hex chars = 68 total.
+const maxTokenLength = 68
+
+// keyRe is a regular expression that matches a Clojars Deploy Token.
+// Clojars Deploy Tokens have the form: "CLOJARS_" followed by exactly
+// 60 lowercase hexadecimal characters.
+var keyRe = regexp.MustCompile(`\bCLOJARS_[a-f0-9]{60}\b`)
+
+// NewDetector returns a new simpletoken.Detector that matches Clojars Deploy Tokens.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: maxTokenLength,
+		Re:     keyRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return ClojarsDeployToken{Token: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/clojarsdeploytoken/detector_test.go
+++ b/veles/secrets/clojarsdeploytoken/detector_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clojarsdeploytoken_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/clojarsdeploytoken"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+const testKey = `CLOJARS_deadbeef0123456789abcdef0123456789abcdef0123456789abcdef0123`
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		clojarsdeploytoken.NewDetector(),
+		testKey,
+		clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+	)
+}
+
+// TestDetector_truePositives tests for cases where we know the Detector
+// will find a Clojars Deploy Token/s.
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{clojarsdeploytoken.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "simple matching string",
+		input: testKey,
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}, {
+		name:  "match at end of string",
+		input: `CLOJARS_DEPLOY_TOKEN=` + testKey,
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}, {
+		name:  "match in middle of string",
+		input: `CLOJARS_DEPLOY_TOKEN="` + testKey + `"`,
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}, {
+		name:  "multiple matches",
+		input: testKey + " " + testKey + " " + testKey,
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}, {
+		name:  "multiple distinct matches",
+		input: testKey + "\n" + testKey[:len(testKey)-1] + "a",
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey[:len(testKey)-1] + "a"},
+		},
+	}, {
+		name: "larger_input_containing_key",
+		input: fmt.Sprintf(`
+	:test_deploy_token: CLOJARS_test
+	:CLOJARS_DEPLOY_TOKEN: %s
+			`, testKey),
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestDetector_trueNegatives tests for cases where we know the Detector
+// will not find a Clojars Deploy Token.
+func TestDetector_trueNegatives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{clojarsdeploytoken.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "empty input",
+		input: "",
+	}, {
+		name:  "short key should not match",
+		input: testKey[:len(testKey)-1],
+	}, {
+		name:  "uppercase hex should not match",
+		input: `CLOJARS_DEADBEEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123`,
+	}, {
+		name:  "invalid character in key should not match",
+		input: `CLOJARS_deadbeef0123456789abcdef01234567g9abcdef0123456789abcdef0123`,
+	}, {
+		name:  "incorrect prefix should not match",
+		input: `CLOJARD_deadbeef0123456789abcdef0123456789abcdef0123456789abcdef0123`,
+	}, {
+		name:  "lowercase prefix should not match",
+		input: `clojars_deadbeef0123456789abcdef0123456789abcdef0123456789abcdef0123`,
+	}, {
+		name:  "missing prefix should not match",
+		input: `deadbeef0123456789abcdef0123456789abcdef0123456789abcdef0123`,
+	}, {
+		name:  "extra characters in key should not match",
+		input: `CLOJARS_deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234`,
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add a new Veles secret detector for [Clojars Deploy Tokens](https://github.com/clojars/clojars-web/wiki/Deploy-Tokens), which are used to authenticate with the [Clojars](https://clojars.org/) package repository for Clojure libraries.

Clojars is the central package repository for the Clojure ecosystem, hosting over 28,000 open-source libraries used by companies like Nubank, Walmart, and Apple.

A leaked deploy token allows supply chain attacks: publishing compromised versions of popular libraries and injecting backdoors into downstream build pipelines.

Fixes #1749

## Implementation

- **Detection pattern**: `CLOJARS_[a-f0-9]{60}` — the `CLOJARS_` prefix followed by exactly 60 lowercase hexadecimal characters provides a high-fidelity match with virtually zero false positives.
- **No validator**: Active validation is not possible because the Clojars API requires HTTP Basic Auth with both a username and the deploy token as the password. Since the scanner cannot infer the username from a standalone token, no validator is included (consistent with other detectors like `rubygemsapikey`, `anthropicapikey`, etc.).

## Changes

- `veles/secrets/clojarsdeploytoken/clojarsdeploytoken.go`: Secret type definition
- `veles/secrets/clojarsdeploytoken/detector.go`: simpletoken-based detector
- `veles/secrets/clojarsdeploytoken/detector_test.go`: Comprehensive tests (acceptance, true positives, true negatives including uppercase hex rejection per reviewer feedback on #1778)
- `extractor/filesystem/list/list.go`: Register detector
- `docs/supported_inventory_types.md`: Add to supported types documentation

## Testing

- All 34 detector tests pass (acceptance, true positives, true negatives)
- `go vet` clean
- `gofmt` clean
- `golangci-lint` clean (0 issues)
- `make lint-plugger` passes
- `go mod tidy` no changes
- Tests run twice to verify no flaky failures

## Notes

- Regex uses lowercase hex only (`[a-f0-9]`) per reviewer feedback on PR #1778 (comment from @alessandro-Doyensec)
- Pattern follows established conventions from similar detectors (`rubygemsapikey`, `cratesioapitoken`, `pypiapitoken`)