### PR TITLE
PRP: Add IBM Cloud API key detector and validator

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -155,6 +155,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Hashicorp Vault token                       | `secrets/hashicorpvaulttoken`          |
 | Hashicorp Vault AppRole token               | `secrets/hashicorpvaultapprole`        |
 | Hugging Face API key                        | `secrets/huggingfaceapikey`            |
+| IBM Cloud API Key                           | `secrets/ibmcloudapikey`               |
 | MariaDB Credentials                         | `secrets/mariadb`                      |
 | Mysql Mylogin                               | `secrets/mysqlmylogin`                 |
 | npmjs Registry Access Tokens                | `secrets/npmjsaccesstoken`             |

--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -63,6 +63,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/hcp"
 	"github.com/google/osv-scalibr/veles/secrets/herokuplatformkey"
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
+	"github.com/google/osv-scalibr/veles/secrets/ibmcloudapikey"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
 	"github.com/google/osv-scalibr/veles/secrets/openai"
@@ -143,6 +144,7 @@ var (
 		fromVeles(hcp.NewClientCredentialsValidator(), "secrets/hcpclientcredentialsvalidate", 0),
 		fromVeles(hcp.NewAccessTokenValidator(), "secrets/hcpaccesstokenvalidate", 0),
 		fromVeles(huggingfaceapikey.NewValidator(), "secrets/huggingfaceapikeyvalidate", 0),
+		fromVeles(ibmcloudapikey.NewValidator(), "secrets/ibmcloudapikeyvalidate", 0),
 		fromVeles(mistralapikey.NewValidator(), "secrets/mistralapikeyvalidate", 0),
 		fromVeles(openai.NewProjectValidator(), "secrets/openaivalidate", 0),
 		fromVeles(openrouter.NewValidator(), "secrets/openroutervalidate", 0),

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -146,6 +146,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/hcp"
 	"github.com/google/osv-scalibr/veles/secrets/herokuplatformkey"
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
+	"github.com/google/osv-scalibr/veles/secrets/ibmcloudapikey"
 	"github.com/google/osv-scalibr/veles/secrets/jwt"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
@@ -384,6 +385,7 @@ var (
 		{hcp.NewPairDetector(), "secrets/hcpclientcredentials", 0},
 		{hcp.NewAccessTokenDetector(), "secrets/hcpaccesstoken", 0},
 		{huggingfaceapikey.NewDetector(), "secrets/huggingfaceapikey", 0},
+		{ibmcloudapikey.NewDetector(), "secrets/ibmcloudapikey", 0},
 		{mistralapikey.NewDetector(), "secrets/mistralapikey", 0},
 		{openai.NewDetector(), "secrets/openai", 0},
 		{openrouter.NewDetector(), "secrets/openrouter", 0},

--- a/veles/secrets/ibmcloudapikey/detector.go
+++ b/veles/secrets/ibmcloudapikey/detector.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ibmcloudapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+const (
+	// maxTokenLength is the maximum length of a valid IBM Cloud API key.
+	// IBM Cloud API keys are 44 characters of mixed-case alphanumeric plus hyphen and underscore.
+	maxTokenLength = 44
+
+	// maxDistance is the maximum distance between an IBM Cloud API key and IBM keyword
+	// to be considered for pairing. We look for nearby keywords to reduce false positives
+	// since IBM Cloud API keys have no distinctive prefix.
+	maxDistance = 200
+)
+
+var (
+	// tokenRe matches IBM Cloud API key format: exactly 44 characters of [A-Za-z0-9_-].
+	tokenRe = regexp.MustCompile(`\b([A-Za-z0-9_-]{44})\b`)
+
+	// keywordRe matches IBM-related keywords that provide context for the key.
+	// Word boundaries are omitted to match "ibm" inside compound identifiers
+	// like IBM_API_KEY or ibm_cloud.
+	keywordRe = regexp.MustCompile(`(?i)(ibm|bluemix|softlayer)`)
+)
+
+// NewDetector returns a detector that finds IBM Cloud API keys by pairing
+// 44-character tokens with nearby IBM-related keywords.
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: maxTokenLength, MaxDistance: maxDistance,
+		FindA: pair.FindAllMatches(tokenRe),
+		FindB: pair.FindAllMatches(keywordRe),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			return Secret{Key: string(p.A.Value)}, true
+		},
+	}
+}

