### PR TITLE
Harden Maven registry trust for pom.xml sourced entries

### DIFF
--- a/clients/datasource/export_test.go
+++ b/clients/datasource/export_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasource
+
+// SetLookupHostForTest replaces the package level host resolver used by
+// validateUntrustedRegistryURL and returns a function that restores the
+// original. Exported only for use by tests in the datasource_test
+// package that exercise AddRegistry against loopback mock servers.
+func SetLookupHostForTest(fn func(string) ([]string, error)) func() {
+	orig := lookupHost
+	lookupHost = fn
+	return func() { lookupHost = orig }
+}

--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -21,7 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -44,6 +46,51 @@ const mavenCentral = "https://repo.maven.apache.org/maven2"
 const artifactRegistryScheme = "artifactregistry"
 
 var errAPIFailed = errors.New("API query failed")
+
+// errUntrustedRegistry indicates a Maven registry URL sourced from an
+// untrusted location (e.g. a pom.xml <repositories> entry) failed
+// validation and must not be queried.
+var errUntrustedRegistry = errors.New("untrusted Maven registry URL")
+
+// lookupHost is indirected through a package variable so tests can stub
+// DNS resolution when validating untrusted registry URLs.
+var lookupHost = net.LookupHost
+
+// validateUntrustedRegistryURL enforces the rules applied to Maven
+// registry URLs that originate from untrusted sources such as a scanned
+// pom.xml. The URL must use http or https, have a non-empty host, and
+// resolve exclusively to public unicast addresses. Any loopback, link
+// local, private, unspecified or multicast address causes rejection to
+// prevent server-side request forgery against internal services, cloud
+// metadata endpoints, and the local host.
+func validateUntrustedRegistryURL(u *url.URL) error {
+	if u == nil {
+		return fmt.Errorf("%w: nil URL", errUntrustedRegistry)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("%w: scheme %q not allowed", errUntrustedRegistry, u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("%w: empty host", errUntrustedRegistry)
+	}
+	addrs, err := lookupHost(host)
+	if err != nil {
+		return fmt.Errorf("%w: resolving %q: %w", errUntrustedRegistry, host, err)
+	}
+	for _, a := range addrs {
+		ip, err := netip.ParseAddr(a)
+		if err != nil {
+			return fmt.Errorf("%w: parsing resolved address %q: %w", errUntrustedRegistry, a, err)
+		}
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+			return fmt.Errorf("%w: host %q resolves to non-public address %s", errUntrustedRegistry, host, a)
+		}
+	}
+	return nil
+}
 
 // MavenRegistryAPIClient defines a client to fetch metadata from a Maven registry.
 type MavenRegistryAPIClient struct {
@@ -75,6 +122,15 @@ type MavenRegistry struct {
 	ID               string
 	ReleasesEnabled  bool
 	SnapshotsEnabled bool
+
+	// TrustedForAuth indicates whether this registry originates from a
+	// trusted source (the tool's own configuration) and is therefore
+	// eligible to be sent credentials from the user's settings.xml. It
+	// must remain false for registries discovered in scanned pom.xml
+	// files, otherwise an attacker-controlled pom.xml could reuse a
+	// known settings.xml server ID to exfiltrate the associated
+	// credentials to an attacker-controlled URL.
+	TrustedForAuth bool
 }
 
 // NewMavenRegistryAPIClient returns a new MavenRegistryAPIClient.
@@ -92,6 +148,10 @@ func NewMavenRegistryAPIClient(ctx context.Context, registry MavenRegistry, loca
 		return nil, fmt.Errorf("invalid Maven registry %s: %w", registry.URL, err)
 	}
 	registry.Parsed = u
+	// The default registry is configured by the tool itself, not by
+	// content scanned from a user-supplied pom.xml, and is therefore
+	// trusted to receive credentials from settings.xml.
+	registry.TrustedForAuth = true
 
 	if localRegistry != "" {
 		localRegistry = filepath.Join(localRegistry, "maven")
@@ -137,7 +197,30 @@ func (m *MavenRegistryAPIClient) WithoutRegistries() *MavenRegistryAPIClient {
 }
 
 // AddRegistry adds the given registry to the list of registries if it has not been added.
+//
+// AddRegistry is the entry point for Maven registries discovered while
+// scanning untrusted pom.xml files, so it validates the URL against
+// validateUntrustedRegistryURL and always records the registry as
+// untrusted for authentication purposes. Callers that need to register
+// a trusted registry must construct the client via
+// NewMavenRegistryAPIClient with the registry supplied at construction
+// time.
 func (m *MavenRegistryAPIClient) AddRegistry(ctx context.Context, registry MavenRegistry) error {
+	u, err := url.Parse(registry.URL)
+	if err != nil {
+		return err
+	}
+	if err := validateUntrustedRegistryURL(u); err != nil {
+		log.Warnf("Rejecting Maven registry %q from pom.xml: %v", registry.URL, err)
+		return err
+	}
+	registry.Parsed = u
+	// Registries reached through AddRegistry always originate from
+	// untrusted scanned content. Force TrustedForAuth off so
+	// settings.xml credentials are never attached to requests against
+	// them, regardless of what the caller passed in.
+	registry.TrustedForAuth = false
+
 	if registry.ID == m.defaultRegistry.ID {
 		return m.updateDefaultRegistry(ctx, registry)
 	}
@@ -148,12 +231,6 @@ func (m *MavenRegistryAPIClient) AddRegistry(ctx context.Context, registry Maven
 		}
 	}
 
-	u, err := url.Parse(registry.URL)
-	if err != nil {
-		return err
-	}
-
-	registry.Parsed = u
 	m.registries = append(m.registries, registry)
 	if registry.Parsed.Scheme == artifactRegistryScheme {
 		m.createGoogleClient(ctx)
@@ -163,12 +240,14 @@ func (m *MavenRegistryAPIClient) AddRegistry(ctx context.Context, registry Maven
 }
 
 func (m *MavenRegistryAPIClient) updateDefaultRegistry(ctx context.Context, registry MavenRegistry) error {
-	u, err := url.Parse(registry.URL)
-	if err != nil {
-		return err
+	if registry.Parsed == nil {
+		u, err := url.Parse(registry.URL)
+		if err != nil {
+			return err
+		}
+		registry.Parsed = u
 	}
 	log.Infof("The default Maven registry is being overwritten from %s to %s", m.defaultRegistry.URL, registry.URL)
-	registry.Parsed = u
 	m.defaultRegistry = registry
 	if registry.Parsed.Scheme == artifactRegistryScheme {
 		m.createGoogleClient(ctx)
@@ -200,6 +279,18 @@ func (m *MavenRegistryAPIClient) DisableGoogleAuth() {
 // GetRegistries returns the registries added to this client.
 func (m *MavenRegistryAPIClient) GetRegistries() (registries []MavenRegistry) {
 	return m.registries
+}
+
+// authFor returns the HTTP authentication to attach to requests for the
+// given registry. Authentication from settings.xml is only returned for
+// registries marked TrustedForAuth; untrusted registries (those added
+// from scanned pom.xml content) always receive a nil authentication so
+// the caller's credentials cannot be leaked to an attacker-chosen URL.
+func (m *MavenRegistryAPIClient) authFor(registry MavenRegistry) *HTTPAuthentication {
+	if !registry.TrustedForAuth {
+		return nil
+	}
+	return m.registryAuths[registry.ID]
 }
 
 // GetProject fetches a pom.xml specified by groupID, artifactID and version and parses it to maven.Project.
@@ -278,7 +369,7 @@ func (m *MavenRegistryAPIClient) getProject(ctx context.Context, registry MavenR
 	}
 
 	var project maven.Project
-	if err := m.get(ctx, m.registryAuths[registry.ID], registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, version, fmt.Sprintf("%s-%s.pom", artifactID, snapshot)}, &project); err != nil {
+	if err := m.get(ctx, m.authFor(registry), registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, version, fmt.Sprintf("%s-%s.pom", artifactID, snapshot)}, &project); err != nil {
 		return maven.Project{}, err
 	}
 
@@ -288,7 +379,7 @@ func (m *MavenRegistryAPIClient) getProject(ctx context.Context, registry MavenR
 // getVersionMetadata fetches a version level maven-metadata.xml and parses it to maven.Metadata.
 func (m *MavenRegistryAPIClient) getVersionMetadata(ctx context.Context, registry MavenRegistry, groupID, artifactID, version string) (maven.Metadata, error) {
 	var metadata maven.Metadata
-	if err := m.get(ctx, m.registryAuths[registry.ID], registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, version, "maven-metadata.xml"}, &metadata); err != nil {
+	if err := m.get(ctx, m.authFor(registry), registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, version, "maven-metadata.xml"}, &metadata); err != nil {
 		return maven.Metadata{}, err
 	}
 
@@ -298,7 +389,7 @@ func (m *MavenRegistryAPIClient) getVersionMetadata(ctx context.Context, registr
 // GetArtifactMetadata fetches an artifact level maven-metadata.xml and parses it to maven.Metadata.
 func (m *MavenRegistryAPIClient) getArtifactMetadata(ctx context.Context, registry MavenRegistry, groupID, artifactID string) (maven.Metadata, error) {
 	var metadata maven.Metadata
-	if err := m.get(ctx, m.registryAuths[registry.ID], registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, "maven-metadata.xml"}, &metadata); err != nil {
+	if err := m.get(ctx, m.authFor(registry), registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, "maven-metadata.xml"}, &metadata); err != nil {
 		return maven.Metadata{}, err
 	}
 

--- a/clients/datasource/maven_registry_auth_test.go
+++ b/clients/datasource/maven_registry_auth_test.go
@@ -23,6 +23,13 @@ import (
 )
 
 func TestWithoutRegistriesMaintainsAuthData(t *testing.T) {
+	// AddRegistry validates that registry hosts resolve to public
+	// addresses. The test registries below use synthetic hostnames, so
+	// stub the resolver to return a deterministic public address.
+	origLookup := lookupHost
+	lookupHost = func(string) ([]string, error) { return []string{"203.0.113.1"}, nil }
+	t.Cleanup(func() { lookupHost = origLookup })
+
 	// Create mock server to test auth is maintained
 	srv := clienttest.NewMockHTTPServer(t)
 

--- a/clients/datasource/maven_registry_test.go
+++ b/clients/datasource/maven_registry_test.go
@@ -106,6 +106,12 @@ func TestGetProjectSnapshot(t *testing.T) {
 }
 
 func TestMultipleRegistry(t *testing.T) {
+	// AddRegistry rejects loopback URLs by default, so pretend the mock
+	// server's 127.0.0.1 address resolves to a public address for the
+	// duration of this test.
+	t.Cleanup(datasource.SetLookupHostForTest(func(string) ([]string, error) {
+		return []string{"203.0.113.1"}, nil
+	}))
 	dft := clienttest.NewMockHTTPServer(t)
 	client, _ := datasource.NewDefaultMavenRegistryAPIClient(t.Context(), dft.URL)
 	dft.SetResponse(t, "org/example/x.y.z/maven-metadata.xml", []byte(`
@@ -196,6 +202,12 @@ func TestMultipleRegistry(t *testing.T) {
 }
 
 func TestUpdateDefaultRegistry(t *testing.T) {
+	// AddRegistry rejects loopback URLs by default, so pretend the mock
+	// server's 127.0.0.1 address resolves to a public address for the
+	// duration of this test.
+	t.Cleanup(datasource.SetLookupHostForTest(func(string) ([]string, error) {
+		return []string{"203.0.113.1"}, nil
+	}))
 	dft := clienttest.NewMockHTTPServer(t)
 	client, _ := datasource.NewDefaultMavenRegistryAPIClient(t.Context(), dft.URL)
 	dft.SetResponse(t, "org/example/x.y.z/maven-metadata.xml", []byte(`

--- a/clients/datasource/maven_registry_validation_test.go
+++ b/clients/datasource/maven_registry_validation_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasource
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAddRegistry_RejectsUntrustedURL(t *testing.T) {
+	origLookup := lookupHost
+	t.Cleanup(func() { lookupHost = origLookup })
+
+	cases := []struct {
+		name      string
+		url       string
+		resolveTo []string
+	}{
+		{name: "non-http scheme", url: "file:///etc/passwd", resolveTo: nil},
+		{name: "ftp scheme", url: "ftp://example.com/repo", resolveTo: []string{"203.0.113.10"}},
+		{name: "artifactregistry scheme from pom.xml", url: "artifactregistry://evil.example/repo", resolveTo: []string{"203.0.113.11"}},
+		{name: "loopback literal", url: "http://127.0.0.1/repo", resolveTo: []string{"127.0.0.1"}},
+		{name: "rfc1918 literal", url: "http://10.0.0.1/repo", resolveTo: []string{"10.0.0.1"}},
+		{name: "link-local literal", url: "http://169.254.169.254/repo", resolveTo: []string{"169.254.169.254"}},
+		{name: "dns-rebind to private", url: "http://evil.example.com/repo", resolveTo: []string{"192.168.1.1"}},
+		{name: "empty host", url: "http:///repo", resolveTo: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lookupHost = func(string) ([]string, error) { return tc.resolveTo, nil }
+			client, err := NewMavenRegistryAPIClient(
+				context.Background(),
+				MavenRegistry{URL: "https://repo.maven.apache.org/maven2", ReleasesEnabled: true},
+				"",
+				true,
+			)
+			if err != nil {
+				t.Fatalf("NewMavenRegistryAPIClient: %v", err)
+			}
+			err = client.AddRegistry(context.Background(), MavenRegistry{URL: tc.url, ID: "hostile"})
+			if err == nil {
+				t.Fatalf("AddRegistry(%q) = nil, want error", tc.url)
+			}
+			if got := client.GetRegistries(); len(got) != 0 {
+				t.Errorf("registry was added despite validation failure: %+v", got)
+			}
+		})
+	}
+}
+
+func TestAddRegistry_ClearsTrustedForAuth(t *testing.T) {
+	origLookup := lookupHost
+	lookupHost = func(string) ([]string, error) { return []string{"203.0.113.42"}, nil }
+	t.Cleanup(func() { lookupHost = origLookup })
+
+	client, err := NewMavenRegistryAPIClient(
+		context.Background(),
+		MavenRegistry{URL: "https://repo.maven.apache.org/maven2", ReleasesEnabled: true},
+		"",
+		true,
+	)
+	if err != nil {
+		t.Fatalf("NewMavenRegistryAPIClient: %v", err)
+	}
+
+	// The caller tries to smuggle in TrustedForAuth=true; AddRegistry must drop it.
+	if err := client.AddRegistry(
+		context.Background(),
+		MavenRegistry{URL: "https://attacker.example/repo", ID: "hostile", TrustedForAuth: true},
+	); err != nil {
+		t.Fatalf("AddRegistry: %v", err)
+	}
+	regs := client.GetRegistries()
+	if len(regs) != 1 {
+		t.Fatalf("expected 1 added registry, got %d", len(regs))
+	}
+	if regs[0].TrustedForAuth {
+		t.Errorf("AddRegistry left TrustedForAuth=true for an untrusted registry")
+	}
+}
+
+func TestAddRegistry_UntrustedCannotOverwriteDefault(t *testing.T) {
+	origLookup := lookupHost
+	lookupHost = func(string) ([]string, error) { return []string{"203.0.113.55"}, nil }
+	t.Cleanup(func() { lookupHost = origLookup })
+
+	client, err := NewMavenRegistryAPIClient(
+		context.Background(),
+		MavenRegistry{URL: "https://repo.maven.apache.org/maven2", ID: "central", ReleasesEnabled: true},
+		"",
+		true,
+	)
+	if err != nil {
+		t.Fatalf("NewMavenRegistryAPIClient: %v", err)
+	}
+
+	// A pom.xml-sourced registry whose ID collides with the default
+	// must not inherit the default registry's trusted status.
+	if err := client.AddRegistry(
+		context.Background(),
+		MavenRegistry{URL: "https://attacker.example/repo", ID: "central", TrustedForAuth: true},
+	); err != nil {
+		t.Fatalf("AddRegistry: %v", err)
+	}
+	if client.defaultRegistry.TrustedForAuth {
+		t.Errorf("default registry was marked trusted after an untrusted overwrite")
+	}
+}
+
+func TestAuthFor_OnlyTrustedRegistriesReceiveCredentials(t *testing.T) {
+	m := &MavenRegistryAPIClient{
+		registryAuths: map[string]*HTTPAuthentication{
+			"central": {Username: "u", Password: "p"},
+		},
+	}
+	trusted := MavenRegistry{ID: "central", TrustedForAuth: true}
+	if got := m.authFor(trusted); got == nil {
+		t.Errorf("authFor(trusted) = nil, want credentials")
+	}
+	untrusted := MavenRegistry{ID: "central", TrustedForAuth: false}
+	if got := m.authFor(untrusted); got != nil {
+		t.Errorf("authFor(untrusted) returned credentials, leak")
+	}
+}


### PR DESCRIPTION
## Summary

Follows up on #1877 and ports the hardening that was originally staged against `osv-scanner` (PR google/osv-scanner#2713, closed in favour of landing the fix here). Registries discovered while scanning a user supplied pom.xml are treated as untrusted input throughout `clients/datasource`.

- `MavenRegistryAPIClient.AddRegistry` now validates the URL before recording it. The scheme must be `http` or `https`, and the host must resolve exclusively to public unicast addresses. Loopback, private, link local, unspecified and multicast destinations are rejected so a scanned pom.xml cannot steer requests at the local host, cloud metadata endpoints, or internal infrastructure. The default registry passed to `NewMavenRegistryAPIClient` is exempt, so users can still point the client at an internal Artifactory or Nexus mirror.
- `MavenRegistry` now carries a `TrustedForAuth` flag. It is only set on the default registry constructed through `NewMavenRegistryAPIClient`; `AddRegistry` always clears it, even for callers that try to set it explicitly. The three fetch helpers (`getProject`, `getVersionMetadata`, `getArtifactMetadata`) now go through a small `authFor` helper that refuses to attach `settings.xml` credentials to untrusted registries. That prevents a scanned pom.xml from reusing a known `settings.xml` `<server>` ID to exfiltrate the associated credentials to an attacker-chosen URL.

## Test plan

- [x] `go test ./clients/datasource/...`
- [x] `go test ./clients/... ./internal/mavenutil/... ./enricher/transitivedependency/pomxml/... ./guidedremediation/internal/manifest/maven/...`
- [x] `go vet ./clients/datasource/...`
- [x] New table-driven tests cover non-http schemes, loopback / RFC1918 / link-local literals, DNS-rebind style public-to-private resolutions, a pom.xml attempt to overwrite the default registry ID, and `TrustedForAuth` smuggling via a caller supplied struct. Existing `TestMultipleRegistry`, `TestUpdateDefaultRegistry` and `TestWithoutRegistriesMaintainsAuthData` stub `lookupHost` so their mock HTTP servers remain reachable under the new validator.