### PR TITLE
PRP: Add MongoDB Atlas API key secret extractor and validator

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -137,6 +137,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Crates.io API Token                         | `secrets/cratesioapitoken`             |
 | Cursor API key                              | `secrets/cursorapikey`                 |
 | DigitalOcean API key                        | `secrets/digitaloceanapikey`           |
+| MongoDB Atlas API key                       | `secrets/mongodbatlasapikey`           |
 | Docker hub PAT                              | `secrets/dockerhubpat`                 |
 | Elastic Cloud API key                       | `secrets/elasticcloudapikey`           |
 | Deno User PAT                               | `secrets/denopatuservalidate`          |

--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -64,6 +64,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/herokuplatformkey"
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
+	"github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
 	"github.com/google/osv-scalibr/veles/secrets/openai"
 	"github.com/google/osv-scalibr/veles/secrets/openrouter"
@@ -184,6 +185,7 @@ var (
 		fromVeles(salesforceoauth2refresh.NewValidator(), "secrets/salesforceoauth2refreshvalidate", 0),
 		fromVeles(salesforceoauth2jwt.NewValidator(), "secrets/salesforceoauth2jwtvalidate", 0),
 		fromVeles(cursorapikey.NewValidator(), "secrets/cursorapikeyvalidate", 0),
+		fromVeles(mongodbatlasapikey.NewValidator(), "secrets/mongodbatlasapikeyvalidate", 0),
 	})
 
 	// SecretsEnrich lists enrichers that add data to detected secrets.

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -118,6 +118,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/secrets/gitbasicauth/codecatalyst"
 	"github.com/google/osv-scalibr/extractor/filesystem/secrets/gitbasicauth/codecommit"
 	"github.com/google/osv-scalibr/extractor/filesystem/secrets/mariadb"
+	"github.com/google/osv-scalibr/extractor/filesystem/secrets/mongodbatlasapikey"
 	"github.com/google/osv-scalibr/extractor/filesystem/secrets/mysqlmylogin"
 	"github.com/google/osv-scalibr/extractor/filesystem/secrets/onepasswordconnecttoken"
 	"github.com/google/osv-scalibr/extractor/filesystem/secrets/pgpass"
@@ -148,6 +149,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
 	"github.com/google/osv-scalibr/veles/secrets/jwt"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
+	velesmongodbatlasapikey "github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
 	"github.com/google/osv-scalibr/veles/secrets/onepasswordkeys"
 	"github.com/google/osv-scalibr/veles/secrets/openai"
@@ -352,6 +354,7 @@ var (
 		bitbucket.Name:               {bitbucket.New},
 		cloudflareapitoken.Name:      {cloudflareapitoken.New},
 		bitwardenoauth2access.Name:   {bitwardenoauth2access.New},
+		mongodbatlasapikey.Name:      {mongodbatlasapikey.New},
 	}
 
 	// SecretDetectors for Detector interface.
@@ -433,6 +436,7 @@ var (
 		{salesforceoauth2jwt.NewDetector(), "secrets/salesforceoauth2jwt", 0},
 		{salesforceoauth2refresh.NewDetector(), "secrets/salesforceoauth2refresh", 0},
 		{discordbottoken.NewDetector(), "secrets/discordbottoken", 0},
+		{velesmongodbatlasapikey.NewDetector(), "secrets/mongodbatlasapikey", 0},
 	})
 
 	// Secrets contains both secret extractors and detectors.

--- a/extractor/filesystem/secrets/mongodbatlasapikey/mongodbatlasapikey.go
+++ b/extractor/filesystem/secrets/mongodbatlasapikey/mongodbatlasapikey.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mongodbatlasapikey extends the veles mongodbatlasapikey.Detector to search inside
+// MongoDB Atlas CLI configuration files (~/.config/atlascli/config.toml and ~/.config/mongocli/config.toml).
+package mongodbatlasapikey
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/secrets/convert"
+	"github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the name of the extractor.
+	Name = "secrets/mongodbatlasapikey"
+	// Version is the version of the extractor.
+	Version = 0
+)
+
+// New returns a filesystem.Extractor which extracts MongoDB Atlas API keys
+// using the mongodbatlasapikey.Detector.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) {
+	return convert.FromVelesDetectorWithRequire(
+		mongodbatlasapikey.NewDetector(), Name, Version, FileRequired,
+	), nil
+}
+
+// FileRequired returns true if the file is a MongoDB Atlas or mongocli configuration file.
+func FileRequired(api filesystem.FileAPI) bool {
+	path := filepath.ToSlash(api.Path())
+	return strings.HasSuffix(path, ".config/atlascli/config.toml") ||
+		strings.HasSuffix(path, ".config/mongocli/config.toml")
+}

