### PR TITLE
Add MongoDB Atlas API key pair detector and validator

### DIFF
--- a/binary/proto/scan_result.proto
+++ b/binary/proto/scan_result.proto
@@ -862,6 +862,7 @@ message SecretData {
     ComposerPackagistCredentials composer_http_basic_credentials = 86;
     DiscordBotToken discord_bot_token = 87;
     BitwardenOAuth2AccessToken bitwarden_oauth2_access_token = 88;
+    MongoDBAtlasAPIKeyCredentials mongodb_atlas_api_key_credentials = 89;
   }
 
   message GCPSAK {
@@ -1323,6 +1324,11 @@ message SecretData {
   message SquareOAuthApplicationSecret {
     string id = 1;   // OAuth Application ID (prefix: sq0idp-)
     string key = 2;  // OAuth Application Secret (prefix: sq0csp-)
+  }
+
+  message MongoDBAtlasAPIKeyCredentials {
+    string public_key = 1;
+    string private_key = 2;
   }
 }
 

--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -156,6 +156,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Hashicorp Vault AppRole token               | `secrets/hashicorpvaultapprole`        |
 | Hugging Face API key                        | `secrets/huggingfaceapikey`            |
 | MariaDB Credentials                         | `secrets/mariadb`                      |
+| MongoDB Atlas API key pair                  | `secrets/mongodbatlasapikey`           |
 | Mysql Mylogin                               | `secrets/mysqlmylogin`                 |
 | npmjs Registry Access Tokens                | `secrets/npmjsaccesstoken`             |
 | 1Password Secret Key                        | `secrets/onepasswordsecretkey`         |

--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -64,6 +64,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/herokuplatformkey"
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
+	"github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
 	"github.com/google/osv-scalibr/veles/secrets/openai"
 	"github.com/google/osv-scalibr/veles/secrets/openrouter"
@@ -184,6 +185,7 @@ var (
 		fromVeles(salesforceoauth2refresh.NewValidator(), "secrets/salesforceoauth2refreshvalidate", 0),
 		fromVeles(salesforceoauth2jwt.NewValidator(), "secrets/salesforceoauth2jwtvalidate", 0),
 		fromVeles(cursorapikey.NewValidator(), "secrets/cursorapikeyvalidate", 0),
+		fromVeles(mongodbatlasapikey.NewValidator(), "secrets/mongodbatlasapikeyvalidate", 0),
 	})
 
 	// SecretsEnrich lists enrichers that add data to detected secrets.

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -148,6 +148,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
 	"github.com/google/osv-scalibr/veles/secrets/jwt"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
+	"github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
 	"github.com/google/osv-scalibr/veles/secrets/onepasswordkeys"
 	"github.com/google/osv-scalibr/veles/secrets/openai"
