### PR TITLE
Add NuGet.org API Key secret extractor and validator

### DIFF
--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -65,6 +65,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
+	"github.com/google/osv-scalibr/veles/secrets/nugetorgapikey"
 	"github.com/google/osv-scalibr/veles/secrets/openai"
 	"github.com/google/osv-scalibr/veles/secrets/openrouter"
 	"github.com/google/osv-scalibr/veles/secrets/packagist"
@@ -127,6 +128,7 @@ var (
 		fromVeles(sendgrid.NewValidator(), "secrets/sendgridvalidate", 0),
 		fromVeles(cratesioapitoken.NewValidator(), "secrets/cratesioapitokenvalidate", 0),
 		fromVeles(npmjsaccesstoken.NewValidator(), "secrets/npmjsaccesstokenvalidate", 0),
+		fromVeles(nugetorgapikey.NewValidator(), "secrets/nugetorgapikeyvalidate", 0),
 		fromVeles(slacktoken.NewAppLevelTokenValidator(), "secrets/slackappleveltokenvalidate", 0),
 		fromVeles(slacktoken.NewAppConfigRefreshTokenValidator(), "secrets/slackconfigrefreshtokenvalidate", 0),
 		fromVeles(slacktoken.NewAppConfigAccessTokenValidator(), "secrets/slackconfigaccesstokenvalidate", 0),

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -149,6 +149,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/jwt"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
+	"github.com/google/osv-scalibr/veles/secrets/nugetorgapikey"
 	"github.com/google/osv-scalibr/veles/secrets/onepasswordkeys"
 	"github.com/google/osv-scalibr/veles/secrets/openai"
 	"github.com/google/osv-scalibr/veles/secrets/openrouter"
@@ -366,6 +367,7 @@ var (
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},
 		{npmjsaccesstoken.NewDetector(), "secrets/npmjsaccesstoken", 0},
+		{nugetorgapikey.NewDetector(), "secrets/nugetorgapikey", 0},
 		{slacktoken.NewAppConfigAccessTokenDetector(), "secrets/slackappconfigaccesstoken", 0},
 		{slacktoken.NewAppConfigRefreshTokenDetector(), "secrets/slackappconfigrefreshtoken", 0},
 		{slacktoken.NewAppLevelTokenDetector(), "secrets/slackappleveltoken", 0},

--- a/veles/secrets/nugetorgapikey/detector.go
+++ b/veles/secrets/nugetorgapikey/detector.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nugetorgapikey contains a Veles Secret type and a Detector for
+// NuGet.org API Keys (prefix `oy2`).
+package nugetorgapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+// maxTokenLength is the maximum size of a NuGet.org API key.
+// NuGet.org API keys are 46 characters total: prefix `oy2` followed by 43
+// alphanumeric characters.
+const maxTokenLength = 46
+
+// tokenRe is a regular expression that matches a NuGet.org API key.
+// NuGet.org API keys have the form: `oy2` followed by 43 alphanumeric
+// characters, for a total of 46 characters.
+var tokenRe = regexp.MustCompile(`oy2[a-zA-Z0-9]{43}`)
+
+// NewDetector returns a new simpletoken.Detector that matches
+// NuGet.org API keys.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: maxTokenLength,
+		Re:     tokenRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return NuGetOrgAPIKey{Token: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/nugetorgapikey/detector_test.go
+++ b/veles/secrets/nugetorgapikey/detector_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nugetorgapikey_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/nugetorgapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+const testKey = `oy2a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v`
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		nugetorgapikey.NewDetector(),
+		testKey,
+		nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+		velestest.WithBackToBack(),
+		velestest.WithPad('a'),
+	)
+}
+
+// TestDetector_truePositives tests for cases where we know the Detector
+// will find a NuGet.org API key/s.
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{nugetorgapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "simple_matching_string",
+		input: testKey,
+		want: []veles.Secret{
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+		},
+	}, {
+		name:  "match_at_end_of_string",
+		input: `NUGET_API_KEY=` + testKey,
+		want: []veles.Secret{
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+		},
+	}, {
+		name:  "match_in_middle_of_string",
+		input: `NUGET_API_KEY="` + testKey + `"`,
+		want: []veles.Secret{
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+		},
+	}, {
+		name:  "multiple_matches",
+		input: testKey + testKey + testKey,
+		want: []veles.Secret{
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+		},
+	}, {
+		name:  "multiple_distinct_matches",
+		input: testKey + "\n" + testKey[:len(testKey)-1] + "w",
+		want: []veles.Secret{
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey[:len(testKey)-1] + "w"},
+		},
+	}, {
+		name: "larger_input_containing_key",
+		input: fmt.Sprintf(`
+:nuget_api_key: nuget-test
+:NUGET_API_KEY: %s
+		`, testKey),
+		want: []veles.Secret{
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+		},
+	}, {
+		name:  "potential_match_longer_than_max_key_length",
+		input: testKey + `extra`,
+		want: []veles.Secret{
+			nugetorgapikey.NuGetOrgAPIKey{Token: testKey},
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			fmt.Printf("got = %+v\n", got)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestDetector_trueNegatives tests for cases where we know the Detector
+// will not find a NuGet.org API key.
+func TestDetector_trueNegatives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{nugetorgapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "empty_input",
+		input: "",
+	}, {
+		name:  "short_key_should_not_match",
+		input: testKey[:len(testKey)-1],
+	}, {
+		name:  "invalid_character_in_key_should_not_match",
+		input: `oy2!@#$%^&*()_+{}[]|:;<>?,./~` + `1234567890123`,
+	}, {
+		name:  "incorrect_prefix_should_not_match",
+		input: `oy3a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v`,
+	}, {
+		name:  "prefix_missing_should_not_match",
+		input: `a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3`,
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/nugetorgapikey/nugetorgapikey.go
+++ b/veles/secrets/nugetorgapikey/nugetorgapikey.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nugetorgapikey
+
+// NuGetOrgAPIKey is a Veles Secret that holds relevant information for a
+// NuGet.org API key (prefix `oy2`).
+// NuGetOrgAPIKey represents an API key used to authenticate requests to the
+// NuGet.org package registry for publishing, updating, and unlisting packages.
+type NuGetOrgAPIKey struct {
+	Token string
+}

--- a/veles/secrets/nugetorgapikey/validator.go
+++ b/veles/secrets/nugetorgapikey/validator.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nugetorgapikey
+
+import (
+	"net/http"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+type pak = NuGetOrgAPIKey
+
+// NewValidator checks whether the given NuGetOrgAPIKey is valid.
+//
+// It performs a PUT request to the NuGet.org package push endpoint
+// using the API key in the X-NuGet-ApiKey header. If the request returns
+// HTTP 400 (Bad Request), the key is considered valid (the key is authenticated
+// but no package body was provided). If 401 Unauthorized or 403 Forbidden,
+// the key is invalid.
+func NewValidator() *sv.Validator[pak] {
+	return &sv.Validator[pak]{
+		Endpoint:   "https://www.nuget.org/api/v2/package",
+		HTTPMethod: http.MethodPut,
+		HTTPHeaders: func(s pak) map[string]string {
+			return map[string]string{"X-NuGet-ApiKey": s.Token}
+		},
+		ValidResponseCodes:   []int{http.StatusBadRequest},
+		InvalidResponseCodes: []int{http.StatusUnauthorized, http.StatusForbidden},
+	}
+}

--- a/veles/secrets/nugetorgapikey/validator_test.go
+++ b/veles/secrets/nugetorgapikey/validator_test.go
@@ -54,8 +54,8 @@ func mockNuGetServer(t *testing.T, expectedKey string, serverResponseCode int) *
 			return
 		}
 
-		// Check X-NuGet-ApiKey header
-		apiKey := r.Header.Get("X-NuGet-ApiKey")
+		// Check X-Nuget-Apikey header
+		apiKey := r.Header.Get("X-Nuget-Apikey")
 		if apiKey != expectedKey {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)

--- a/veles/secrets/nugetorgapikey/validator_test.go
+++ b/veles/secrets/nugetorgapikey/validator_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nugetorgapikey_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/nugetorgapikey"
+)
+
+const validatorTestKey = "oy2a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v"
+
+// mockTransport redirects requests to the test server
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the original URL with our test server URL
+	if req.URL.Host == "www.nuget.org" {
+		testURL, _ := url.Parse(m.testServer.URL)
+		req.URL.Scheme = testURL.Scheme
+		req.URL.Host = testURL.Host
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// mockNuGetServer creates a mock NuGet API server for testing
+func mockNuGetServer(t *testing.T, expectedKey string, serverResponseCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if it's a PUT request to the expected endpoint
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v2/package" {
+			t.Errorf("unexpected request: %s %s, expected: PUT /api/v2/package", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		// Check X-NuGet-ApiKey header
+		apiKey := r.Header.Get("X-NuGet-ApiKey")
+		if apiKey != expectedKey {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Set response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(serverResponseCode)
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name               string
+		key                string
+		serverExpectedKey  string
+		serverResponseCode int
+		want               veles.ValidationStatus
+		expectError        bool
+	}{
+		{
+			name:               "valid_key",
+			key:                validatorTestKey,
+			serverExpectedKey:  validatorTestKey,
+			serverResponseCode: http.StatusBadRequest,
+			want:               veles.ValidationValid,
+		},
+		{
+			name:               "invalid_key_unauthorized",
+			key:                "random_string",
+			serverExpectedKey:  validatorTestKey,
+			serverResponseCode: http.StatusUnauthorized,
+			want:               veles.ValidationInvalid,
+		},
+		{
+			name:               "invalid_key_forbidden",
+			key:                "random_string",
+			serverExpectedKey:  validatorTestKey,
+			serverResponseCode: http.StatusForbidden,
+			want:               veles.ValidationInvalid,
+		},
+		{
+			name:               "server_error",
+			serverResponseCode: http.StatusInternalServerError,
+			want:               veles.ValidationFailed,
+			expectError:        true,
+		},
+		{
+			name:               "bad_gateway",
+			serverResponseCode: http.StatusBadGateway,
+			want:               veles.ValidationFailed,
+			expectError:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a mock server
+			server := mockNuGetServer(t, tc.serverExpectedKey, tc.serverResponseCode)
+			defer server.Close()
+
+			// Create a client with custom transport
+			client := &http.Client{
+				Transport: &mockTransport{testServer: server},
+			}
+
+			// Create a validator with a mock client
+			validator := nugetorgapikey.NewValidator()
+			validator.HTTPC = client
+
+			// Create a test key
+			key := nugetorgapikey.NuGetOrgAPIKey{Token: tc.key}
+
+			// Test validation
+			got, err := validator.Validate(t.Context(), key)
+
+			// Check error expectation
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Validate() expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			}
+
+			// Check validation status
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidator_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	// Create a client with custom transport
+	client := &http.Client{
+		Transport: &mockTransport{testServer: server},
+	}
+
+	validator := nugetorgapikey.NewValidator()
+	validator.HTTPC = client
+
+	key := nugetorgapikey.NuGetOrgAPIKey{Token: validatorTestKey}
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// Test validation with cancelled context
+	got, err := validator.Validate(ctx, key)
+
+	if err == nil {
+		t.Errorf("Validate() expected error due to context cancellation, got nil")
+	}
+	if got != veles.ValidationFailed {
+		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
+	}
+}
+
+func TestValidator_InvalidRequest(t *testing.T) {
+	// Create a mock server that returns 401 Unauthorized
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	// Create a client with custom transport
+	client := &http.Client{
+		Transport: &mockTransport{testServer: server},
+	}
+
+	validator := nugetorgapikey.NewValidator()
+	validator.HTTPC = client
+
+	testCases := []struct {
+		name     string
+		key      string
+		expected veles.ValidationStatus
+	}{
+		{
+			name:     "empty_key",
+			key:      "",
+			expected: veles.ValidationInvalid,
+		},
+		{
+			name:     "invalid_key_format",
+			key:      "invalid-key-format",
+			expected: veles.ValidationInvalid,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			key := nugetorgapikey.NuGetOrgAPIKey{Token: tc.key}
+
+			got, err := validator.Validate(t.Context(), key)
+
+			if err != nil {
+				t.Errorf("Validate() unexpected error for %s: %v", tc.name, err)
+			}
+			if got != tc.expected {
+				t.Errorf("Validate() = %v, want %v for %s", got, tc.expected, tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements a secret extractor and validator for NuGet.org API Keys, addressing issue #1734.

- **Secret type**: NuGet.org API Key (prefix `oy2`, 46 characters total)
- **Risk**: Leaked keys allow attackers to publish, update, or unlist .NET packages on NuGet.org, enabling supply chain attacks
- **Detection**: Regex-based detector matching `oy2` followed by 43 alphanumeric characters
- **Validation**: PUT request to `https://www.nuget.org/api/v2/package` with `X-NuGet-ApiKey` header — valid keys return 400 (Bad Request, no package body), invalid keys return 401/403

### Files added

| File | Description |
|------|-------------|
| `veles/secrets/nugetorgapikey/nugetorgapikey.go` | Secret struct (`NuGetOrgAPIKey`) with `Token` field |
| `veles/secrets/nugetorgapikey/detector.go` | Regex detector using `simpletoken.Detector` |
| `veles/secrets/nugetorgapikey/detector_test.go` | True positive/negative tests + acceptance tests via `velestest.AcceptDetector` |
| `veles/secrets/nugetorgapikey/validator.go` | HTTP validator using `simplevalidate.Validator` |
| `veles/secrets/nugetorgapikey/validator_test.go` | Mock HTTP server tests for valid/invalid/error cases + context cancellation |

### Registration

- Detector registered in `extractor/filesystem/list/list.go`
- Validator registered in `enricher/enricherlist/list.go`
- Proto registration skipped (requires `.proto` file changes and code regeneration)

### References

- Closes #1734
- Pattern: https://learn.microsoft.com/en-us/nuget/nuget-org/scoped-api-keys
- NuGet Server API: https://learn.microsoft.com/en-us/nuget/api/overview

## Test plan

- [x] All detector tests pass (acceptance, true positives, true negatives)
- [x] All validator tests pass (valid key, invalid key, server errors, context cancellation)
- [x] Registration files compile successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)