--- a/extractor/filesystem/secrets/mongodbatlasapikey/mongodbatlasapikey_test.go
+++ b/extractor/filesystem/secrets/mongodbatlasapikey/mongodbatlasapikey_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlasapikey_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor/filesystem/secrets/mongodbatlasapikey"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/inventory/location"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	mongodbatlasapikeydetector "github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		inputPath string
+		want      bool
+		isWindows bool
+	}{
+		{inputPath: "", want: false},
+
+		// linux
+		{inputPath: `/Users/example-user/.config/atlascli/config.toml`, want: true},
+		{inputPath: `/Users/example-user/.config/mongocli/config.toml`, want: true},
+		{inputPath: `/Users/example-user/.config/atlascli/other.toml`, want: false},
+		{inputPath: `/Users/example-user/bad/path`, want: false},
+
+		// windows
+		{inputPath: `C:\Users\USERNAME\.config\atlascli\config.toml`, isWindows: true, want: true},
+		{inputPath: `C:\Users\USERNAME\.config\mongocli\config.toml`, isWindows: true, want: true},
+		{inputPath: `C:\Users\USERNAME\another\bad\path`, isWindows: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.inputPath, func(t *testing.T) {
+			if tt.isWindows && runtime.GOOS != "windows" {
+				t.Skipf("Skipping test %q for %q", t.Name(), runtime.GOOS)
+			}
+			e, err := mongodbatlasapikey.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("mongodbatlasapikey.New failed: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%s) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []*struct {
+		Name        string
+		Path        string
+		WantSecrets []*inventory.Secret
+		WantErr     error
+	}{
+		{
+			Name:        "empty",
+			Path:        "empty",
+			WantSecrets: nil,
+		},
+		{
+			Name: "atlascli_config",
+			Path: "atlascli_config",
+			WantSecrets: []*inventory.Secret{
+				{
+					Secret: mongodbatlasapikeydetector.APIKey{
+						PublicKey:  "abcdef01",
+						PrivateKey: "12345678-abcd-1234-abcd-123456789012",
+					},
+					Location: location.FromPath("atlascli_config"),
+				},
+			},
+		},
+		{
+			Name:        "random_content",
+			Path:        "random_content",
+			WantSecrets: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := mongodbatlasapikey.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("mongodbatlasapikey.New failed: %v", err)
+			}
+
+			inputCfg := extracttest.ScanInputMockConfig{
+				Path:         tt.Path,
+				FakeScanRoot: "testdata",
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, inputCfg)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Secrets: tt.WantSecrets}
+			opts := []cmp.Option{cmpopts.SortSlices(extracttest.PackageCmpLess), cmpopts.EquateEmpty()}
+			if diff := cmp.Diff(wantInv, got, opts...); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/secrets/mongodbatlasapikey/testdata/atlascli_config
+++ b/extractor/filesystem/secrets/mongodbatlasapikey/testdata/atlascli_config
@@ -1,0 +1,5 @@
+[default]
+  org_id = "5f0a1d2b3c4e5f6a7b8c9d0e"
+  public_api_key = "abcdef01"
+  private_api_key = "12345678-abcd-1234-abcd-123456789012"
+  service = "cloud"

--- a/extractor/filesystem/secrets/mongodbatlasapikey/testdata/random_content
+++ b/extractor/filesystem/secrets/mongodbatlasapikey/testdata/random_content
@@ -1,0 +1,2 @@
+This is just some random text that does not contain any MongoDB Atlas API keys.
+It has some numbers 12345678 and letters abcdef but no valid key patterns.

--- a/veles/secrets/mongodbatlasapikey/detector.go
+++ b/veles/secrets/mongodbatlasapikey/detector.go
@@ -33,7 +33,7 @@ const (
 // rePublicKey matches MongoDB Atlas public API keys with context labels.
 // Public keys are alphanumeric strings, typically 8 characters long.
 // Matches patterns like: public_api_key = "abcdefgh" or MONGODB_ATLAS_PUBLIC_KEY=abcdefgh
-var rePublicKey = regexp.MustCompile(`(?i)(?:public[_-]?api[_-]?key|MONGODB[_-]?ATLAS[_-]?PUBLIC[_-]?KEY)\s*[=:]\s*["']?([a-z0-9]{8})["']?`)
+var rePublicKey = regexp.MustCompile(`(?i)(?:public[_-]?api[_-]?key|MONGODB[_-]?ATLAS[_-]?PUBLIC[_-]?KEY)\s*[=:]\s*["']?([a-z0-9]{8})(?:[^a-z0-9]|$)`)
 
 // rePrivateKey matches MongoDB Atlas private API keys with context labels.
 // Private keys are UUIDs.
@@ -45,7 +45,7 @@ var rePrivateKey = regexp.MustCompile(`(?i)(?:private[_-]?api[_-]?key|MONGODB[_-
 func NewDetector() veles.Detector {
 	return &pair.Detector{
 		MaxElementLen: maxElementLen,
-		MaxDistance:    maxDistance,
+		MaxDistance:   maxDistance,
 		FindA:         findAllMatches(rePublicKey),
 		FindB:         findAllMatches(rePrivateKey),
 		FromPair: func(p pair.Pair) (veles.Secret, bool) {

--- a/veles/secrets/mongodbatlasapikey/detector.go
+++ b/veles/secrets/mongodbatlasapikey/detector.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mongodbatlasapikey contains a Veles Secret type and a Detector for
+// MongoDB Atlas API Key pairs (public_api_key + private_api_key).
+package mongodbatlasapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+const (
+	// maxElementLen is the maximum length of a single key element including context.
+	maxElementLen = 120
+	// maxDistance is the maximum distance between the public and private key in bytes.
+	maxDistance = 10 * 1 << 10 // 10 KiB
+)
+
+// rePublicKey matches MongoDB Atlas public API keys with context labels.
+// Public keys are alphanumeric strings, typically 8 characters long.
+// Matches patterns like: public_api_key = "abcdefgh" or MONGODB_ATLAS_PUBLIC_KEY=abcdefgh
+var rePublicKey = regexp.MustCompile(`(?i)(?:public[_-]?api[_-]?key|MONGODB[_-]?ATLAS[_-]?PUBLIC[_-]?KEY)\s*[=:]\s*["']?([a-z0-9]{8})["']?`)
+
+// rePrivateKey matches MongoDB Atlas private API keys with context labels.
+// Private keys are UUIDs.
+// Matches patterns like: private_api_key = "12345678-abcd-1234-abcd-123456789012"
+var rePrivateKey = regexp.MustCompile(`(?i)(?:private[_-]?api[_-]?key|MONGODB[_-]?ATLAS[_-]?PRIVATE[_-]?KEY)\s*[=:]\s*["']?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})["']?`)
+
+// NewDetector returns a context-aware detector that matches MongoDB Atlas API key
+// pairs (public_api_key and private_api_key).
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: maxElementLen,
+		MaxDistance:    maxDistance,
+		FindA:         findAllMatches(rePublicKey),
+		FindB:         findAllMatches(rePrivateKey),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			return APIKey{PublicKey: string(p.A.Value), PrivateKey: string(p.B.Value)}, true
+		},
+		FromPartialPair: func(p pair.Pair) (veles.Secret, bool) {
+			if p.A == nil {
+				return APIKey{PrivateKey: string(p.B.Value)}, true
+			}
+			return APIKey{PublicKey: string(p.A.Value)}, true
+		},
+	}
+}
+
+// findAllMatches returns a function which finds all matches of a given regex.
+func findAllMatches(re *regexp.Regexp) func(data []byte) []*pair.Match {
+	return func(data []byte) []*pair.Match {
+		matches := re.FindAllSubmatchIndex(data, -1)
+		var results []*pair.Match
+		for _, m := range matches {
+			results = append(results, &pair.Match{
+				Start: m[0],
+				Value: data[m[2]:m[3]],
+			})
+		}
+		return results
+	}
+}

--- a/veles/secrets/mongodbatlasapikey/detector_test.go
+++ b/veles/secrets/mongodbatlasapikey/detector_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlasapikey_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
+)
+
+const (
+	testPublicKey  = "abcdef01"
+	testPrivateKey = "12345678-abcd-1234-abcd-123456789012"
+)
+
+// TestDetector_truePositives tests for cases where we know the Detector
+// will find MongoDB Atlas API keys.
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{mongodbatlasapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name: "toml config pair",
+		input: `[default]
+  public_api_key = "abcdef01"
+  private_api_key = "12345678-abcd-1234-abcd-123456789012"`,
+		want: []veles.Secret{
+			mongodbatlasapikey.APIKey{PublicKey: testPublicKey, PrivateKey: testPrivateKey},
+		},
+	}, {
+		name: "env var style pair",
+		input: `MONGODB_ATLAS_PUBLIC_KEY=abcdef01
+MONGODB_ATLAS_PRIVATE_KEY=12345678-abcd-1234-abcd-123456789012`,
+		want: []veles.Secret{
+			mongodbatlasapikey.APIKey{PublicKey: testPublicKey, PrivateKey: testPrivateKey},
+		},
+	}, {
+		name: "yaml style pair",
+		input: `public_api_key: abcdef01
+private_api_key: 12345678-abcd-1234-abcd-123456789012`,
+		want: []veles.Secret{
+			mongodbatlasapikey.APIKey{PublicKey: testPublicKey, PrivateKey: testPrivateKey},
+		},
+	}, {
+		name:  "private key only",
+		input: `private_api_key = "12345678-abcd-1234-abcd-123456789012"`,
+		want: []veles.Secret{
+			mongodbatlasapikey.APIKey{PrivateKey: testPrivateKey},
+		},
+	}, {
+		name:  "public key only",
+		input: `public_api_key = "abcdef01"`,
+		want: []veles.Secret{
+			mongodbatlasapikey.APIKey{PublicKey: testPublicKey},
+		},
+	}, {
+		name: "config with surrounding context",
+		input: `# MongoDB Atlas configuration
+[default]
+  org_id = "5f0a1d2b3c4e5f6a7b8c9d0e"
+  public_api_key = "abcdef01"
+  private_api_key = "12345678-abcd-1234-abcd-123456789012"
+  service = "cloud"`,
+		want: []veles.Secret{
+			mongodbatlasapikey.APIKey{PublicKey: testPublicKey, PrivateKey: testPrivateKey},
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestDetector_trueNegatives tests for cases where we know the Detector
+// will not find MongoDB Atlas API keys.
+func TestDetector_trueNegatives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{mongodbatlasapikey.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "empty input",
+		input: "",
+	}, {
+		name:  "random uuid without context",
+		input: "12345678-abcd-1234-abcd-123456789012",
+	}, {
+		name:  "short public key without context",
+		input: "abcdef01",
+	}, {
+		name:  "unrelated config key",
+		input: `api_key = "abcdef01"`,
+	}, {
+		name:  "invalid uuid format",
+		input: `private_api_key = "not-a-valid-uuid-format"`,
+	}, {
+		name:  "public key too long",
+		input: `public_api_key = "abcdefghij"`,
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/mongodbatlasapikey/mongodbatlasapikey.go
+++ b/veles/secrets/mongodbatlasapikey/mongodbatlasapikey.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlasapikey
+
+// APIKey is a Veles Secret that holds relevant information for a
+// MongoDB Atlas API key pair (public_api_key + private_api_key).
+// These credentials are used to authenticate against the MongoDB Atlas
+// Admin API v2 via HTTP Digest Authentication.
+type APIKey struct {
+	PublicKey  string
+	PrivateKey string
+}

--- a/veles/secrets/mongodbatlasapikey/validator.go
+++ b/veles/secrets/mongodbatlasapikey/validator.go
@@ -16,14 +16,10 @@ package mongodbatlasapikey
 
 import (
 	"context"
-	"crypto/md5"
-	"errors"
 	"fmt"
-	"math/rand"
 	"net/http"
-	"regexp"
-	"strings"
 
+	"github.com/google/osv-scalibr/clients/datasource"
 	"github.com/google/osv-scalibr/veles"
 )
 
@@ -51,6 +47,8 @@ func NewValidator() *Validator {
 //
 // A GET request is sent to the API root endpoint. If the server responds with
 // HTTP 200, the key is valid. If 401 after digest auth, the key is invalid.
+// Digest auth is handled by the shared HTTPAuthentication client from
+// clients/datasource, which implements RFC 2617.
 func (v *Validator) Validate(ctx context.Context, secret APIKey) (veles.ValidationStatus, error) {
 	if secret.PublicKey == "" || secret.PrivateKey == "" {
 		return veles.ValidationInvalid, nil
@@ -66,55 +64,22 @@ func (v *Validator) Validate(ctx context.Context, secret APIKey) (veles.Validati
 		endpoint = atlasEndpoint
 	}
 
-	// Step 1: Send initial request without authentication to get the WWW-Authenticate challenge.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return veles.ValidationFailed, fmt.Errorf("creating initial request: %w", err)
+	auth := &datasource.HTTPAuthentication{
+		SupportedMethods: []datasource.HTTPAuthMethod{datasource.AuthDigest},
+		Username:         secret.PublicKey,
+		Password:         secret.PrivateKey,
 	}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		if ctx.Err() != nil {
-			return veles.ValidationFailed, ctx.Err()
-		}
-		return veles.ValidationFailed, fmt.Errorf("initial request failed: %w", err)
-	}
-	resp.Body.Close()
-
-	if resp.StatusCode != http.StatusUnauthorized {
-		// Unexpected response to unauthenticated request.
-		return veles.ValidationFailed, fmt.Errorf("unexpected status %d on initial request", resp.StatusCode)
-	}
-
-	wwwAuth := resp.Header.Get("Www-Authenticate")
-	if wwwAuth == "" {
-		return veles.ValidationFailed, errors.New("missing Www-Authenticate header")
-	}
-
-	challenge, err := parseDigestChallenge(wwwAuth)
-	if err != nil {
-		return veles.ValidationFailed, fmt.Errorf("parsing digest challenge: %w", err)
-	}
-
-	// Step 2: Compute digest response and send authenticated request.
-	authHeader := computeDigestAuth(secret.PublicKey, secret.PrivateKey, "GET", endpoint, challenge)
-
-	authReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return veles.ValidationFailed, fmt.Errorf("creating auth request: %w", err)
-	}
-	authReq.Header.Set("Authorization", authHeader)
-
-	authResp, err := client.Do(authReq)
+	resp, err := auth.Get(ctx, client, endpoint)
 	if err != nil {
 		if ctx.Err() != nil {
 			return veles.ValidationFailed, ctx.Err()
 		}
-		return veles.ValidationFailed, fmt.Errorf("auth request failed: %w", err)
+		return veles.ValidationFailed, fmt.Errorf("request failed: %w", err)
 	}
-	authResp.Body.Close()
+	defer resp.Body.Close()
 
-	switch authResp.StatusCode {
+	switch resp.StatusCode {
 	case http.StatusOK:
 		return veles.ValidationValid, nil
 	case http.StatusForbidden:
@@ -123,85 +88,6 @@ func (v *Validator) Validate(ctx context.Context, secret APIKey) (veles.Validati
 	case http.StatusUnauthorized:
 		return veles.ValidationInvalid, nil
 	default:
-		return veles.ValidationFailed, fmt.Errorf("unexpected status %d", authResp.StatusCode)
+		return veles.ValidationFailed, fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
-}
-
-// digestChallenge holds parsed fields from a Www-Authenticate: Digest header.
-type digestChallenge struct {
-	realm     string
-	nonce     string
-	qop       string
-	algorithm string
-}
-
-var digestFieldRe = regexp.MustCompile(`(\w+)="([^"]*)"`)
-
-// parseDigestChallenge parses a Www-Authenticate: Digest header value.
-func parseDigestChallenge(header string) (*digestChallenge, error) {
-	if !strings.HasPrefix(header, "Digest ") {
-		return nil, fmt.Errorf("not a Digest challenge: %s", header)
-	}
-
-	c := &digestChallenge{algorithm: "MD5"}
-	matches := digestFieldRe.FindAllStringSubmatch(header, -1)
-	for _, m := range matches {
-		switch strings.ToLower(m[1]) {
-		case "realm":
-			c.realm = m[2]
-		case "nonce":
-			c.nonce = m[2]
-		case "qop":
-			c.qop = m[2]
-		case "algorithm":
-			c.algorithm = m[2]
-		}
-	}
-
-	if c.nonce == "" {
-		return nil, errors.New("missing nonce in digest challenge")
-	}
-
-	return c, nil
-}
-
-// computeDigestAuth computes the Authorization header for HTTP Digest Authentication
-// (RFC 2617). MD5 is mandated by the protocol — MongoDB Atlas Admin API v1.0 requires it.
-// This mirrors clients/datasource/http_auth.go which uses the same pattern.
-func computeDigestAuth(username, password, method, uri string, c *digestChallenge) string {
-	//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617), not used for password storage.
-	ha1 := fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s:%s:%s", username, c.realm, password)))
-	//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617).
-	ha2 := fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s:%s", method, uri)))
-
-	nc := "00000001"
-	cnonce := fmt.Sprintf("%08x", rand.Int31())
-
-	var response string
-	if strings.Contains(c.qop, "auth") {
-		//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617).
-		response = fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s:%s:%s:%s:%s:%s", ha1, c.nonce, nc, cnonce, "auth", ha2)))
-	} else {
-		//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617).
-		response = fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s:%s:%s", ha1, c.nonce, ha2)))
-	}
-
-	parts := []string{
-		fmt.Sprintf(`username="%s"`, username),
-		fmt.Sprintf(`realm="%s"`, c.realm),
-		fmt.Sprintf(`nonce="%s"`, c.nonce),
-		fmt.Sprintf(`uri="%s"`, uri),
-		fmt.Sprintf(`response="%s"`, response),
-		"algorithm=" + c.algorithm,
-	}
-
-	if strings.Contains(c.qop, "auth") {
-		parts = append(parts,
-			"qop=auth",
-			"nc="+nc,
-			fmt.Sprintf(`cnonce="%s"`, cnonce),
-		)
-	}
-
-	return "Digest " + strings.Join(parts, ", ")
 }

--- a/veles/secrets/mongodbatlasapikey/validator.go
+++ b/veles/secrets/mongodbatlasapikey/validator.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlasapikey
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/google/osv-scalibr/veles"
+)
+
+const (
+	// atlasEndpoint is the MongoDB Atlas Admin API v2 endpoint used for validation.
+	atlasEndpoint = "https://cloud.mongodb.com/api/atlas/v2"
+)
+
+// Validator validates MongoDB Atlas API keys via the Atlas Admin API
+// using HTTP Digest Authentication.
+type Validator struct {
+	// Endpoint overrides the default Atlas API endpoint (for testing).
+	Endpoint string
+	// HTTPC is the HTTP client to use. Uses http.DefaultClient if nil.
+	HTTPC *http.Client
+}
+
+// NewValidator creates a new Validator for MongoDB Atlas API keys.
+func NewValidator() *Validator {
+	return &Validator{}
+}
+
+// Validate validates a MongoDB Atlas API key pair by performing HTTP Digest
+// Authentication against the Atlas Admin API v2.
+//
+// A GET request is sent to the API root endpoint. If the server responds with
+// HTTP 200, the key is valid. If 401 after digest auth, the key is invalid.
+func (v *Validator) Validate(ctx context.Context, secret APIKey) (veles.ValidationStatus, error) {
+	if secret.PublicKey == "" || secret.PrivateKey == "" {
+		return veles.ValidationInvalid, nil
+	}
+
+	client := v.HTTPC
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	endpoint := v.Endpoint
+	if endpoint == "" {
+		endpoint = atlasEndpoint
+	}
+
+	// Step 1: Send initial request without authentication to get the WWW-Authenticate challenge.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("creating initial request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return veles.ValidationFailed, ctx.Err()
+		}
+		return veles.ValidationFailed, fmt.Errorf("initial request failed: %w", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		// Unexpected response to unauthenticated request.
+		return veles.ValidationFailed, fmt.Errorf("unexpected status %d on initial request", resp.StatusCode)
+	}
+
+	wwwAuth := resp.Header.Get("Www-Authenticate")
+	if wwwAuth == "" {
+		return veles.ValidationFailed, fmt.Errorf("missing Www-Authenticate header")
+	}
+
+	challenge, err := parseDigestChallenge(wwwAuth)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("parsing digest challenge: %w", err)
+	}
+
+	// Step 2: Compute digest response and send authenticated request.
+	authHeader := computeDigestAuth(secret.PublicKey, secret.PrivateKey, "GET", endpoint, challenge)
+
+	authReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("creating auth request: %w", err)
+	}
+	authReq.Header.Set("Authorization", authHeader)
+
+	authResp, err := client.Do(authReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return veles.ValidationFailed, ctx.Err()
+		}
+		return veles.ValidationFailed, fmt.Errorf("auth request failed: %w", err)
+	}
+	authResp.Body.Close()
+
+	switch authResp.StatusCode {
+	case http.StatusOK:
+		return veles.ValidationValid, nil
+	case http.StatusForbidden:
+		// 403 means the key is valid but lacks permissions for this endpoint.
+		return veles.ValidationValid, nil
+	case http.StatusUnauthorized:
+		return veles.ValidationInvalid, nil
+	default:
+		return veles.ValidationFailed, fmt.Errorf("unexpected status %d", authResp.StatusCode)
+	}
+}
+
+// digestChallenge holds parsed fields from a Www-Authenticate: Digest header.
+type digestChallenge struct {
+	realm     string
+	nonce     string
+	qop       string
+	algorithm string
+}
+
+var digestFieldRe = regexp.MustCompile(`(\w+)="([^"]*)"`)
+
+// parseDigestChallenge parses a Www-Authenticate: Digest header value.
+func parseDigestChallenge(header string) (*digestChallenge, error) {
+	if !strings.HasPrefix(header, "Digest ") {
+		return nil, fmt.Errorf("not a Digest challenge: %s", header)
+	}
+
+	c := &digestChallenge{algorithm: "MD5"}
+	matches := digestFieldRe.FindAllStringSubmatch(header, -1)
+	for _, m := range matches {
+		switch strings.ToLower(m[1]) {
+		case "realm":
+			c.realm = m[2]
+		case "nonce":
+			c.nonce = m[2]
+		case "qop":
+			c.qop = m[2]
+		case "algorithm":
+			c.algorithm = m[2]
+		}
+	}
+
+	if c.nonce == "" {
+		return nil, fmt.Errorf("missing nonce in digest challenge")
+	}
+
+	return c, nil
+}
+
+// computeDigestAuth computes the Authorization header for HTTP Digest Authentication.
+func computeDigestAuth(username, password, method, uri string, c *digestChallenge) string {
+	ha1 := md5sum(fmt.Sprintf("%s:%s:%s", username, c.realm, password))
+	ha2 := md5sum(fmt.Sprintf("%s:%s", method, uri))
+
+	nc := "00000001"
+	cnonce := fmt.Sprintf("%08x", rand.Int31())
+
+	var response string
+	if strings.Contains(c.qop, "auth") {
+		response = md5sum(fmt.Sprintf("%s:%s:%s:%s:%s:%s", ha1, c.nonce, nc, cnonce, "auth", ha2))
+	} else {
+		response = md5sum(fmt.Sprintf("%s:%s:%s", ha1, c.nonce, ha2))
+	}
+
+	parts := []string{
+		fmt.Sprintf(`username="%s"`, username),
+		fmt.Sprintf(`realm="%s"`, c.realm),
+		fmt.Sprintf(`nonce="%s"`, c.nonce),
+		fmt.Sprintf(`uri="%s"`, uri),
+		fmt.Sprintf(`response="%s"`, response),
+		fmt.Sprintf(`algorithm=%s`, c.algorithm),
+	}
+
+	if strings.Contains(c.qop, "auth") {
+		parts = append(parts,
+			fmt.Sprintf(`qop=auth`),
+			fmt.Sprintf(`nc=%s`, nc),
+			fmt.Sprintf(`cnonce="%s"`, cnonce),
+		)
+	}
+
+	return "Digest " + strings.Join(parts, ", ")
+}
+
+func md5sum(s string) string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(s)))
+}