@@ -385,6 +386,7 @@ var (
 		{hcp.NewAccessTokenDetector(), "secrets/hcpaccesstoken", 0},
 		{huggingfaceapikey.NewDetector(), "secrets/huggingfaceapikey", 0},
 		{mistralapikey.NewDetector(), "secrets/mistralapikey", 0},
+		{mongodbatlasapikey.NewDetector(), "secrets/mongodbatlasapikey", 0},
 		{openai.NewDetector(), "secrets/openai", 0},
 		{openrouter.NewDetector(), "secrets/openrouter", 0},
 		{packagist.NewAPISecretDetector(), "secrets/packagistsecret", 0},

--- a/veles/secrets/mongodbatlasapikey/detector.go
+++ b/veles/secrets/mongodbatlasapikey/detector.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlasapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+var (
+	// publicKeyPattern matches MongoDB Atlas public API keys near identifying context.
+	// Atlas public keys are 8 lowercase alphanumeric characters, but this pattern is too
+	// generic on its own. We anchor it with context keywords that indicate an Atlas key.
+	//
+	// Matches patterns like:
+	//   public_api_key = "yhrqvogk"
+	//   MONGODB_ATLAS_PUBLIC_KEY=yhrqvogk
+	//   "publicApiKey": "yhrqvogk"
+	//   public_key: abcd1234
+	publicKeyPattern = regexp.MustCompile(`(?i)(?:public[-_]?(?:api[-_]?)?key)["']?\s*[=:]\s*["'\x60]?([a-z0-9]{8})\b`)
+
+	// privateKeyPattern matches MongoDB Atlas private API keys (UUID format) near context.
+	// Atlas private keys are standard UUIDs (8-4-4-4-12 hex format).
+	//
+	// Matches patterns like:
+	//   private_api_key = "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"
+	//   MONGODB_ATLAS_PRIVATE_KEY=f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97
+	//   "privateApiKey": "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"
+	//   private_key: f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97
+	privateKeyPattern = regexp.MustCompile(`(?i)(?:private[-_]?(?:api[-_]?)?key)["']?\s*[=:]\s*["'\x60]?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`)
+)
+
+const (
+	// maxPublicKeyLen accounts for the context prefix + separators + the 8-char key value.
+	maxPublicKeyLen = 80
+	// maxPrivateKeyLen accounts for the context prefix + separators + the 36-char UUID value.
+	maxPrivateKeyLen = 100
+	// maxDistance is the maximum distance between public and private keys to be considered for pairing.
+	// 10 KiB covers config files and environment variable blocks.
+	maxDistance = 10 * 1 << 10 // 10 KiB
+)
+
+// NewDetector returns a new Veles Detector that finds MongoDB Atlas API key pairs.
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: max(maxPublicKeyLen, maxPrivateKeyLen),
+		MaxDistance:   uint32(maxDistance),
+		FindA:        pair.FindAllMatches(publicKeyPattern),
+		FindB:        pair.FindAllMatches(privateKeyPattern),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			pubSub := publicKeyPattern.FindSubmatch(p.A.Value)
+			if len(pubSub) < 2 {
+				return Credentials{}, false
+			}
+			privSub := privateKeyPattern.FindSubmatch(p.B.Value)
+			if len(privSub) < 2 {
+				return Credentials{}, false
+			}
+			return Credentials{
+				PublicKey:  string(pubSub[1]),
+				PrivateKey: string(privSub[1]),
+			}, true
+		},
+	}
+}

