### PR TITLE
  clients/datasource: reject non-HTTPS Maven registry URLs when credentials configured

### DIFF
--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -156,7 +156,7 @@ func (m *MavenRegistryAPIClient) AddRegistry(ctx context.Context, registry Maven
 	// An untrusted pom.xml could otherwise redirect a credentialed registry ID to an
 	// attacker-controlled HTTP endpoint and steal credentials via a 401 challenge.
 	if _, hasAuth := m.registryAuths[registry.ID]; hasAuth && u.Scheme != "https" && u.Scheme != artifactRegistryScheme {
-		return fmt.Errorf("Maven registry %q URL %q must use https:// to prevent exfiltration of configured credentials", registry.ID, registry.URL)
+		return fmt.Errorf("maven registry %q URL %q must use https:// to prevent exfiltration of configured credentials", registry.ID, registry.URL)
 	}
 
 	registry.Parsed = u
@@ -177,7 +177,7 @@ func (m *MavenRegistryAPIClient) updateDefaultRegistry(ctx context.Context, regi
 	// An untrusted pom.xml could otherwise redirect a credentialed registry ID to an
 	// attacker-controlled HTTP endpoint and steal credentials via a 401 challenge.
 	if _, hasAuth := m.registryAuths[registry.ID]; hasAuth && u.Scheme != "https" && u.Scheme != artifactRegistryScheme {
-		return fmt.Errorf("Maven registry %q URL %q must use https:// to prevent exfiltration of configured credentials", registry.ID, registry.URL)
+		return fmt.Errorf("maven registry %q URL %q must use https:// to prevent exfiltration of configured credentials", registry.ID, registry.URL)
 	}
 	log.Infof("The default Maven registry is being overwritten from %s to %s", m.defaultRegistry.URL, registry.URL)
 	registry.Parsed = u

--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -152,6 +152,12 @@ func (m *MavenRegistryAPIClient) AddRegistry(ctx context.Context, registry Maven
 	if err != nil {
 		return err
 	}
+	// Reject non-HTTPS URLs when credentials are configured for this registry ID.
+	// An untrusted pom.xml could otherwise redirect a credentialed registry ID to an
+	// attacker-controlled HTTP endpoint and steal credentials via a 401 challenge.
+	if _, hasAuth := m.registryAuths[registry.ID]; hasAuth && u.Scheme != "https" && u.Scheme != artifactRegistryScheme {
+		return fmt.Errorf("Maven registry %q URL %q must use https:// to prevent exfiltration of configured credentials", registry.ID, registry.URL)
+	}
 
 	registry.Parsed = u
 	m.registries = append(m.registries, registry)
@@ -166,6 +172,12 @@ func (m *MavenRegistryAPIClient) updateDefaultRegistry(ctx context.Context, regi
 	u, err := url.Parse(registry.URL)
 	if err != nil {
 		return err
+	}
+	// Reject non-HTTPS URLs when credentials are configured for this registry ID.
+	// An untrusted pom.xml could otherwise redirect a credentialed registry ID to an
+	// attacker-controlled HTTP endpoint and steal credentials via a 401 challenge.
+	if _, hasAuth := m.registryAuths[registry.ID]; hasAuth && u.Scheme != "https" && u.Scheme != artifactRegistryScheme {
+		return fmt.Errorf("Maven registry %q URL %q must use https:// to prevent exfiltration of configured credentials", registry.ID, registry.URL)
 	}
 	log.Infof("The default Maven registry is being overwritten from %s to %s", m.defaultRegistry.URL, registry.URL)
 	registry.Parsed = u

--- a/clients/datasource/maven_registry_auth_test.go
+++ b/clients/datasource/maven_registry_auth_test.go
@@ -22,6 +22,70 @@ import (
 	"github.com/google/osv-scalibr/clients/clienttest"
 )
 
+func TestAddRegistryRejectsHTTPWhenCredentialsConfigured(t *testing.T) {
+	srv := clienttest.NewMockHTTPServer(t)
+	client, _ := NewDefaultMavenRegistryAPIClient(t.Context(), srv.URL)
+	client.registryAuths = map[string]*HTTPAuthentication{
+		"private-repo": {
+			SupportedMethods: []HTTPAuthMethod{AuthBasic},
+			Username:         "user",
+			Password:         "pass",
+		},
+	}
+
+	err := client.AddRegistry(t.Context(), MavenRegistry{
+		URL:             "http://attacker.com/maven2/",
+		ID:              "private-repo",
+		ReleasesEnabled: true,
+	})
+	if err == nil {
+		t.Error("AddRegistry() should reject http:// URL when credentials are configured, got nil error")
+	}
+}
+
+func TestUpdateDefaultRegistryRejectsHTTPWhenCredentialsConfigured(t *testing.T) {
+	srv := clienttest.NewMockHTTPServer(t)
+	// Default registry gets ID "default" when none is specified.
+	client, _ := NewDefaultMavenRegistryAPIClient(t.Context(), srv.URL)
+	client.registryAuths = map[string]*HTTPAuthentication{
+		"default": {
+			SupportedMethods: []HTTPAuthMethod{AuthBasic},
+			Username:         "user",
+			Password:         "pass",
+		},
+	}
+
+	err := client.AddRegistry(t.Context(), MavenRegistry{
+		URL:             "http://attacker.com/maven2/",
+		ID:              "default",
+		ReleasesEnabled: true,
+	})
+	if err == nil {
+		t.Error("AddRegistry() should reject http:// URL when updating default registry with credentials, got nil error")
+	}
+}
+
+func TestAddRegistryAllowsHTTPSWhenCredentialsConfigured(t *testing.T) {
+	srv := clienttest.NewMockHTTPServer(t)
+	client, _ := NewDefaultMavenRegistryAPIClient(t.Context(), srv.URL)
+	client.registryAuths = map[string]*HTTPAuthentication{
+		"private-repo": {
+			SupportedMethods: []HTTPAuthMethod{AuthBasic},
+			Username:         "user",
+			Password:         "pass",
+		},
+	}
+
+	err := client.AddRegistry(t.Context(), MavenRegistry{
+		URL:             "https://private.maven.org/maven2/",
+		ID:              "private-repo",
+		ReleasesEnabled: true,
+	})
+	if err != nil {
+		t.Errorf("AddRegistry() should allow https:// URL when credentials are configured, got error: %v", err)
+	}
+}
+
 func TestWithoutRegistriesMaintainsAuthData(t *testing.T) {
 	// Create mock server to test auth is maintained
 	srv := clienttest.NewMockHTTPServer(t)


### PR DESCRIPTION
Description:
  Fixes #1877

  ## What this fixes

  `AddRegistry()` and `updateDefaultRegistry()` accept any URL from pom.xml without
  validating the scheme. If a victim has credentials configured in `~/.m2/settings.xml`
  for a registry ID (e.g. `central`), an attacker-controlled pom.xml can redirect that ID
  to an `http://` endpoint. The client then responds to a 401 challenge by sending the
  victim's credentials in plaintext.

  Attack path:
  1. Malicious pom.xml declares `<repository><id>central</id><url>http://attacker.com</url>`
  2. `AddRegistry()` accepts the http URL, overriding the trusted registry for "central"
  3. Client loads `registryAuths["central"]` from settings.xml
  4. HTTP GET → attacker returns 401 + `WWW-Authenticate: Basic`
  5. Client re-requests with `Authorization: Basic <base64(user:pass)>` → credentials stolen

  ## Fix

  Before accepting a registry URL, check whether credentials are configured for that
  registry ID. If they are, reject any non-HTTPS (and non-artifactregistry) scheme with a
  descriptive error.

  ## Tests

  Added three tests in `maven_registry_auth_test.go`:
  - `TestAddRegistryRejectsHTTPWhenCredentialsConfigured`
  - `TestUpdateDefaultRegistryRejectsHTTPWhenCredentialsConfigured`
  - `TestAddRegistryAllowsHTTPSWhenCredentialsConfigured`