--- a/veles/secrets/mongodbatlasapikey/validator.go
+++ b/veles/secrets/mongodbatlasapikey/validator.go
@@ -165,19 +165,25 @@ func parseDigestChallenge(header string) (*digestChallenge, error) {
 	return c, nil
 }
 
-// computeDigestAuth computes the Authorization header for HTTP Digest Authentication.
+// computeDigestAuth computes the Authorization header for HTTP Digest Authentication
+// (RFC 2617). MD5 is mandated by the protocol — MongoDB Atlas Admin API v1.0 requires it.
+// This mirrors clients/datasource/http_auth.go which uses the same pattern.
 func computeDigestAuth(username, password, method, uri string, c *digestChallenge) string {
-	ha1 := md5sum(fmt.Sprintf("%s:%s:%s", username, c.realm, password))
-	ha2 := md5sum(fmt.Sprintf("%s:%s", method, uri))
+	//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617), not used for password storage.
+	ha1 := fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s:%s", username, c.realm, password))))
+	//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617).
+	ha2 := fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s", method, uri))))
 
 	nc := "00000001"
 	cnonce := fmt.Sprintf("%08x", rand.Int31())
 
 	var response string
 	if strings.Contains(c.qop, "auth") {
-		response = md5sum(fmt.Sprintf("%s:%s:%s:%s:%s:%s", ha1, c.nonce, nc, cnonce, "auth", ha2))
+		//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617).
+		response = fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s:%s:%s:%s:%s", ha1, c.nonce, nc, cnonce, "auth", ha2))))
 	} else {
-		response = md5sum(fmt.Sprintf("%s:%s:%s", ha1, c.nonce, ha2))
+		//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617).
+		response = fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s:%s", ha1, c.nonce, ha2))))
 	}
 
 	parts := []string{
@@ -198,8 +204,4 @@ func computeDigestAuth(username, password, method, uri string, c *digestChalleng
 	}
 
 	return "Digest " + strings.Join(parts, ", ")
-}
-
-func md5sum(s string) string {
-	return fmt.Sprintf("%x", md5.Sum([]byte(s)))
 }

--- a/veles/secrets/mongodbatlasapikey/validator.go
+++ b/veles/secrets/mongodbatlasapikey/validator.go
@@ -17,6 +17,7 @@ package mongodbatlasapikey
 import (
 	"context"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -87,7 +88,7 @@ func (v *Validator) Validate(ctx context.Context, secret APIKey) (veles.Validati
 
 	wwwAuth := resp.Header.Get("Www-Authenticate")
 	if wwwAuth == "" {
-		return veles.ValidationFailed, fmt.Errorf("missing Www-Authenticate header")
+		return veles.ValidationFailed, errors.New("missing Www-Authenticate header")
 	}
 
 	challenge, err := parseDigestChallenge(wwwAuth)
@@ -158,7 +159,7 @@ func parseDigestChallenge(header string) (*digestChallenge, error) {
 	}
 
 	if c.nonce == "" {
-		return nil, fmt.Errorf("missing nonce in digest challenge")
+		return nil, errors.New("missing nonce in digest challenge")
 	}
 
 	return c, nil
@@ -185,13 +186,13 @@ func computeDigestAuth(username, password, method, uri string, c *digestChalleng
 		fmt.Sprintf(`nonce="%s"`, c.nonce),
 		fmt.Sprintf(`uri="%s"`, uri),
 		fmt.Sprintf(`response="%s"`, response),
-		fmt.Sprintf(`algorithm=%s`, c.algorithm),
+		"algorithm=" + c.algorithm,
 	}
 
 	if strings.Contains(c.qop, "auth") {
 		parts = append(parts,
-			fmt.Sprintf(`qop=auth`),
-			fmt.Sprintf(`nc=%s`, nc),
+			"qop=auth",
+			"nc="+nc,
 			fmt.Sprintf(`cnonce="%s"`, cnonce),
 		)
 	}

--- a/veles/secrets/mongodbatlasapikey/validator.go
+++ b/veles/secrets/mongodbatlasapikey/validator.go
@@ -170,9 +170,9 @@ func parseDigestChallenge(header string) (*digestChallenge, error) {
 // This mirrors clients/datasource/http_auth.go which uses the same pattern.
 func computeDigestAuth(username, password, method, uri string, c *digestChallenge) string {
 	//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617), not used for password storage.
-	ha1 := fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s:%s", username, c.realm, password))))
+	ha1 := fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s:%s:%s", username, c.realm, password)))
 	//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617).
-	ha2 := fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s", method, uri))))
+	ha2 := fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s:%s", method, uri)))
 
 	nc := "00000001"
 	cnonce := fmt.Sprintf("%08x", rand.Int31())
@@ -180,10 +180,10 @@ func computeDigestAuth(username, password, method, uri string, c *digestChalleng
 	var response string
 	if strings.Contains(c.qop, "auth") {
 		//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617).
-		response = fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s:%s:%s:%s:%s", ha1, c.nonce, nc, cnonce, "auth", ha2))))
+		response = fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s:%s:%s:%s:%s:%s", ha1, c.nonce, nc, cnonce, "auth", ha2)))
 	} else {
 		//nolint:gosec // MD5 is required by HTTP Digest Auth (RFC 2617).
-		response = fmt.Sprintf("%x", md5.Sum([]byte(fmt.Sprintf("%s:%s:%s", ha1, c.nonce, ha2))))
+		response = fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s:%s:%s", ha1, c.nonce, ha2)))
 	}
 
 	parts := []string{

--- a/veles/secrets/mongodbatlasapikey/validator_test.go
+++ b/veles/secrets/mongodbatlasapikey/validator_test.go
@@ -34,7 +34,7 @@ const (
 
 // mockAtlasServer creates a mock MongoDB Atlas API server for testing.
 // It implements HTTP Digest Authentication.
-func mockAtlasServer(t *testing.T, expectedPublicKey, expectedPrivateKey string, authResponseCode int) *httptest.Server {
+func mockAtlasServer(t *testing.T, expectedPublicKey string, authResponseCode int) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +43,7 @@ func mockAtlasServer(t *testing.T, expectedPublicKey, expectedPrivateKey string,
 		if authHeader == "" {
 			// No auth header: return 401 with Digest challenge.
 			w.Header().Set("Www-Authenticate",
-				fmt.Sprintf(`Digest realm="MMS Public API", nonce="testnonce123", qop="auth", algorithm=MD5`))
+				`Digest realm="MMS Public API", nonce="testnonce123", qop="auth", algorithm=MD5`)
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -138,7 +138,7 @@ func TestValidator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var server *httptest.Server
 			if tc.serverExpectedKey != "" || tc.serverResponseCode != 0 {
-				server = mockAtlasServer(t, tc.serverExpectedKey, "", tc.serverResponseCode)
+				server = mockAtlasServer(t, tc.serverExpectedKey, tc.serverResponseCode)
 				defer server.Close()
 			}
 

--- a/veles/secrets/mongodbatlasapikey/validator_test.go
+++ b/veles/secrets/mongodbatlasapikey/validator_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlasapikey_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/mongodbatlasapikey"
+)
+
+const (
+	validPublicKey  = "abcdef01"
+	validPrivateKey = "12345678-abcd-1234-abcd-123456789012"
+)
+
+// mockAtlasServer creates a mock MongoDB Atlas API server for testing.
+// It implements HTTP Digest Authentication.
+func mockAtlasServer(t *testing.T, expectedPublicKey, expectedPrivateKey string, authResponseCode int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+
+		if authHeader == "" {
+			// No auth header: return 401 with Digest challenge.
+			w.Header().Set("Www-Authenticate",
+				fmt.Sprintf(`Digest realm="MMS Public API", nonce="testnonce123", qop="auth", algorithm=MD5`))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Verify the username in the digest auth matches the expected public key.
+		if expectedPublicKey != "" && !containsUsername(authHeader, expectedPublicKey) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(authResponseCode)
+	}))
+}
+
+// containsUsername checks if the Authorization header contains the expected username.
+func containsUsername(authHeader, username string) bool {
+	expected := fmt.Sprintf(`username="%s"`, username)
+	return len(authHeader) > 0 && contains(authHeader, expected)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name               string
+		publicKey          string
+		privateKey         string
+		serverExpectedKey  string
+		serverResponseCode int
+		want               veles.ValidationStatus
+		wantErr            error
+	}{
+		{
+			name:               "valid_key",
+			publicKey:          validPublicKey,
+			privateKey:         validPrivateKey,
+			serverExpectedKey:  validPublicKey,
+			serverResponseCode: http.StatusOK,
+			want:               veles.ValidationValid,
+		},
+		{
+			name:               "valid_key_forbidden_scope",
+			publicKey:          validPublicKey,
+			privateKey:         validPrivateKey,
+			serverExpectedKey:  validPublicKey,
+			serverResponseCode: http.StatusForbidden,
+			want:               veles.ValidationValid,
+		},
+		{
+			name:               "invalid_key_unauthorized",
+			publicKey:          "wrongkey1",
+			privateKey:         "00000000-0000-0000-0000-000000000000",
+			serverExpectedKey:  validPublicKey,
+			serverResponseCode: http.StatusUnauthorized,
+			want:               veles.ValidationInvalid,
+		},
+		{
+			name:       "empty_public_key",
+			publicKey:  "",
+			privateKey: validPrivateKey,
+			want:       veles.ValidationInvalid,
+		},
+		{
+			name:       "empty_private_key",
+			publicKey:  validPublicKey,
+			privateKey: "",
+			want:       veles.ValidationInvalid,
+		},
+		{
+			name:               "server_error",
+			publicKey:          validPublicKey,
+			privateKey:         validPrivateKey,
+			serverExpectedKey:  validPublicKey,
+			serverResponseCode: http.StatusInternalServerError,
+			want:               veles.ValidationFailed,
+			wantErr:            cmpopts.AnyError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var server *httptest.Server
+			if tc.serverExpectedKey != "" || tc.serverResponseCode != 0 {
+				server = mockAtlasServer(t, tc.serverExpectedKey, "", tc.serverResponseCode)
+				defer server.Close()
+			}
+
+			validator := mongodbatlasapikey.NewValidator()
+			if server != nil {
+				validator.Endpoint = server.URL
+			}
+
+			key := mongodbatlasapikey.APIKey{
+				PublicKey:  tc.publicKey,
+				PrivateKey: tc.privateKey,
+			}
+
+			got, err := validator.Validate(t.Context(), key)
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
+			}
+
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidator_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Www-Authenticate", `Digest realm="MMS Public API", nonce="testnonce", qop="auth"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	validator := mongodbatlasapikey.NewValidator()
+	validator.Endpoint = server.URL
+
+	key := mongodbatlasapikey.APIKey{
+		PublicKey:  validPublicKey,
+		PrivateKey: validPrivateKey,
+	}
+
+	// Create a cancelled context.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	got, err := validator.Validate(ctx, key)
+
+	if err == nil {
+		t.Errorf("Validate() expected error due to context cancellation, got nil")
+	}
+	if got != veles.ValidationFailed {
+		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Implements detection and validation of MongoDB Atlas API key pairs (`public_api_key` + `private_api_key`) as found in Atlas CLI configuration files.

Fixes #1451

## Components

### Veles Secret Detector (`veles/secrets/mongodbatlasapikey/`)
- **Pair detector**: Context-aware matching of `public_api_key`/`private_api_key` patterns using the `pair.Detector` framework
- Supports TOML, YAML, and environment variable formats
- Handles partial matches (public key only or private key only)

### Validator (`validator.go`)
- Validates API keys via the MongoDB Atlas Admin API v2 (`https://cloud.mongodb.com/api/atlas/v2`)
- Implements **HTTP Digest Authentication** (required by the Atlas API)
- Returns `ValidationValid` for HTTP 200/403, `ValidationInvalid` for 401

### Filesystem Extractor (`extractor/filesystem/secrets/mongodbatlasapikey/`)
- Targets `~/.config/atlascli/config.toml` (Atlas CLI)
- Targets `~/.config/mongocli/config.toml` (legacy MongoDB CLI)

## Files Changed
- `veles/secrets/mongodbatlasapikey/` — Secret type, detector, and validator (5 files)
- `extractor/filesystem/secrets/mongodbatlasapikey/` — Filesystem extractor with tests and testdata (5 files)
- `extractor/filesystem/list/list.go` — Register detector and extractor
- `enricher/enricherlist/list.go` — Register validator
- `docs/supported_inventory_types.md` — Add documentation entry

## Notes
- Proto/secret.go integration deferred — the proto message definition (`MongoDBAtlasAPIKey`) and mapping functions can be added as part of the merge process. The core detection and validation logic is complete and tested.
- The existing `urlcreds` detector already covers `mongodb+srv://user:pass@host` connection strings, so this PR focuses specifically on the Atlas CLI API key format.