### PR TITLE
PRP: Add Dropbox short-lived access token detector and validator

### DIFF
--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -50,6 +50,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/digitaloceanapikey"
 	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
 	"github.com/google/osv-scalibr/veles/secrets/dockerhubpat"
+	"github.com/google/osv-scalibr/veles/secrets/dropboxappaccesstoken"
 	"github.com/google/osv-scalibr/veles/secrets/elasticcloudapikey"
 	"github.com/google/osv-scalibr/veles/secrets/gcpoauth2access"
 	"github.com/google/osv-scalibr/veles/secrets/gcpsak"
@@ -131,6 +132,7 @@ var (
 		fromVeles(slacktoken.NewAppConfigRefreshTokenValidator(), "secrets/slackconfigrefreshtokenvalidate", 0),
 		fromVeles(slacktoken.NewAppConfigAccessTokenValidator(), "secrets/slackconfigaccesstokenvalidate", 0),
 		fromVeles(dockerhubpat.NewValidator(), "secrets/dockerhubpatvalidate", 0),
+		fromVeles(dropboxappaccesstoken.NewValidator(), "secrets/dropboxappaccesstokenvalidate", 0),
 		fromVeles(cloudflareapitoken.NewValidator(), "secrets/cloudflareapitokenvalidate", 0),
 		fromVeles(denopat.NewUserTokenValidator(), "secrets/denopatuservalidate", 0),
 		fromVeles(denopat.NewOrgTokenValidator(), "secrets/denopatorgvalidate", 0),

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -132,6 +132,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/digitaloceanapikey"
 	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
 	"github.com/google/osv-scalibr/veles/secrets/dockerhubpat"
+	"github.com/google/osv-scalibr/veles/secrets/dropboxappaccesstoken"
 	"github.com/google/osv-scalibr/veles/secrets/elasticcloudapikey"
 	"github.com/google/osv-scalibr/veles/secrets/gcpapikey"
 	"github.com/google/osv-scalibr/veles/secrets/gcpexpressmode"
@@ -370,6 +371,7 @@ var (
 		{slacktoken.NewAppConfigRefreshTokenDetector(), "secrets/slackappconfigrefreshtoken", 0},
 		{slacktoken.NewAppLevelTokenDetector(), "secrets/slackappleveltoken", 0},
 		{dockerhubpat.NewDetector(), "secrets/dockerhubpat", 0},
+		{dropboxappaccesstoken.NewDetector(), "secrets/dropboxappaccesstoken", 0},
 		{elasticcloudapikey.NewDetector(), "secrets/elasticcloudapikey", 0},
 		{denopat.NewUserTokenDetector(), "secrets/denopatuser", 0},
 		{denopat.NewOrgTokenDetector(), "secrets/denopatorg", 0},

--- a/veles/secrets/dropboxappaccesstoken/detector.go
+++ b/veles/secrets/dropboxappaccesstoken/detector.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dropboxappaccesstoken
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+// maxTokenLength is the maximum size of a Dropbox short-lived access token.
+// These tokens are base64-encoded and typically 130-200+ characters.
+const maxTokenLength = 500
+
+// tokenRe matches Dropbox short-lived access tokens.
+// These tokens have a distinctive "sl." prefix followed by base64url-safe
+// characters (alphanumeric, hyphen, underscore). The minimum length after the
+// prefix is set to 100 to avoid false positives.
+//
+// Reference: https://www.dropbox.com/developers/documentation/http/documentation
+var tokenRe = regexp.MustCompile(`sl\.[A-Za-z0-9_-]{100,}`)
+
+// NewDetector returns a new simpletoken.Detector that matches Dropbox
+// short-lived access tokens with the "sl." prefix.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: maxTokenLength,
+		Re:     tokenRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return AccessToken{Token: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/dropboxappaccesstoken/detector_test.go
+++ b/veles/secrets/dropboxappaccesstoken/detector_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dropboxappaccesstoken
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+// validToken is a realistic Dropbox short-lived access token (sl. prefix + 130 chars).
+const validToken = "sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45Aexample"
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		NewDetector(),
+		validToken,
+		AccessToken{Token: validToken},
+	)
+}
+
+func TestDetector(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "valid_token",
+		input: validToken,
+		want: []veles.Secret{
+			AccessToken{Token: validToken},
+		},
+	}, {
+		name:  "token_in_env_var",
+		input: "DROPBOX_ACCESS_TOKEN=" + validToken,
+		want: []veles.Secret{
+			AccessToken{Token: validToken},
+		},
+	}, {
+		name:  "token_in_config_file",
+		input: `access_token: "` + validToken + `"`,
+		want: []veles.Secret{
+			AccessToken{Token: validToken},
+		},
+	}, {
+		name:  "token_in_json",
+		input: `{"access_token": "` + validToken + `"}`,
+		want: []veles.Secret{
+			AccessToken{Token: validToken},
+		},
+	}, {
+		name: "multiple_tokens",
+		input: validToken + "\n" +
+			"sl.BcY0z7Gf4BvI6p77_hnKqS143kxBxRQJWW0oYOlezodZU13blD3fg320eAj7hzQWoYQrtJTvg0myXLKzZMkuNQI_e0gp_1hYfy8w48XIwquz5_H9g5_XY56Bfxample",
+		want: []veles.Secret{
+			AccessToken{Token: validToken},
+			AccessToken{Token: "sl.BcY0z7Gf4BvI6p77_hnKqS143kxBxRQJWW0oYOlezodZU13blD3fg320eAj7hzQWoYQrtJTvg0myXLKzZMkuNQI_e0gp_1hYfy8w48XIwquz5_H9g5_XY56Bfxample"},
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDetector_NoMatches(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		input string
+	}{{
+		name:  "empty_input",
+		input: "",
+	}, {
+		name:  "no_secrets",
+		input: "This is just regular text with no secrets",
+	}, {
+		name:  "sl_prefix_too_short",
+		input: "sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC",
+	}, {
+		name:  "wrong_prefix",
+		input: "sx." + strings.Repeat("A", 130),
+	}, {
+		name:  "no_prefix",
+		input: strings.Repeat("A", 130),
+	}, {
+		name:  "sl_prefix_99_chars",
+		input: "sl." + strings.Repeat("A", 99),
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if len(got) != 0 {
+				t.Errorf("Detect() got %v secrets, want 0", len(got))
+			}
+		})
+	}
+}

--- a/veles/secrets/dropboxappaccesstoken/dropboxappaccesstoken.go
+++ b/veles/secrets/dropboxappaccesstoken/dropboxappaccesstoken.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dropboxappaccesstoken contains Veles Secret types and Detectors for
+// Dropbox short-lived access tokens.
+package dropboxappaccesstoken
+
+// AccessToken is a Veles Secret that holds a Dropbox short-lived access token.
+type AccessToken struct {
+	Token string
+}

--- a/veles/secrets/dropboxappaccesstoken/validator.go
+++ b/veles/secrets/dropboxappaccesstoken/validator.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dropboxappaccesstoken
+
+import (
+	"net/http"
+	"time"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+const (
+	// dropboxAPIBaseURL is the Dropbox API v2 base URL.
+	dropboxAPIBaseURL = "https://api.dropboxapi.com"
+	// validationTimeout is the timeout for API validation requests.
+	validationTimeout = 10 * time.Second
+	// GetCurrentAccountEndpoint is the Dropbox API endpoint for getting the
+	// current user's account information. This is a read-only endpoint that
+	// verifies the token is valid without modifying any data.
+	// Reference: https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account
+	GetCurrentAccountEndpoint = "/2/users/get_current_account"
+)
+
+// NewValidator creates a new Validator that validates Dropbox access tokens by
+// making a test request to the Dropbox API /2/users/get_current_account endpoint.
+// A POST request with a valid Bearer token returns 200 OK.
+// An invalid token returns 401 Unauthorized.
+func NewValidator() *sv.Validator[AccessToken] {
+	return &sv.Validator[AccessToken]{
+		Endpoint:   dropboxAPIBaseURL + GetCurrentAccountEndpoint,
+		HTTPMethod: http.MethodPost,
+		HTTPHeaders: func(t AccessToken) map[string]string {
+			return map[string]string{"Authorization": "Bearer " + t.Token}
+		},
+		ValidResponseCodes:   []int{http.StatusOK, http.StatusTooManyRequests},
+		InvalidResponseCodes: []int{http.StatusUnauthorized},
+		HTTPC: &http.Client{
+			Timeout: validationTimeout,
+		},
+	}
+}

--- a/veles/secrets/dropboxappaccesstoken/validator_test.go
+++ b/veles/secrets/dropboxappaccesstoken/validator_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dropboxappaccesstoken_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/dropboxappaccesstoken"
+)
+
+const validatorTestToken = "sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45Aexample"
+
+func mockDropboxServer(t *testing.T, expectedToken string, statusCode int) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		endpoint := dropboxappaccesstoken.GetCurrentAccountEndpoint
+		if r.Method != http.MethodPost || r.URL.Path != endpoint {
+			t.Errorf("unexpected request: %s %s, expected: POST %s",
+				r.Method, r.URL.Path, endpoint)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		expectedAuth := "Bearer " + expectedToken
+		if r.Header.Get("Authorization") != expectedAuth {
+			t.Errorf("expected Authorization: %s, got: %s",
+				expectedAuth, r.Header.Get("Authorization"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+	}))
+
+	return server
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		want       veles.ValidationStatus
+		wantErr    error
+	}{
+		{
+			name:       "valid_token",
+			statusCode: http.StatusOK,
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "invalid_token_unauthorized",
+			statusCode: http.StatusUnauthorized,
+			want:       veles.ValidationInvalid,
+		},
+		{
+			name:       "rate_limited_but_likely_valid",
+			statusCode: http.StatusTooManyRequests,
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "forbidden_but_authenticated",
+			statusCode: http.StatusForbidden,
+			want:       veles.ValidationFailed,
+			wantErr:    cmpopts.AnyError,
+		},
+		{
+			name:       "server_error",
+			statusCode: http.StatusInternalServerError,
+			want:       veles.ValidationFailed,
+			wantErr:    cmpopts.AnyError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := mockDropboxServer(t, validatorTestToken, tc.statusCode)
+			defer server.Close()
+
+			validator := dropboxappaccesstoken.NewValidator()
+			validator.HTTPC = server.Client()
+			validator.Endpoint = server.URL + dropboxappaccesstoken.GetCurrentAccountEndpoint
+
+			token := dropboxappaccesstoken.AccessToken{Token: validatorTestToken}
+			got, err := validator.Validate(t.Context(), token)
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
+			}
+
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add a Veles secret detector and validator for Dropbox short-lived access tokens.

Dropbox access tokens use a distinctive `sl.` prefix followed by base64url-safe characters, making them highly identifiable with minimal false positive risk.

### Detector
- Pattern: `sl.[A-Za-z0-9_-]{100,}`
- Uses `simpletoken.Detector` following existing project patterns
- Minimum 100 characters after prefix to avoid false positives
- Maximum token length: 500 characters

### Validator
- Endpoint: `POST /2/users/get_current_account` (read-only)
- Reference: https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account
- 200 OK / 429 Too Many Requests → valid
- 401 Unauthorized → invalid
- Uses `simplevalidate.Validator` following existing project patterns

## Changes

- `veles/secrets/dropboxappaccesstoken/dropboxappaccesstoken.go`: Secret type definition
- `veles/secrets/dropboxappaccesstoken/detector.go`: Token detector with sl. prefix regex
- `veles/secrets/dropboxappaccesstoken/detector_test.go`: 26 acceptance + detection tests
- `veles/secrets/dropboxappaccesstoken/validator.go`: API-based token validator
- `veles/secrets/dropboxappaccesstoken/validator_test.go`: 5 validation tests with mock server
- `extractor/filesystem/list/list.go`: Register detector in SecretDetectors
- `enricher/enricherlist/list.go`: Register validator in SecretsValidate

## Testing

- All 31 tests pass locally (run twice to verify no flaky tests)
- `go vet` clean
- `gofmt` clean
- Build compiles successfully

Fixes #1030