--- a/veles/secrets/mongodbatlasapikey/detector.go
+++ b/veles/secrets/mongodbatlasapikey/detector.go
@@ -59,8 +59,8 @@ func NewDetector() veles.Detector {
 	return &pair.Detector{
 		MaxElementLen: max(maxPublicKeyLen, maxPrivateKeyLen),
 		MaxDistance:   uint32(maxDistance),
-		FindA:        pair.FindAllMatches(publicKeyPattern),
-		FindB:        pair.FindAllMatches(privateKeyPattern),
+		FindA:         pair.FindAllMatches(publicKeyPattern),
+		FindB:         pair.FindAllMatches(privateKeyPattern),
 		FromPair: func(p pair.Pair) (veles.Secret, bool) {
 			pubSub := publicKeyPattern.FindSubmatch(p.A.Value)
 			if len(pubSub) < 2 {

--- a/veles/secrets/mongodbatlasapikey/detector_test.go
+++ b/veles/secrets/mongodbatlasapikey/detector_test.go
@@ -176,7 +176,7 @@ private_api_key = "22222222-2222-2222-2222-222222222222"`,
 		},
 		// --- Backtick-quoted values ---
 		{
-			name: "backtick_quoted_values",
+			name:  "backtick_quoted_values",
 			input: "public_api_key = `abcd1234`\nprivate_api_key = `f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97`",
 			want: []veles.Secret{
 				mongodbatlasapikey.Credentials{

--- a/veles/secrets/mongodbatlasapikey/detector_test.go
+++ b/veles/secrets/mongodbatlasapikey/detector_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlasapikey_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		mongodbatlasapikey.NewDetector(),
+		`public_api_key = "yhrqvogk"
+private_api_key = "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"`,
+		mongodbatlasapikey.Credentials{PublicKey: "yhrqvogk", PrivateKey: "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"},
+	)
+}
+
+func TestDetector_Detect(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{mongodbatlasapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		// --- Empty or invalid input ---
+		{
+			name:  "empty_input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "no_context_keywords",
+			input: "yhrqvogk f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97",
+			want:  nil,
+		},
+		// --- Only one key present ---
+		{
+			name:  "public_key_only",
+			input: `public_api_key = "yhrqvogk"`,
+			want:  nil,
+		},
+		{
+			name:  "private_key_only",
+			input: `private_api_key = "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"`,
+			want:  nil,
+		},
+		// --- Atlas CLI config format (TOML) ---
+		{
+			name: "atlas_cli_config_toml",
+			input: `[default]
+org_id = "5d9b0a58f10fab3a94b73abc"
+public_api_key = "yhrqvogk"
+private_api_key = "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"`,
+			want: []veles.Secret{
+				mongodbatlasapikey.Credentials{
+					PublicKey:  "yhrqvogk",
+					PrivateKey: "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97",
+				},
+			},
+		},
+		// --- Environment variable format ---
+		{
+			name: "environment_variables",
+			input: `MONGODB_ATLAS_PUBLIC_KEY=abcd1234
+MONGODB_ATLAS_PRIVATE_KEY=12345678-abcd-1234-abcd-123456789abc`,
+			want: []veles.Secret{
+				mongodbatlasapikey.Credentials{
+					PublicKey:  "abcd1234",
+					PrivateKey: "12345678-abcd-1234-abcd-123456789abc",
+				},
+			},
+		},
+		// --- JSON format ---
+		{
+			name: "json_config",
+			input: `{
+  "publicApiKey": "yhrqvogk",
+  "privateApiKey": "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"
+}`,
+			want: []veles.Secret{
+				mongodbatlasapikey.Credentials{
+					PublicKey:  "yhrqvogk",
+					PrivateKey: "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97",
+				},
+			},
+		},
+		// --- YAML format ---
+		{
+			name: "yaml_config",
+			input: `mongodb_atlas:
+  public_key: abcd1234
+  private_key: 12345678-abcd-1234-abcd-123456789abc`,
+			want: []veles.Secret{
+				mongodbatlasapikey.Credentials{
+					PublicKey:  "abcd1234",
+					PrivateKey: "12345678-abcd-1234-abcd-123456789abc",
+				},
+			},
+		},
+		// --- Terraform provider format ---
+		{
+			name: "terraform_provider",
+			input: `provider "mongodbatlas" {
+  public_key  = "yhrqvogk"
+  private_key = "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"
+}`,
+			want: []veles.Secret{
+				mongodbatlasapikey.Credentials{
+					PublicKey:  "yhrqvogk",
+					PrivateKey: "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97",
+				},
+			},
+		},
+		// --- Keys too far apart (no pairing) ---
+		{
+			name: "keys_too_far_apart",
+			input: `public_api_key = "yhrqvogk"` + strings.Repeat("\nfiller line with random data", 500) + `
+private_api_key = "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"`,
+			want: nil,
+		},
+		// --- Invalid key formats ---
+		{
+			name:  "public_key_too_long",
+			input: `public_api_key = "yhrqvogk123" private_api_key = "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"`,
+			want:  nil,
+		},
+		{
+			name:  "private_key_not_uuid",
+			input: `public_api_key = "yhrqvogk" private_api_key = "not-a-valid-uuid-format"`,
+			want:  nil,
+		},
+		// --- Multiple key pairs ---
+		{
+			name: "multiple_key_pairs",
+			input: `# Production
+public_api_key = "prodkey1"
+private_api_key = "11111111-1111-1111-1111-111111111111"
+
+# Staging
+public_api_key = "stagkey2"
+private_api_key = "22222222-2222-2222-2222-222222222222"`,
+			want: []veles.Secret{
+				mongodbatlasapikey.Credentials{
+					PublicKey:  "prodkey1",
+					PrivateKey: "11111111-1111-1111-1111-111111111111",
+				},
+				mongodbatlasapikey.Credentials{
+					PublicKey:  "stagkey2",
+					PrivateKey: "22222222-2222-2222-2222-222222222222",
+				},
+			},
+		},
+		// --- Backtick-quoted values ---
+		{
+			name: "backtick_quoted_values",
+			input: "public_api_key = `abcd1234`\nprivate_api_key = `f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97`",
+			want: []veles.Secret{
+				mongodbatlasapikey.Credentials{
+					PublicKey:  "abcd1234",
+					PrivateKey: "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/mongodbatlasapikey/mongodbatlasapikey.go
+++ b/veles/secrets/mongodbatlasapikey/mongodbatlasapikey.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mongodbatlasapikey contains a Veles Secret type, a Detector, and a Validator for
+// MongoDB Atlas API keys (public key + private key pair).
+//
+// ref: https://www.mongodb.com/docs/atlas/configure-api-access/
+package mongodbatlasapikey
+
+// Credentials is a Veles Secret that holds the value of the MongoDB Atlas API key pair.
+type Credentials struct {
+	PublicKey  string
+	PrivateKey string
+}

--- a/veles/secrets/mongodbatlasapikey/validator.go
+++ b/veles/secrets/mongodbatlasapikey/validator.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"crypto/md5"
 	"crypto/rand"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -68,7 +70,7 @@ func (v *Validator) Validate(ctx context.Context, key Credentials) (veles.Valida
 
 	challenge := resp.Header.Get("Www-Authenticate")
 	if challenge == "" {
-		return veles.ValidationFailed, fmt.Errorf("missing WWW-Authenticate header")
+		return veles.ValidationFailed, errors.New("missing WWW-Authenticate header")
 	}
 
 	// Step 2: Parse the Digest challenge and compute response.
@@ -77,7 +79,7 @@ func (v *Validator) Validate(ctx context.Context, key Credentials) (veles.Valida
 	nonce := params["nonce"]
 	qop := params["qop"]
 	if realm == "" || nonce == "" {
-		return veles.ValidationFailed, fmt.Errorf("incomplete digest challenge")
+		return veles.ValidationFailed, errors.New("incomplete digest challenge")
 	}
 
 	authHeader, err := computeDigestAuth(key.PublicKey, key.PrivateKey, "GET", "/api/atlas/v2/", realm, nonce, qop)
@@ -117,7 +119,7 @@ func (v *Validator) Validate(ctx context.Context, key Credentials) (veles.Valida
 func parseDigestChallenge(header string) map[string]string {
 	params := make(map[string]string)
 	header = strings.TrimPrefix(header, "Digest ")
-	for _, part := range strings.Split(header, ",") {
+	for part := range strings.SplitSeq(header, ",") {
 		part = strings.TrimSpace(part)
 		k, v, ok := strings.Cut(part, "=")
 		if !ok {
@@ -161,5 +163,5 @@ func generateCNonce() (string, error) {
 	if _, err := rand.Read(b); err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%x", b), nil
+	return hex.EncodeToString(b), nil
 }

--- a/veles/secrets/mongodbatlasapikey/validator.go
+++ b/veles/secrets/mongodbatlasapikey/validator.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlasapikey
+
+import (
+	"context"
+	"crypto/md5"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/osv-scalibr/veles"
+)
+
+const atlasAPIURL = "https://cloud.mongodb.com/api/atlas/v2/"
+
+// Validator is a Veles Validator for MongoDB Atlas API key pairs.
+// It uses HTTP Digest Authentication (RFC 2617) against the Atlas Admin API.
+type Validator struct {
+	client *http.Client
+}
+
+// NewValidator creates a new Validator.
+func NewValidator() *Validator {
+	return &Validator{
+		client: http.DefaultClient,
+	}
+}
+
+// SetHTTPClient configures the http.Client that the Validator uses.
+func (v *Validator) SetHTTPClient(cli *http.Client) {
+	v.client = cli
+}
+
+// Validate checks whether the given MongoDB Atlas API key pair is valid
+// using HTTP Digest Authentication against the Atlas Admin API v2.
+func (v *Validator) Validate(ctx context.Context, key Credentials) (veles.ValidationStatus, error) {
+	// Step 1: Send unauthenticated request to get Digest Auth challenge.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, atlasAPIURL, nil)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("User-Agent", "osv-scalibr")
+	req.Header.Set("Accept", "application/vnd.atlas.2023-01-01+json")
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("initial request: %w", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		return veles.ValidationFailed, fmt.Errorf("expected 401 challenge, got %d", resp.StatusCode)
+	}
+
+	challenge := resp.Header.Get("Www-Authenticate")
+	if challenge == "" {
+		return veles.ValidationFailed, fmt.Errorf("missing WWW-Authenticate header")
+	}
+
+	// Step 2: Parse the Digest challenge and compute response.
+	params := parseDigestChallenge(challenge)
+	realm := params["realm"]
+	nonce := params["nonce"]
+	qop := params["qop"]
+	if realm == "" || nonce == "" {
+		return veles.ValidationFailed, fmt.Errorf("incomplete digest challenge")
+	}
+
+	authHeader, err := computeDigestAuth(key.PublicKey, key.PrivateKey, "GET", "/api/atlas/v2/", realm, nonce, qop)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("computing digest auth: %w", err)
+	}
+
+	// Step 3: Send authenticated request.
+	authReq, err := http.NewRequestWithContext(ctx, http.MethodGet, atlasAPIURL, nil)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("building auth request: %w", err)
+	}
+	authReq.Header.Set("User-Agent", "osv-scalibr")
+	authReq.Header.Set("Accept", "application/vnd.atlas.2023-01-01+json")
+	authReq.Header.Set("Authorization", authHeader)
+
+	authResp, err := v.client.Do(authReq)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("auth request: %w", err)
+	}
+	authResp.Body.Close()
+
+	switch authResp.StatusCode {
+	case http.StatusOK:
+		return veles.ValidationValid, nil
+	case http.StatusUnauthorized:
+		return veles.ValidationInvalid, nil
+	case http.StatusForbidden:
+		// Authenticated but lacks permissions — key is valid.
+		return veles.ValidationValid, nil
+	default:
+		return veles.ValidationFailed, fmt.Errorf("unexpected status: %d", authResp.StatusCode)
+	}
+}
+
+// parseDigestChallenge extracts key-value parameters from a Digest WWW-Authenticate header.
+func parseDigestChallenge(header string) map[string]string {
+	params := make(map[string]string)
+	header = strings.TrimPrefix(header, "Digest ")
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		params[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"`)
+	}
+	return params
+}
+
+// computeDigestAuth computes an HTTP Digest Authentication header value per RFC 2617.
+func computeDigestAuth(username, password, method, uri, realm, nonce, qop string) (string, error) {
+	ha1 := md5Hex(username + ":" + realm + ":" + password)
+	ha2 := md5Hex(method + ":" + uri)
+
+	cnonce, err := generateCNonce()
+	if err != nil {
+		return "", fmt.Errorf("generating cnonce: %w", err)
+	}
+	nc := "00000001"
+
+	var response string
+	if qop == "auth" || qop == "auth-int" {
+		response = md5Hex(ha1 + ":" + nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2)
+	} else {
+		response = md5Hex(ha1 + ":" + nonce + ":" + ha2)
+	}
+
+	return fmt.Sprintf(
+		`Digest username="%s", realm="%s", nonce="%s", uri="%s", qop=%s, nc=%s, cnonce="%s", response="%s"`,
+		username, realm, nonce, uri, qop, nc, cnonce, response,
+	), nil
+}
+
+func md5Hex(s string) string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(s)))
+}
+
+func generateCNonce() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}

