### PR TITLE
Add Clojars Deploy Token secret extractor

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -126,6 +126,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/azurestorageaccountaccesskey"
 	"github.com/google/osv-scalibr/veles/secrets/azuretoken"
 	"github.com/google/osv-scalibr/veles/secrets/circleci"
+	"github.com/google/osv-scalibr/veles/secrets/clojarsdeploytoken"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
@@ -364,6 +365,7 @@ var (
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
+		{clojarsdeploytoken.NewDetector(), "secrets/clojarsdeploytoken", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},
 		{npmjsaccesstoken.NewDetector(), "secrets/npmjsaccesstoken", 0},
 		{slacktoken.NewAppConfigAccessTokenDetector(), "secrets/slackappconfigaccesstoken", 0},

--- a/veles/secrets/clojarsdeploytoken/clojarsdeploytoken.go
+++ b/veles/secrets/clojarsdeploytoken/clojarsdeploytoken.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clojarsdeploytoken
+
+// ClojarsDeployToken is a Veles Secret that holds relevant information for a
+// Clojars Deploy Token (prefix `CLOJARS_`).
+// ClojarsDeployToken represents a deploy token used to authenticate and publish
+// packages to the Clojars repository.
+type ClojarsDeployToken struct {
+	Token string
+}

--- a/veles/secrets/clojarsdeploytoken/detector.go
+++ b/veles/secrets/clojarsdeploytoken/detector.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clojarsdeploytoken contains a Veles Secret type and a Detector for
+// Clojars Deploy Tokens (prefix `CLOJARS_`).
+package clojarsdeploytoken
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+// maxTokenLength is the maximum size of a Clojars deploy token.
+const maxTokenLength = 68
+
+// tokenRe is a regular expression that matches a Clojars deploy token.
+// Clojars deploy tokens have the form: `CLOJARS_` followed by exactly 60
+// lowercase hexadecimal characters.
+var tokenRe = regexp.MustCompile(`CLOJARS_[a-f0-9]{60}`)
+
+// NewDetector returns a new simpletoken.Detector that matches
+// Clojars deploy tokens.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: maxTokenLength,
+		Re:     tokenRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return ClojarsDeployToken{Token: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/clojarsdeploytoken/detector_test.go
+++ b/veles/secrets/clojarsdeploytoken/detector_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clojarsdeploytoken_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/clojarsdeploytoken"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+const testKey = `CLOJARS_abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456`
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		clojarsdeploytoken.NewDetector(),
+		testKey,
+		clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		velestest.WithBackToBack(),
+		velestest.WithPad('z'),
+	)
+}
+
+// TestDetector_truePositives tests for cases where we know the Detector
+// will find a Clojars deploy token/s.
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{clojarsdeploytoken.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "simple_matching_string",
+		input: testKey,
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}, {
+		name:  "match_at_end_of_string",
+		input: `CLOJARS_TOKEN=` + testKey,
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}, {
+		name:  "match_in_middle_of_string",
+		input: `CLOJARS_TOKEN="` + testKey + `"`,
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}, {
+		name:  "multiple_matches",
+		input: testKey + " " + testKey + " " + testKey,
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}, {
+		name:  "multiple_distinct_matches",
+		input: testKey + "\n" + testKey[:len(testKey)-1] + "a",
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey[:len(testKey)-1] + "a"},
+		},
+	}, {
+		name: "larger_input_containing_key",
+		input: fmt.Sprintf(`
+:clojars_deploy_token: clojars-test
+:CLOJARS_TOKEN: %s
+		`, testKey),
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}, {
+		name:  "potential_match_longer_than_max_key_length",
+		input: testKey + `extra`,
+		want: []veles.Secret{
+			clojarsdeploytoken.ClojarsDeployToken{Token: testKey},
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			fmt.Printf("got = %+v\n", got)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestDetector_trueNegatives tests for cases where we know the Detector
+// will not find a Clojars deploy token.
+func TestDetector_trueNegatives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{clojarsdeploytoken.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "empty_input",
+		input: "",
+	}, {
+		name:  "short_key_should_not_match",
+		input: testKey[:len(testKey)-1],
+	}, {
+		name:  "invalid_character_in_key_should_not_match",
+		input: `CLOJARS_` + `GHIJKL1234567890GHIJKL1234567890GHIJKL1234567890GHIJKL123456`,
+	}, {
+		name:  "incorrect_prefix_should_not_match",
+		input: `CLOJARZ_abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456`,
+	}, {
+		name:  "prefix_missing_should_not_match",
+		input: `abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456`,
+	}, {
+		name:  "uppercase_hex_should_not_match",
+		input: `CLOJARS_ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF123456`,
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a new secret extractor for Clojars Deploy Tokens (resolves #1749)
- Implements a detector using regex `CLOJARS_[a-f0-9]{60}` matching the 68-character token format (8-char prefix + 60 lowercase hex characters)
- Registers the detector in `extractor/filesystem/list/list.go`

## Design Notes

**No validator is included.** The Clojars API requires Basic Auth with both a username and the deploy token for authentication. Since the username cannot be inferred from the token alone, standalone token validation is not possible. The strict prefix + 60 hex character pattern provides high-fidelity matching without network verification.

## Files Changed

- `veles/secrets/clojarsdeploytoken/clojarsdeploytoken.go` — Secret struct definition
- `veles/secrets/clojarsdeploytoken/detector.go` — Detector using `simpletoken.Detector`
- `veles/secrets/clojarsdeploytoken/detector_test.go` — Acceptance, true positive, and true negative tests
- `extractor/filesystem/list/list.go` — Detector registration

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./veles/secrets/clojarsdeploytoken/...` — all tests pass (acceptance, true positives, true negatives)
- [x] Acceptance tests cover: exact match, start/end/middle positions, multiple matches, back-to-back, chunk boundaries
- [x] True negatives cover: empty input, short key, invalid chars, wrong prefix, missing prefix, uppercase hex