### PR TITLE
Add DataBricks Personal Access Token secret extractor and validator

### DIFF
--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -46,6 +46,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/cloudflareapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
+	"github.com/google/osv-scalibr/veles/secrets/databrickspat"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
 	"github.com/google/osv-scalibr/veles/secrets/digitaloceanapikey"
 	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
@@ -132,6 +133,7 @@ var (
 		fromVeles(slacktoken.NewAppConfigAccessTokenValidator(), "secrets/slackconfigaccesstokenvalidate", 0),
 		fromVeles(dockerhubpat.NewValidator(), "secrets/dockerhubpatvalidate", 0),
 		fromVeles(cloudflareapitoken.NewValidator(), "secrets/cloudflareapitokenvalidate", 0),
+		fromVeles(databrickspat.NewValidator(), "secrets/databrickspatvalidate", 0),
 		fromVeles(denopat.NewUserTokenValidator(), "secrets/denopatuservalidate", 0),
 		fromVeles(denopat.NewOrgTokenValidator(), "secrets/denopatorgvalidate", 0),
 		fromVeles(gcpsak.NewValidator(), "secrets/gcpsakvalidate", 0),

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -128,6 +128,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/circleci"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
+	"github.com/google/osv-scalibr/veles/secrets/databrickspat"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
 	"github.com/google/osv-scalibr/veles/secrets/digitaloceanapikey"
 	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
@@ -362,6 +363,7 @@ var (
 		{circleci.NewPersonalAccessTokenDetector(), "secrets/circlecipat", 0},
 		{circleci.NewProjectTokenDetector(), "secrets/circleciproject", 0},
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
+		{databrickspat.NewDetector(), "secrets/databrickspat", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},

--- a/veles/secrets/databrickspat/databrickspat.go
+++ b/veles/secrets/databrickspat/databrickspat.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databrickspat
+
+// DatabricksPAT is a Veles Secret that holds relevant information for a
+// Databricks Personal Access Token (prefix `dapi`).
+// DatabricksPAT represents a token used to authenticate requests to the
+// Databricks REST API.
+type DatabricksPAT struct {
+	Token string
+}

--- a/veles/secrets/databrickspat/detector.go
+++ b/veles/secrets/databrickspat/detector.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package databrickspat contains a Veles Secret type and a Detector for
+// Databricks Personal Access Tokens (prefix `dapi`).
+package databrickspat
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+// maxTokenLength is the maximum size of a Databricks Personal Access Token.
+// Databricks PATs have the form: `dapi` (4 chars) + 32 hex characters = 36 chars.
+const maxTokenLength = 36
+
+// tokenRe is a regular expression that matches a Databricks Personal Access Token.
+// Databricks PATs have the form: `dapi` followed by 32 lowercase hexadecimal characters.
+var tokenRe = regexp.MustCompile(`dapi[a-f0-9]{32}`)
+
+// NewDetector returns a new simpletoken.Detector that matches
+// Databricks Personal Access Tokens.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: maxTokenLength,
+		Re:     tokenRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return DatabricksPAT{Token: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/databrickspat/detector_test.go
+++ b/veles/secrets/databrickspat/detector_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databrickspat_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/databrickspat"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+const testKey = `dapi1234567890abcdef1234567890abcdef`
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		databrickspat.NewDetector(),
+		testKey,
+		databrickspat.DatabricksPAT{Token: testKey},
+		velestest.WithBackToBack(),
+		velestest.WithPad('a'),
+	)
+}
+
+// TestDetector_truePositives tests for cases where we know the Detector
+// will find a Databricks Personal Access Token/s.
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{databrickspat.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "simple_matching_string",
+		input: testKey,
+		want: []veles.Secret{
+			databrickspat.DatabricksPAT{Token: testKey},
+		},
+	}, {
+		name:  "match_at_end_of_string",
+		input: `DATABRICKS_TOKEN=` + testKey,
+		want: []veles.Secret{
+			databrickspat.DatabricksPAT{Token: testKey},
+		},
+	}, {
+		name:  "match_in_middle_of_string",
+		input: `DATABRICKS_TOKEN="` + testKey + `"`,
+		want: []veles.Secret{
+			databrickspat.DatabricksPAT{Token: testKey},
+		},
+	}, {
+		name:  "multiple_matches",
+		input: testKey + testKey + testKey,
+		want: []veles.Secret{
+			databrickspat.DatabricksPAT{Token: testKey},
+			databrickspat.DatabricksPAT{Token: testKey},
+			databrickspat.DatabricksPAT{Token: testKey},
+		},
+	}, {
+		name:  "multiple_distinct_matches",
+		input: testKey + "\n" + testKey[:len(testKey)-1] + "a",
+		want: []veles.Secret{
+			databrickspat.DatabricksPAT{Token: testKey},
+			databrickspat.DatabricksPAT{Token: testKey[:len(testKey)-1] + "a"},
+		},
+	}, {
+		name: "larger_input_containing_key",
+		input: fmt.Sprintf(`
+:databricks_token: databricks-test
+:DATABRICKS_TOKEN: %s
+		`, testKey),
+		want: []veles.Secret{
+			databrickspat.DatabricksPAT{Token: testKey},
+		},
+	}, {
+		name:  "potential_match_longer_than_max_key_length",
+		input: testKey + `extra`,
+		want: []veles.Secret{
+			databrickspat.DatabricksPAT{Token: testKey},
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			fmt.Printf("got = %+v\n", got)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestDetector_trueNegatives tests for cases where we know the Detector
+// will not find a Databricks Personal Access Token.
+func TestDetector_trueNegatives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{databrickspat.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "empty_input",
+		input: "",
+	}, {
+		name:  "short_key_should_not_match",
+		input: "dapi1234567890abcdef1234567890abcde",
+	}, {
+		name:  "invalid_character_in_key_should_not_match",
+		input: `dapi!@#$%^&*()_+{}[]|:;<>?,./~123456`,
+	}, {
+		name:  "incorrect_prefix_should_not_match",
+		input: `dapy1234567890abcdef1234567890abcdef`,
+	}, {
+		name:  "prefix_missing_should_not_match",
+		input: `1234567890abcdef1234567890abcdef`,
+	}, {
+		name:  "uppercase_hex_should_not_match",
+		input: `dapi1234567890ABCDEF1234567890ABCDEF`,
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/databrickspat/validator.go
+++ b/veles/secrets/databrickspat/validator.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databrickspat
+
+import (
+	"net/http"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+type pak = DatabricksPAT
+
+// NewValidator checks whether the given DatabricksPAT is valid.
+//
+// It performs a GET request to the Databricks accounts API endpoint
+// using the PAT in the Authorization header. If the request returns
+// HTTP 200 or 403 (valid token, insufficient scope), the token is considered valid.
+// If 401 Unauthorized, the token is invalid. Other errors return ValidationFailed.
+func NewValidator() *sv.Validator[pak] {
+	return &sv.Validator[pak]{
+		Endpoint:   "https://accounts.cloud.databricks.com/api/2.0/accounts",
+		HTTPMethod: http.MethodGet,
+		HTTPHeaders: func(s pak) map[string]string {
+			return map[string]string{"Authorization": "Bearer " + s.Token}
+		},
+		ValidResponseCodes:   []int{http.StatusOK, http.StatusForbidden},
+		InvalidResponseCodes: []int{http.StatusUnauthorized},
+	}
+}

--- a/veles/secrets/databrickspat/validator_test.go
+++ b/veles/secrets/databrickspat/validator_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databrickspat_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/databrickspat"
+)
+
+const validatorTestKey = "dapi1234567890abcdef1234567890abcdef"
+
+// mockTransport redirects requests to the test server
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the original URL with our test server URL
+	if req.URL.Host == "accounts.cloud.databricks.com" {
+		testURL, _ := url.Parse(m.testServer.URL)
+		req.URL.Scheme = testURL.Scheme
+		req.URL.Host = testURL.Host
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// mockDatabricksServer creates a mock Databricks API server for testing
+func mockDatabricksServer(t *testing.T, expectedKey string, serverResponseCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if it's a GET request to the expected endpoint
+		if r.Method != http.MethodGet || r.URL.Path != "/api/2.0/accounts" {
+			t.Errorf("unexpected request: %s %s, expected: GET /api/2.0/accounts", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		// Check Authorization header
+		authHeader := r.Header.Get("Authorization")
+		if !strings.Contains(authHeader, expectedKey) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Set response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(serverResponseCode)
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name               string
+		key                string
+		serverExpectedKey  string
+		serverResponseCode int
+		want               veles.ValidationStatus
+		expectError        bool
+	}{
+		{
+			name:               "valid_key",
+			key:                validatorTestKey,
+			serverExpectedKey:  validatorTestKey,
+			serverResponseCode: http.StatusOK,
+			want:               veles.ValidationValid,
+		},
+		{
+			name:               "valid_key_forbidden_scope",
+			key:                validatorTestKey,
+			serverExpectedKey:  validatorTestKey,
+			serverResponseCode: http.StatusForbidden,
+			want:               veles.ValidationValid,
+		},
+		{
+			name:               "invalid_key_unauthorized",
+			key:                "random_string",
+			serverExpectedKey:  validatorTestKey,
+			serverResponseCode: http.StatusUnauthorized,
+			want:               veles.ValidationInvalid,
+		},
+		{
+			name:               "server_error",
+			serverResponseCode: http.StatusInternalServerError,
+			want:               veles.ValidationFailed,
+			expectError:        true,
+		},
+		{
+			name:               "bad_gateway",
+			serverResponseCode: http.StatusBadGateway,
+			want:               veles.ValidationFailed,
+			expectError:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a mock server
+			server := mockDatabricksServer(t, tc.serverExpectedKey, tc.serverResponseCode)
+			defer server.Close()
+
+			// Create a client with custom transport
+			client := &http.Client{
+				Transport: &mockTransport{testServer: server},
+			}
+
+			// Create a validator with a mock client
+			validator := databrickspat.NewValidator()
+			validator.HTTPC = client
+
+			// Create a test key
+			key := databrickspat.DatabricksPAT{Token: tc.key}
+
+			// Test validation
+			got, err := validator.Validate(t.Context(), key)
+
+			// Check error expectation
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Validate() expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			}
+
+			// Check validation status
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidator_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create a client with custom transport
+	client := &http.Client{
+		Transport: &mockTransport{testServer: server},
+	}
+
+	validator := databrickspat.NewValidator()
+	validator.HTTPC = client
+
+	key := databrickspat.DatabricksPAT{Token: validatorTestKey}
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// Test validation with cancelled context
+	got, err := validator.Validate(ctx, key)
+
+	if err == nil {
+		t.Errorf("Validate() expected error due to context cancellation, got nil")
+	}
+	if got != veles.ValidationFailed {
+		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
+	}
+}
+
+func TestValidator_InvalidRequest(t *testing.T) {
+	// Create a mock server that returns 401 Unauthorized
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	// Create a client with custom transport
+	client := &http.Client{
+		Transport: &mockTransport{testServer: server},
+	}
+
+	validator := databrickspat.NewValidator()
+	validator.HTTPC = client
+
+	testCases := []struct {
+		name     string
+		key      string
+		expected veles.ValidationStatus
+	}{
+		{
+			name:     "empty_key",
+			key:      "",
+			expected: veles.ValidationInvalid,
+		},
+		{
+			name:     "invalid_key_format",
+			key:      "invalid-key-format",
+			expected: veles.ValidationInvalid,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			key := databrickspat.DatabricksPAT{Token: tc.key}
+
+			got, err := validator.Validate(t.Context(), key)
+
+			if err != nil {
+				t.Errorf("Validate() unexpected error for %s: %v", tc.name, err)
+			}
+			if got != tc.expected {
+				t.Errorf("Validate() = %v, want %v for %s", got, tc.expected, tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a new Veles secret type, detector, and validator for **Databricks Personal Access Tokens** (prefix `dapi` + 32 lowercase hex characters, 36 chars total)
- Validates tokens against the Databricks accounts API (`https://accounts.cloud.databricks.com/api/2.0/accounts`) — treats HTTP 200/403 as valid (token exists), 401 as invalid
- Registers the detector in `extractor/filesystem/list/list.go` and the validator in `enricher/enricherlist/list.go`

Resolves #1719

## Files Added
- `veles/secrets/databrickspat/databrickspat.go` — Secret struct
- `veles/secrets/databrickspat/detector.go` — Regex-based detector
- `veles/secrets/databrickspat/detector_test.go` — True positive/negative tests + acceptance tests
- `veles/secrets/databrickspat/validator.go` — HTTP-based validator using simplevalidate
- `veles/secrets/databrickspat/validator_test.go` — Mock server tests including context cancellation

## Test plan
- [x] `go build ./veles/secrets/databrickspat/...` — compiles successfully
- [x] `go test ./veles/secrets/databrickspat/... -v` — all tests pass (detector acceptance, true positives, true negatives, validator valid/invalid/error/context cancellation)
- [x] `go build ./enricher/enricherlist/...` — registration compiles
- [x] `go build ./extractor/filesystem/list/...` — registration compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)