--- a/veles/secrets/mongodbatlasapikey/validator_test.go
+++ b/veles/secrets/mongodbatlasapikey/validator_test.go
@@ -58,7 +58,7 @@ func verifyDigestAuth(authHeader, expectedUser, expectedPass string) bool {
 	}
 
 	params := make(map[string]string)
-	for _, part := range strings.Split(strings.TrimPrefix(authHeader, "Digest "), ",") {
+	for part := range strings.SplitSeq(strings.TrimPrefix(authHeader, "Digest "), ",") {
 		part = strings.TrimSpace(part)
 		k, v, ok := strings.Cut(part, "=")
 		if !ok {

--- a/veles/secrets/mongodbatlasapikey/validator_test.go
+++ b/veles/secrets/mongodbatlasapikey/validator_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlasapikey_test
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
+)
+
+type mockRoundTripper struct {
+	url string
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host == "cloud.mongodb.com" {
+		testURL, _ := url.Parse(m.url)
+		req.URL.Scheme = testURL.Scheme
+		req.URL.Host = testURL.Host
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+const (
+	validPublicKey  = "yhrqvogk"
+	validPrivateKey = "f2a79e29-8a44-4c75-a56d-5a4f7c6d1c97"
+	testRealm       = "MMS Public API"
+	testNonce       = "testnonce123"
+)
+
+func md5Hex(s string) string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(s)))
+}
+
+// verifyDigestAuth checks a Digest Authorization header against expected credentials.
+func verifyDigestAuth(authHeader, expectedUser, expectedPass string) bool {
+	if !strings.HasPrefix(authHeader, "Digest ") {
+		return false
+	}
+
+	params := make(map[string]string)
+	for _, part := range strings.Split(strings.TrimPrefix(authHeader, "Digest "), ",") {
+		part = strings.TrimSpace(part)
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		params[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"`)
+	}
+
+	username := params["username"]
+	nonce := params["nonce"]
+	nc := params["nc"]
+	cnonce := params["cnonce"]
+	qop := params["qop"]
+	uri := params["uri"]
+	response := params["response"]
+
+	if username != expectedUser {
+		return false
+	}
+
+	ha1 := md5Hex(username + ":" + testRealm + ":" + expectedPass)
+	ha2 := md5Hex("GET:" + uri)
+
+	var expected string
+	if qop == "auth" || qop == "auth-int" {
+		expected = md5Hex(ha1 + ":" + nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2)
+	} else {
+		expected = md5Hex(ha1 + ":" + nonce + ":" + ha2)
+	}
+
+	return response == expected
+}
+
+// mockAtlasServer creates a test server that simulates MongoDB Atlas Digest Auth.
+func mockAtlasServer(statusOnAuth int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			// Step 1: Return Digest challenge.
+			w.Header().Set("Www-Authenticate", fmt.Sprintf(
+				`Digest realm="%s", nonce="%s", qop="auth"`, testRealm, testNonce))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Step 2: Verify credentials.
+		if verifyDigestAuth(auth, validPublicKey, validPrivateKey) {
+			w.WriteHeader(statusOnAuth)
+		} else {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name   string
+		key    mongodbatlasapikey.Credentials
+		want   veles.ValidationStatus
+		server *httptest.Server
+	}{
+		{
+			name: "valid_credentials",
+			key: mongodbatlasapikey.Credentials{
+				PublicKey:  validPublicKey,
+				PrivateKey: validPrivateKey,
+			},
+			want:   veles.ValidationValid,
+			server: mockAtlasServer(http.StatusOK),
+		},
+		{
+			name: "invalid_public_key",
+			key: mongodbatlasapikey.Credentials{
+				PublicKey:  "badpubky",
+				PrivateKey: validPrivateKey,
+			},
+			want:   veles.ValidationInvalid,
+			server: mockAtlasServer(http.StatusOK),
+		},
+		{
+			name: "invalid_private_key",
+			key: mongodbatlasapikey.Credentials{
+				PublicKey:  validPublicKey,
+				PrivateKey: "00000000-0000-0000-0000-000000000000",
+			},
+			want:   veles.ValidationInvalid,
+			server: mockAtlasServer(http.StatusOK),
+		},
+		{
+			name: "forbidden_but_authenticated",
+			key: mongodbatlasapikey.Credentials{
+				PublicKey:  validPublicKey,
+				PrivateKey: validPrivateKey,
+			},
+			want:   veles.ValidationValid,
+			server: mockAtlasServer(http.StatusForbidden),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer tc.server.Close()
+			client := &http.Client{
+				Transport: &mockRoundTripper{url: tc.server.URL},
+			}
+
+			validator := mongodbatlasapikey.NewValidator()
+			validator.SetHTTPClient(client)
+
+			got, err := validator.Validate(t.Context(), tc.key)
+			if err != nil {
+				t.Errorf("Validate() error: %v, want nil", err)
+			}
+			if got != tc.want {
+				t.Errorf("Validate() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements detection and validation for MongoDB Atlas API key pairs (public key + private key) as requested in #1451.

### Detector
- Uses `pair.Detector` to find public/private key pairs by proximity (within 10 KiB)
- Context-anchored regex patterns match keys near identifying keywords (`public_api_key`, `MONGODB_ATLAS_PUBLIC_KEY`, `publicApiKey`, etc.)
- Public key format: 8 lowercase alphanumeric characters
- Private key format: UUID (8-4-4-4-12 hex)
- Supports TOML, JSON, YAML, environment variables, Terraform HCL, and backtick-quoted values

### Validator
- HTTP Digest Authentication (RFC 2617) against the Atlas Admin API v2 (`https://cloud.mongodb.com/api/atlas/v2/`)
- Two-step process: unauthenticated request to get challenge, then compute digest response
- Status mapping: 200 → Valid, 401 → Invalid, 403 → Valid (authenticated but lacks permissions)

### Registration
- Added validator to `enricher/enricherlist/list.go`
- Added `MongoDBAtlasAPIKeyCredentials` proto message to `scan_result.proto`
- Added entry to `docs/supported_inventory_types.md`

### Note for reviewers
- `scan_result.pb.go` needs regeneration after the `.proto` change
- `binary/proto/secret.go` needs the type switch case + conversion function for `mongodbatlasapikey.Credentials` (depends on regenerated pb.go)

## Test plan

- [x] `TestDetectorAcceptance` — passes all position, engine, and max-secret-len subtests
- [x] `TestDetector_Detect` — 14 test cases covering empty input, missing context, single key only, TOML config, env vars, JSON, YAML, Terraform, keys too far apart, invalid key formats, multiple key pairs, backtick-quoted values
- [x] `TestValidator` — 4 test cases using mock Digest Auth server (valid credentials, invalid public key, invalid private key, forbidden but authenticated)
- [x] Full `go build ./...` passes (excluding proto regeneration)

Fixes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)