--- a/veles/secrets/ibmcloudapikey/detector_test.go
+++ b/veles/secrets/ibmcloudapikey/detector_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ibmcloudapikey_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/ibmcloudapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		ibmcloudapikey.NewDetector(),
+		`ibm_api_key: hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS`,
+		ibmcloudapikey.Secret{Key: `hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS`},
+	)
+}
+
+func TestDetector_Detect(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{ibmcloudapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		{
+			name:  "empty_input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "token_without_ibm_keyword",
+			input: "api_key: hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS",
+			want:  nil,
+		},
+		{
+			name:  "ibm_keyword_without_token",
+			input: "ibm cloud api key: too_short",
+			want:  nil,
+		},
+		{
+			name:  "token_too_short",
+			input: "ibm_api_key: hQ7IfkjEssAt7gM5M3CnDFqulK",
+			want:  nil,
+		},
+		{
+			name:  "ibm_keyword_and_token_in_close_proximity",
+			input: `ibm_api_key: hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS`,
+			want: []veles.Secret{
+				ibmcloudapikey.Secret{Key: "hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS"},
+			},
+		},
+		{
+			name: "ibm_cloud_credentials_file",
+			input: `[default]
+apikey = Re34sdGs2ACMEfrtz2-2FeRxgB1KHjYhBpFo7dLRz2bx
+url = https://iam.cloud.ibm.com/identity/token`,
+			want: []veles.Secret{
+				ibmcloudapikey.Secret{Key: "Re34sdGs2ACMEfrtz2-2FeRxgB1KHjYhBpFo7dLRz2bx"},
+			},
+		},
+		{
+			name:  "ibm_env_var_format",
+			input: `export IBM_API_KEY=hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS`,
+			want: []veles.Secret{
+				ibmcloudapikey.Secret{Key: "hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS"},
+			},
+		},
+		{
+			name: "ibm_json_config",
+			input: `{
+				"ibm_cloud": {
+					"apikey": "Re34sdGs2ACMEfrtz2-2FeRxgB1KHjYhBpFo7dLRz2bx"
+				}
+			}`,
+			want: []veles.Secret{
+				ibmcloudapikey.Secret{Key: "Re34sdGs2ACMEfrtz2-2FeRxgB1KHjYhBpFo7dLRz2bx"},
+			},
+		},
+		{
+			name:  "bluemix_keyword",
+			input: `BLUEMIX_API_KEY=hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS`,
+			want: []veles.Secret{
+				ibmcloudapikey.Secret{Key: "hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS"},
+			},
+		},
+		{
+			name:  "token_too_far_from_keyword",
+			input: `ibm_config: true` + strings.Repeat("\nfiller line with random data", 100) + "\napikey = hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS",
+			want:  nil,
+		},
+		{
+			name: "multiple_ibm_keys",
+			input: `ibm_key1 = hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS
+ibm_key2 = Re34sdGs2ACMEfrtz2-2FeRxgB1KHjYhBpFo7dLRz2bx`,
+			want: []veles.Secret{
+				ibmcloudapikey.Secret{Key: "hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS"},
+				ibmcloudapikey.Secret{Key: "Re34sdGs2ACMEfrtz2-2FeRxgB1KHjYhBpFo7dLRz2bx"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/ibmcloudapikey/ibmcloudapikey.go
+++ b/veles/secrets/ibmcloudapikey/ibmcloudapikey.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ibmcloudapikey contains Veles Secret types and Detectors for IBM Cloud API keys.
+//
+// ref: https://cloud.ibm.com/docs/account?topic=account-userapikey
+package ibmcloudapikey
+
+// Secret is a Veles Secret that holds the value of an IBM Cloud API key.
+type Secret struct {
+	Key string
+}

--- a/veles/secrets/ibmcloudapikey/validator.go
+++ b/veles/secrets/ibmcloudapikey/validator.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ibmcloudapikey
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+// NewValidator creates a Validator for IBM Cloud API keys.
+// It validates by exchanging the API key for an IAM access token.
+// A successful exchange (200) means the key is valid.
+// An error response (400, 401) means the key is invalid.
+func NewValidator() *simplevalidate.Validator[Secret] {
+	return &simplevalidate.Validator[Secret]{
+		Endpoint:   "https://iam.cloud.ibm.com/identity/token",
+		HTTPMethod: http.MethodPost,
+		HTTPHeaders: func(_ Secret) map[string]string {
+			return map[string]string{
+				"Content-Type": "application/x-www-form-urlencoded",
+				"Accept":       "application/json",
+			}
+		},
+		Body: func(s Secret) (string, error) {
+			return url.Values{
+				"grant_type": {"urn:ibm:params:oauth:grant-type:apikey"},
+				"apikey":     {s.Key},
+			}.Encode(), nil
+		},
+		ValidResponseCodes:   []int{http.StatusOK},
+		InvalidResponseCodes: []int{http.StatusBadRequest, http.StatusUnauthorized},
+	}
+}

--- a/veles/secrets/ibmcloudapikey/validator_test.go
+++ b/veles/secrets/ibmcloudapikey/validator_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ibmcloudapikey_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/ibmcloudapikey"
+)
+
+const validAPIKey = "hQ7IfkjEssAt7gM5M3CnDFqulKxOPtIxRuLNxSM4XxxS"
+
+// mockTransport redirects requests to the test server.
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host == "iam.cloud.ibm.com" {
+		testURL, _ := url.Parse(m.testServer.URL)
+		req.URL.Scheme = testURL.Scheme
+		req.URL.Host = testURL.Host
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// mockIAMServer creates a mock IBM Cloud IAM server for testing.
+func mockIAMServer(t *testing.T, expectedKey string, responseCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/identity/token" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		apikey := r.FormValue("apikey")
+		grantType := r.FormValue("grant_type")
+
+		if grantType != "urn:ibm:params:oauth:grant-type:apikey" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if apikey != expectedKey {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errorCode":"BXNIM0415E","errorMessage":"Provided API key could not be found."}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(responseCode)
+		if responseCode == http.StatusOK {
+			_, _ = w.Write([]byte(`{"access_token":"eyJ...","token_type":"Bearer","expires_in":3600}`))
+		}
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name               string
+		key                string
+		serverExpectedKey  string
+		serverResponseCode int
+		want               veles.ValidationStatus
+		wantErr            error
+	}{
+		{
+			name:               "valid_key",
+			key:                validAPIKey,
+			serverExpectedKey:  validAPIKey,
+			serverResponseCode: http.StatusOK,
+			want:               veles.ValidationValid,
+		},
+		{
+			name:               "invalid_key",
+			key:                "invalidKey_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			serverExpectedKey:  validAPIKey,
+			serverResponseCode: http.StatusBadRequest,
+			want:               veles.ValidationInvalid,
+		},
+		{
+			name:               "unauthorized_key",
+			key:                "wrongKey_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			serverExpectedKey:  validAPIKey,
+			serverResponseCode: http.StatusUnauthorized,
+			want:               veles.ValidationInvalid,
+		},
+		{
+			name:               "server_error",
+			key:                validAPIKey,
+			serverExpectedKey:  validAPIKey,
+			serverResponseCode: http.StatusInternalServerError,
+			want:               veles.ValidationFailed,
+			wantErr:            cmpopts.AnyError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := mockIAMServer(t, tc.serverExpectedKey, tc.serverResponseCode)
+			defer server.Close()
+
+			client := &http.Client{
+				Transport: &mockTransport{testServer: server},
+			}
+
+			validator := ibmcloudapikey.NewValidator()
+			validator.HTTPC = client
+
+			secret := ibmcloudapikey.Secret{Key: tc.key}
+
+			got, err := validator.Validate(t.Context(), secret)
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
+			}
+
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidator_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: &mockTransport{testServer: server},
+	}
+
+	validator := ibmcloudapikey.NewValidator()
+	validator.HTTPC = client
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	secret := ibmcloudapikey.Secret{Key: validAPIKey}
+
+	got, err := validator.Validate(ctx, secret)
+
+	if err == nil {
+		t.Error("Validate() expected error due to context cancellation, got nil")
+	}
+	if got != veles.ValidationFailed {
+		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
+	}
+}


### PR DESCRIPTION
## Description

Add a secret detector and validator for IBM Cloud API keys, addressing issue #1025.

### Detector
Uses `pair.Detector` to identify IBM Cloud API keys by pairing 44-character alphanumeric tokens (`[A-Za-z0-9_-]{44}`) with nearby IBM-related keywords (`ibm`, `bluemix`, `softlayer`). IBM Cloud API keys lack a distinctive prefix, so keyword context is required to minimize false positives.

### Validator
Uses `simplevalidate` to verify keys by exchanging them for IAM access tokens via a POST to `https://iam.cloud.ibm.com/identity/token` with `grant_type=urn:ibm:params:oauth:grant-type:apikey`. A 200 response indicates a valid key; 400/401 indicates invalid.

## Changes

- `veles/secrets/ibmcloudapikey/ibmcloudapikey.go`: Secret type definition
- `veles/secrets/ibmcloudapikey/detector.go`: Pair-based detector with keyword context
- `veles/secrets/ibmcloudapikey/detector_test.go`: 11 detector tests including acceptance test
- `veles/secrets/ibmcloudapikey/validator.go`: IAM token endpoint validator using simplevalidate
- `veles/secrets/ibmcloudapikey/validator_test.go`: 6 validator tests with mock IAM server
- `enricher/enricherlist/list.go`: Register validator
- `extractor/filesystem/list/list.go`: Register detector
- `docs/supported_inventory_types.md`: Add to supported types table

## Testing

- All 17 tests pass locally (11 detector + 6 validator)
- Tests run twice with no flaky failures
- `go vet`, `gofmt` clean
- Acceptance test registered

## Notes

- Proto message and pb.go regeneration will be needed by maintainers (`make protos`)
- Existing PR #1808 for this issue has merge conflicts

Fixes #1025