### PR TITLE
Acceptance tests for secrets validator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ lint-plugger:
 test:
 	CGO_ENABLED=1 go test ./...
 
+test-accept-validator:
+	ONLINE=1 CGO_ENABLED=1 go test ./veles/secrets/... -run 'TestAccept.*Validator'
+
 test_bench:
 	# add `-benchmem -cpuprofile=cpu.prof -memprofile=mem.prof` to extract cpu and memory profiling
 	# then check check pprof with `go tool pprof -http=:8080 cpu.prof`

--- a/veles/secrets/anthropicapikey/model_validator_test.go
+++ b/veles/secrets/anthropicapikey/model_validator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/anthropicapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
@@ -61,6 +62,20 @@ func mockAnthropicModelServer(t *testing.T, expectedKey string, statusCode int, 
 	}))
 
 	return server
+}
+
+func TestAcceptModelValidator(t *testing.T) {
+	brokenValidator := anthropicapikey.NewModelValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		anthropicapikey.NewModelValidator(),
+		velestest.WithTrueNegatives(anthropicapikey.ModelAPIKey{
+			Key: "sk-ant-api03-osvscalibr-invalid000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
 }
 
 func TestModelValidator(t *testing.T) {

--- a/veles/secrets/anthropicapikey/workspace_validator_test.go
+++ b/veles/secrets/anthropicapikey/workspace_validator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/anthropicapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
@@ -61,6 +62,20 @@ func mockAnthropicWorkspaceServer(t *testing.T, expectedKey string, statusCode i
 	}))
 
 	return server
+}
+
+func TestAcceptMWorkspaceValidator(t *testing.T) {
+	brokenValidator := anthropicapikey.NewWorkspaceValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		anthropicapikey.NewWorkspaceValidator(),
+		velestest.WithTrueNegatives(anthropicapikey.WorkspaceAPIKey{
+			Key: "sk-ant-admin01-osvscalibr-invalid0000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
 }
 
 func TestWorkspaceValidator(t *testing.T) {

--- a/veles/secrets/awsaccesskey/validator.go
+++ b/veles/secrets/awsaccesskey/validator.go
@@ -29,6 +29,8 @@ import (
 const (
 	// CodeSignatureDoesNotMatch is returned by AWS if a request and the signature don't match
 	CodeSignatureDoesNotMatch = "SignatureDoesNotMatch"
+	// InvalidClientTokenId is returned by AWS if the provided token id is not valid
+	InvalidClientTokenId = "InvalidClientTokenId"
 	// CodeAccessDenied is returned by AWS if the user doesn't have access to a resource
 	CodeAccessDenied = "AccessDenied"
 )
@@ -110,7 +112,7 @@ func (v *Validator) Validate(ctx context.Context, key Credentials) (veles.Valida
 	}
 
 	switch errResp.Error.Code {
-	case CodeSignatureDoesNotMatch:
+	case CodeSignatureDoesNotMatch, InvalidClientTokenId:
 		// Signature mismatch => credentials invalid
 		return veles.ValidationInvalid, nil
 	case CodeAccessDenied:

--- a/veles/secrets/awsaccesskey/validator.go
+++ b/veles/secrets/awsaccesskey/validator.go
@@ -29,8 +29,8 @@ import (
 const (
 	// CodeSignatureDoesNotMatch is returned by AWS if a request and the signature don't match
 	CodeSignatureDoesNotMatch = "SignatureDoesNotMatch"
-	// InvalidClientTokenId is returned by AWS if the provided token id is not valid
-	InvalidClientTokenId = "InvalidClientTokenId"
+	// InvalidClientTokenID is returned by AWS if the provided token id is not valid
+	InvalidClientTokenID = "InvalidClientTokenId"
 	// CodeAccessDenied is returned by AWS if the user doesn't have access to a resource
 	CodeAccessDenied = "AccessDenied"
 )
@@ -112,7 +112,7 @@ func (v *Validator) Validate(ctx context.Context, key Credentials) (veles.Valida
 	}
 
 	switch errResp.Error.Code {
-	case CodeSignatureDoesNotMatch, InvalidClientTokenId:
+	case CodeSignatureDoesNotMatch, InvalidClientTokenID:
 		// Signature mismatch => credentials invalid
 		return veles.ValidationInvalid, nil
 	case CodeAccessDenied:

--- a/veles/secrets/awsaccesskey/validator_test.go
+++ b/veles/secrets/awsaccesskey/validator_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/awsaccesskey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 type fakeSigner struct{}
@@ -97,6 +98,21 @@ const (
 	badSecret        = "badSecret"
 	correctSignature = exampleAccessID + ":" + correctSecret
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := awsaccesskey.NewValidator()
+	brokenValidator.SetHTTPClient(velestest.BrokenClient)
+
+	velestest.AcceptValidator(
+		t,
+		awsaccesskey.NewValidator(),
+		velestest.WithTrueNegatives(awsaccesskey.Credentials{
+			AccessID: exampleAccessID,
+			Secret:   badSecret,
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 func TestValidator(t *testing.T) {
 	cases := []struct {

--- a/veles/secrets/bitwardenoauth2access/validator_test.go
+++ b/veles/secrets/bitwardenoauth2access/validator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/bitwardenoauth2access"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
@@ -91,6 +92,21 @@ func mockBitwardenServer(t *testing.T, expectedClientID, expectedClientSecret st
 
 		w.WriteHeader(http.StatusBadRequest)
 	}))
+}
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := bitwardenoauth2access.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		bitwardenoauth2access.NewValidator(),
+		velestest.WithTrueNegatives(bitwardenoauth2access.Token{
+			ClientID:     validatorTestClientID,
+			ClientSecret: "invalid_secret_1234567890",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
 }
 
 func TestValidator(t *testing.T) {

--- a/veles/secrets/bitwardenoauth2access/validator_test.go
+++ b/veles/secrets/bitwardenoauth2access/validator_test.go
@@ -15,7 +15,6 @@
 package bitwardenoauth2access_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -167,94 +166,6 @@ func TestValidator(t *testing.T) {
 			// Check validation status
 			if got != tc.want {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	// Create a server that responds OK
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := bitwardenoauth2access.NewValidator()
-	validator.HTTPC = client
-
-	// Create a test token
-	token := bitwardenoauth2access.Token{
-		ClientID:     validatorTestClientID,
-		ClientSecret: validatorTestClientSecret,
-	}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, token)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-	}
-}
-
-func TestValidator_InvalidRequest(t *testing.T) {
-	// Create a mock server that returns 400 Bad Request
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := bitwardenoauth2access.NewValidator()
-	validator.HTTPC = client
-
-	testCases := []struct {
-		name     string
-		token    bitwardenoauth2access.Token
-		expected veles.ValidationStatus
-	}{
-		{
-			name: "empty credentials",
-			token: bitwardenoauth2access.Token{
-				ClientID:     "",
-				ClientSecret: "",
-			},
-			expected: veles.ValidationInvalid,
-		},
-		{
-			name: "invalid format credentials",
-			token: bitwardenoauth2access.Token{
-				ClientID:     "not-a-uuid",
-				ClientSecret: "invalid",
-			},
-			expected: veles.ValidationInvalid,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := validator.Validate(t.Context(), tc.token)
-
-			if err != nil {
-				t.Errorf("Validate() unexpected error for %s: %v", tc.name, err)
-			}
-			if got != tc.expected {
-				t.Errorf("Validate() = %v, want %v for %s", got, tc.expected, tc.name)
 			}
 		})
 	}

--- a/veles/secrets/circleci/validator_test.go
+++ b/veles/secrets/circleci/validator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/circleci"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
@@ -72,6 +73,20 @@ func mockCircleCIPATServer(t *testing.T, expectedToken string, serverResponseCod
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(serverResponseCode)
 	}))
+}
+
+func TestAcceptPersonalAccessTokenValidator(t *testing.T) {
+	brokenValidator := circleci.NewPersonalAccessTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		circleci.NewPersonalAccessTokenValidator(),
+		velestest.WithTrueNegatives(circleci.PersonalAccessToken{
+			Token: "CCIPAT_invalid_token_1234567890_1234567890123456789012345678901234567890",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
 }
 
 func TestPersonalAccessTokenValidator(t *testing.T) {
@@ -171,6 +186,20 @@ func mockCircleCIProjectServer(t *testing.T, expectedToken string, serverRespons
 			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
 		}
 	}))
+}
+
+func TestAcceptProjectTokenValidator(t *testing.T) {
+	brokenValidator := circleci.NewProjectTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		circleci.NewProjectTokenValidator(),
+		velestest.WithTrueNegatives(circleci.ProjectToken{
+			Token: "CCIPRJ_invalid_token_1234567890_1234567890123456789012345678901234567890",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
 }
 
 func TestProjectTokenValidator(t *testing.T) {

--- a/veles/secrets/circleci/validator_test.go
+++ b/veles/secrets/circleci/validator_test.go
@@ -15,7 +15,6 @@
 package circleci_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -273,67 +272,5 @@ func TestProjectTokenValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestPersonalAccessTokenValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := circleci.NewPersonalAccessTokenValidator()
-	validator.HTTPC = client
-
-	token := circleci.PersonalAccessToken{Token: validatorTestPAT}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, token)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-	}
-}
-
-func TestProjectTokenValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := circleci.NewProjectTokenValidator()
-	validator.HTTPC = client
-
-	token := circleci.ProjectToken{Token: validatorTestProject}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, token)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }

--- a/veles/secrets/cloudflareapitoken/validator.go
+++ b/veles/secrets/cloudflareapitoken/validator.go
@@ -37,6 +37,6 @@ func NewValidator() *sv.Validator[cat] {
 			return map[string]string{"Authorization": "Bearer " + s.Token}
 		},
 		ValidResponseCodes:   []int{http.StatusOK},
-		InvalidResponseCodes: []int{http.StatusForbidden},
+		InvalidResponseCodes: []int{http.StatusForbidden, http.StatusBadRequest},
 	}
 }

--- a/veles/secrets/cloudflareapitoken/validator_test.go
+++ b/veles/secrets/cloudflareapitoken/validator_test.go
@@ -76,7 +76,7 @@ func TestAcceptValidator(t *testing.T) {
 		t,
 		cloudflareapitoken.NewValidator(),
 		velestest.WithTrueNegatives(cloudflareapitoken.CloudflareAPIToken{
-			Token: "invalid_token_7awgM4jG5SQvxcvmNzhKj8P",
+			Token: validatorTestToken,
 		}),
 		velestest.WithBrokenTransport(brokenValidator),
 	)

--- a/veles/secrets/cloudflareapitoken/validator_test.go
+++ b/veles/secrets/cloudflareapitoken/validator_test.go
@@ -15,7 +15,6 @@
 package cloudflareapitoken_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -131,38 +130,6 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := cloudflareapitoken.NewValidator()
-	validator.HTTPC = client
-
-	// Create a test token
-	token := cloudflareapitoken.CloudflareAPIToken{Token: validatorTestToken}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, token)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/cloudflareapitoken/validator_test.go
+++ b/veles/secrets/cloudflareapitoken/validator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/cloudflareapitoken"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestToken = "7awgM4jG5SQvxcvmNzhKj8PQjxo7awgM4jG5SQv"
@@ -66,6 +67,20 @@ func mockCloudflareServer(t *testing.T, expectedToken string) *httptest.Server {
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
+}
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := cloudflareapitoken.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		cloudflareapitoken.NewValidator(),
+		velestest.WithTrueNegatives(cloudflareapitoken.CloudflareAPIToken{
+			Token: "invalid_token_7awgM4jG5SQvxcvmNzhKj8P",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
 }
 
 func TestValidator(t *testing.T) {

--- a/veles/secrets/cratesioapitoken/validator.go
+++ b/veles/secrets/cratesioapitoken/validator.go
@@ -46,7 +46,7 @@ func NewValidator() *simplevalidate.Validator[CratesIOAPItoken] {
 		},
 		Body:                 buildRequestBody,
 		ValidResponseCodes:   []int{http.StatusNotFound},
-		InvalidResponseCodes: []int{http.StatusForbidden},
+		InvalidResponseCodes: []int{http.StatusForbidden, http.StatusUnauthorized},
 	}
 }
 

--- a/veles/secrets/cratesioapitoken/validator_test.go
+++ b/veles/secrets/cratesioapitoken/validator_test.go
@@ -15,7 +15,6 @@
 package cratesioapitoken_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -140,35 +139,6 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := mockCratesioServer(t, "Bearer "+validatorValidTestKey)
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := cratesioapitoken.NewValidator()
-	validator.HTTPC = client
-
-	key := cratesioapitoken.CratesIOAPItoken{Token: validatorValidTestKey}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/cratesioapitoken/validator_test.go
+++ b/veles/secrets/cratesioapitoken/validator_test.go
@@ -86,7 +86,10 @@ func TestAcceptValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		cratesioapitoken.NewValidator(),
-		velestest.WithTrueNegatives(cratesioapitoken.CratesIOAPItoken{Token: "random_string"}),
+		velestest.WithTrueNegatives(
+			cratesioapitoken.CratesIOAPItoken{Token: "randomKey"},
+			cratesioapitoken.CratesIOAPItoken{Token: validatorValidTestKey},
+		),
 		velestest.WithBrokenTransport(brokenValidator),
 	)
 }

--- a/veles/secrets/cratesioapitoken/validator_test.go
+++ b/veles/secrets/cratesioapitoken/validator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorValidTestKey = "cioAbCdEfGhIjKlMnOpQrStUvWxYz123456"
@@ -77,6 +78,18 @@ func mockCratesioServer(t *testing.T, expectedKey string) *httptest.Server {
 			return
 		}
 	}))
+}
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := cratesioapitoken.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		cratesioapitoken.NewValidator(),
+		velestest.WithTrueNegatives(cratesioapitoken.CratesIOAPItoken{Token: "random_string"}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
 }
 
 func TestValidator(t *testing.T) {

--- a/veles/secrets/cursorapikey/validator_test.go
+++ b/veles/secrets/cursorapikey/validator_test.go
@@ -23,12 +23,27 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	validatorTestKey = "key_abcdef0123456789abcdef0123456789" +
 		"abcdef0123456789abcdef0123456789"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := cursorapikey.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		cursorapikey.NewValidator(),
+		velestest.WithTrueNegatives(cursorapikey.APIKey{
+			Key: "key_osvscalibr_invalid0000000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockCursorServer creates a mock Cursor API server for testing.
 func mockCursorServer(t *testing.T, expectedKey string, statusCode int) *httptest.Server {

--- a/veles/secrets/denopat/validator_test.go
+++ b/veles/secrets/denopat/validator_test.go
@@ -26,11 +26,40 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestDdpPat = "ddp_qz538MNyqwfETb1ikqeqHiqA9Aa9Pv22yzmw"
 
 const validatorTestDdoPat = "ddo_4nkT2HnlnbPpGbW5RVE7DsIyfMJ3bN3YeqZT"
+
+func TestAcceptUserTokenValidator(t *testing.T) {
+	brokenValidator := denopat.NewUserTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		denopat.NewUserTokenValidator(),
+		velestest.WithTrueNegatives(denopat.DenoUserPAT{
+			Pat: "ddp_invalid000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptOrgTokenValidator(t *testing.T) {
+	brokenValidator := denopat.NewOrgTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		denopat.NewOrgTokenValidator(),
+		velestest.WithTrueNegatives(denopat.DenoOrgPAT{
+			Pat: "ddo_invalid000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/denopat/validator_test.go
+++ b/veles/secrets/denopat/validator_test.go
@@ -238,69 +238,6 @@ func TestOrgTokenValidator(t *testing.T) {
 		})
 	}
 }
-func TestUserTokenValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := denopat.NewUserTokenValidator()
-	validator.HTTPC = client
-
-	// Create a test pat
-	pat := denopat.DenoUserPAT{Pat: validatorTestDdpPat}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, pat)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-	}
-}
-
-func TestOrgTokenValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := denopat.NewOrgTokenValidator()
-	validator.HTTPC = client
-
-	// Create a test pat
-	pat := denopat.DenoOrgPAT{Pat: validatorTestDdoPat}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, pat)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-	}
-}
 
 func TestUserTokenValidator_InvalidRequest(t *testing.T) {
 	// Create a mock server that returns 401 Unauthorized

--- a/veles/secrets/digitaloceanapikey/validator_test.go
+++ b/veles/secrets/digitaloceanapikey/validator_test.go
@@ -26,9 +26,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/digitaloceanapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestKey = "dop_v1_4c6aeb9deed0fb897e585f8ecafa555dd0a9b46087b1e354bcab59b0483edfaf"
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := digitaloceanapikey.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		digitaloceanapikey.NewValidator(),
+		velestest.WithTrueNegatives(digitaloceanapikey.DigitaloceanAPIToken{
+			Key: "dop_v1_osvscalibr_invalid000000000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/digitaloceanapikey/validator_test.go
+++ b/veles/secrets/digitaloceanapikey/validator_test.go
@@ -15,7 +15,6 @@
 package digitaloceanapikey_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -157,37 +156,6 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := digitaloceanapikey.NewValidator()
-	validator.HTTPC = client
-
-	key := digitaloceanapikey.DigitaloceanAPIToken{Key: validatorTestKey}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/discordbottoken/validator_test.go
+++ b/veles/secrets/discordbottoken/validator_test.go
@@ -22,9 +22,24 @@ import (
 
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestToken = "MTIzNDU2Nzg5MDEyMzQ1Njc4.YAaBbC.dEFGhijklMNOPqrSTUVwxyzAB12"
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := discordbottoken.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		discordbottoken.NewValidator(),
+		velestest.WithTrueNegatives(discordbottoken.DiscordBotToken{
+			Token: "1234567890123456789.OSVSCALIBR.invalid0000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/dockerhubpat/validator_test.go
+++ b/veles/secrets/dockerhubpat/validator_test.go
@@ -26,10 +26,26 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/dockerhubpat"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestPat = "dckr_oat_7awgM4jG5SQvxcvmNzhKj8PQjxo"
 const validatorTestUsername = "User123"
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := dockerhubpat.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		dockerhubpat.NewValidator(),
+		velestest.WithTrueNegatives(dockerhubpat.DockerHubPAT{
+			Pat:      "dckr_pat_osvscalibr_invalid000000000000000000000000",
+			Username: validatorTestUsername,
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockDockerHubServer creates a mock Docker Hub API server for testing
 func mockDockerHubServer(t *testing.T, expectedKey string, expectedUser string) *httptest.Server {

--- a/veles/secrets/dockerhubpat/validator_test.go
+++ b/veles/secrets/dockerhubpat/validator_test.go
@@ -15,7 +15,6 @@
 package dockerhubpat_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -126,33 +125,6 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	validator := dockerhubpat.NewValidator()
-	validator.HTTPC = server.Client()
-	validator.Endpoint = server.URL + "/v2/auth/token/"
-
-	// Create a test username and pat
-	usernamePat := dockerhubpat.DockerHubPAT{Pat: validatorTestPat, Username: validatorTestUsername}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, usernamePat)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/elasticcloudapikey/validator_test.go
+++ b/veles/secrets/elasticcloudapikey/validator_test.go
@@ -26,9 +26,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/elasticcloudapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestKey = "essu_VWtSQlNXNWFjMEpWWVZsbFVUZDBORmRQTldJNmNuWnVYMU5yY1ZGdlJ6aHVlRE5rWmxGelIyUk9kdz09AAAAANx5Zs4="
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := elasticcloudapikey.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		elasticcloudapikey.NewValidator(),
+		velestest.WithTrueNegatives(elasticcloudapikey.ElasticCloudAPIKey{
+			Key: "essu_osvscalibr_invalid00000000000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/elasticcloudapikey/validator_test.go
+++ b/veles/secrets/elasticcloudapikey/validator_test.go
@@ -15,7 +15,6 @@
 package elasticcloudapikey_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -168,38 +167,6 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"user":{"id":"test-user"}}`))
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := elasticcloudapikey.NewValidator()
-	validator.HTTPC = client
-
-	key := elasticcloudapikey.ElasticCloudAPIKey{Key: validatorTestKey}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/gcpoauth2access/validator_test.go
+++ b/veles/secrets/gcpoauth2access/validator_test.go
@@ -29,11 +29,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/gcpoauth2access"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	endpoint = "https://www.googleapis.com/oauth2/v3/tokeninfo"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := gcpoauth2access.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		gcpoauth2access.NewValidator(),
+		velestest.WithTrueNegatives(gcpoauth2access.Token{Token: "osvscalibr-not-a-real-gcp-access-token"}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 type mockRoundTripper struct {
 	want *http.Request

--- a/veles/secrets/gcpsak/validator_test.go
+++ b/veles/secrets/gcpsak/validator_test.go
@@ -15,9 +15,7 @@
 package gcpsak_test
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -188,26 +186,5 @@ func TestValidator_errors(t *testing.T) {
 				t.Errorf("Validate() = %q, want %q", status, veles.ValidationFailed)
 			}
 		})
-	}
-}
-
-func TestValidator_respectsContext(t *testing.T) {
-	srv := httptest.NewTLSServer(nil)
-	t.Cleanup(func() {
-		srv.Close()
-	})
-	validator := gcpsak.NewValidator(
-		gcpsak.WithClient(srv.Client()),
-		gcpsak.WithDefaultUniverse(srv.Listener.Addr().String()),
-	)
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-	sak := gcpsak.GCPSAK{
-		PrivateKeyID:   exampleKeyID,
-		ServiceAccount: exampleServiceAccount,
-		Signature:      exampleSignature,
-	}
-	if _, err := validator.Validate(ctx, sak); !errors.Is(err, context.Canceled) {
-		t.Errorf("Validate() error: %v, want context.Canceled", err)
 	}
 }

--- a/veles/secrets/gcpsak/validator_test.go
+++ b/veles/secrets/gcpsak/validator_test.go
@@ -25,7 +25,21 @@ import (
 
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/gcpsak"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := gcpsak.NewValidator(gcpsak.WithClient(velestest.BrokenClient))
+
+	velestest.AcceptValidator(
+		t,
+		gcpsak.NewValidator(),
+		velestest.WithTrueNegatives(gcpsak.GCPSAK{
+			ServiceAccount: "osvscalibr-fake@fake-project.iam.gserviceaccount.com",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 const (
 	pathPrefix = "/robot/v1/metadata/x509/"

--- a/veles/secrets/gcshmackey/validator.go
+++ b/veles/secrets/gcshmackey/validator.go
@@ -74,6 +74,7 @@ func (v *Validator) Validate(ctx context.Context, key HMACKey) (veles.Validation
 		return veles.ValidationFailed, fmt.Errorf("building failed: %w", err)
 	}
 	req.Header.Set("User-Agent", "osv-scalibr")
+	req.Header.Set("Host", "storage.googleapis.com")
 	req.Header.Set("Accept-Encoding", "gzip")
 
 	if err := v.signer.Sign(req, key.AccessID, key.Secret); err != nil {

--- a/veles/secrets/gcshmackey/validator_test.go
+++ b/veles/secrets/gcshmackey/validator_test.go
@@ -24,7 +24,24 @@ import (
 
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/gcshmackey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := gcshmackey.NewValidator()
+	brokenValidator.SetHTTPClient(velestest.BrokenClient)
+
+	velestest.AcceptValidator(
+		t,
+		gcshmackey.NewValidator(),
+		velestest.WithTrueNegatives(gcshmackey.HMACKey{
+			AccessID: "GOOG1OSVSCALIBR000000000000000000000000000000000000000000000",
+			Secret:   "osvscalibrfakefakefakefakefakefakefakefake",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[gcshmackey.HMACKey](),
+	)
+}
 
 type fakeSigner struct{}
 

--- a/veles/secrets/gcshmackey/validator_test.go
+++ b/veles/secrets/gcshmackey/validator_test.go
@@ -39,7 +39,6 @@ func TestAcceptValidator(t *testing.T) {
 			Secret:   "osvscalibrfakefakefakefakefakefakefakefake",
 		}),
 		velestest.WithBrokenTransport(brokenValidator),
-		velestest.WithoutOnline[gcshmackey.HMACKey](),
 	)
 }
 

--- a/veles/secrets/gitbasicauth/bitbucket/validator_test.go
+++ b/veles/secrets/gitbasicauth/bitbucket/validator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/gitbasicauth/bitbucket"
 	"github.com/google/osv-scalibr/veles/secrets/gitbasicauth/mockserver"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 var (
@@ -34,6 +35,19 @@ var (
 	validatorTestBadRepoURL  = "https://x-token-auth:token@bitbucket.org/workspace/bad-project-repo.git"
 	badHostURL               = "https://x-token-auth:token@bad-host.com/workspace/bad-project-repo.git"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := bitbucket.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		bitbucket.NewValidator(),
+		velestest.WithMalformedSecrets(bitbucket.Credentials{FullURL: badHostURL}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[bitbucket.Credentials](),
+	)
+}
 
 func TestValidator(t *testing.T) {
 	cancelledContext, cancel := context.WithCancel(t.Context())

--- a/veles/secrets/gitbasicauth/bitbucket/validator_test.go
+++ b/veles/secrets/gitbasicauth/bitbucket/validator_test.go
@@ -43,7 +43,7 @@ func TestAcceptValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		bitbucket.NewValidator(),
-		velestest.WithMalformedSecrets(bitbucket.Credentials{FullURL: badHostURL}),
+		velestest.WithTrueNegatives(bitbucket.Credentials{FullURL: validatorTokenURL}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[bitbucket.Credentials](),
 	)

--- a/veles/secrets/gitbasicauth/codecatalyst/validator_test.go
+++ b/veles/secrets/gitbasicauth/codecatalyst/validator_test.go
@@ -43,6 +43,7 @@ func TestAcceptValidator(t *testing.T) {
 		t,
 		codecatalyst.NewValidator(),
 		velestest.WithMalformedSecrets(codecatalyst.Credentials{FullURL: badHostURL}),
+		velestest.WithTrueNegatives(codecatalyst.Credentials{FullURL: validatorTestURL}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[codecatalyst.Credentials](),
 	)

--- a/veles/secrets/gitbasicauth/codecatalyst/validator_test.go
+++ b/veles/secrets/gitbasicauth/codecatalyst/validator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/gitbasicauth/codecatalyst"
 	"github.com/google/osv-scalibr/veles/secrets/gitbasicauth/mockserver"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 var (
@@ -33,6 +34,19 @@ var (
 	validatorTestBadRepoURL  = "https://user:pat@git.region.codecatalyst.aws/v1/space/project/bad-repo"
 	badHostURL               = "https://user:pat@bad-host.com/v1/space/project/bad-repo"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := codecatalyst.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		codecatalyst.NewValidator(),
+		velestest.WithMalformedSecrets(codecatalyst.Credentials{FullURL: badHostURL}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[codecatalyst.Credentials](),
+	)
+}
 
 func TestValidator(t *testing.T) {
 	cancelledContext, cancel := context.WithCancel(t.Context())

--- a/veles/secrets/gitbasicauth/codecommit/validator_test.go
+++ b/veles/secrets/gitbasicauth/codecommit/validator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/gitbasicauth/codecommit"
 	"github.com/google/osv-scalibr/veles/secrets/gitbasicauth/mockserver"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 var (
@@ -33,6 +34,19 @@ var (
 	validatorTestBadRepoURL  = "https://user:token@git-codecommit.us-east-1.amazonaws.com/v1/repos/osv-scalibr-bad"
 	badHostURL               = "https://user:token@bad-host/v1/repos/osv-scalibr-bad"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := codecommit.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		codecommit.NewValidator(),
+		velestest.WithMalformedSecrets(codecommit.Credentials{FullURL: badHostURL}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[codecommit.Credentials](),
+	)
+}
 
 func TestValidator(t *testing.T) {
 	cancelledContext, cancel := context.WithCancel(t.Context())

--- a/veles/secrets/gitbasicauth/codecommit/validator_test.go
+++ b/veles/secrets/gitbasicauth/codecommit/validator_test.go
@@ -43,6 +43,7 @@ func TestAcceptValidator(t *testing.T) {
 		t,
 		codecommit.NewValidator(),
 		velestest.WithMalformedSecrets(codecommit.Credentials{FullURL: badHostURL}),
+		velestest.WithTrueNegatives(codecommit.Credentials{FullURL: validatorTestURL}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[codecommit.Credentials](),
 	)

--- a/veles/secrets/github/app_s2s_validator_test.go
+++ b/veles/secrets/github/app_s2s_validator_test.go
@@ -25,9 +25,24 @@ import (
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/github"
 	"github.com/google/osv-scalibr/veles/secrets/github/mockgithub"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const s2sValidatorTestKey = `ghs_oJrI3NxJonXega4cd3v1XHDjjMk3jh2ENWzb`
+
+func TestAcceptAppS2STokenValidator(t *testing.T) {
+	brokenValidator := github.NewAppS2STokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		github.NewAppS2STokenValidator(),
+		velestest.WithTrueNegatives(github.AppServerToServerToken{
+			Token: `ghs_000000000000000000000000000000000000`,
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 func TestAppS2STokenValidator(t *testing.T) {
 	cancelledContext, cancel := context.WithCancel(t.Context())

--- a/veles/secrets/github/app_u2s_validator_test.go
+++ b/veles/secrets/github/app_u2s_validator_test.go
@@ -25,9 +25,24 @@ import (
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/github"
 	"github.com/google/osv-scalibr/veles/secrets/github/mockgithub"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const u2sValidatorTestKey = `ghu_aGgfQsQ52sImE9zwWxKcjt2nhESfYG1U2FhX`
+
+func TestAcceptAppU2STokenValidator(t *testing.T) {
+	brokenValidator := github.NewAppU2STokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		github.NewAppU2STokenValidator(),
+		velestest.WithTrueNegatives(github.AppUserToServerToken{
+			Token: `ghu_000000000000000000000000000000000000`,
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 func TestAppU2SValidator(t *testing.T) {
 	cancelledContext, cancel := context.WithCancel(t.Context())

--- a/veles/secrets/github/oauth_validator_test.go
+++ b/veles/secrets/github/oauth_validator_test.go
@@ -25,9 +25,24 @@ import (
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/github"
 	"github.com/google/osv-scalibr/veles/secrets/github/mockgithub"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const oauthValidatorTestKey = `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`
+
+func TestAcceptOAuthTokenValidator(t *testing.T) {
+	brokenValidator := github.NewOAuthTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		github.NewOAuthTokenValidator(),
+		velestest.WithTrueNegatives(github.OAuthToken{
+			Token: `gho_000000000000000000000000000000000000`,
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 func TestOAuthTokenValidator(t *testing.T) {
 	cancelledContext, cancel := context.WithCancel(t.Context())

--- a/veles/secrets/github/pat_classic_validator_test.go
+++ b/veles/secrets/github/pat_classic_validator_test.go
@@ -25,11 +25,26 @@ import (
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/github"
 	"github.com/google/osv-scalibr/veles/secrets/github/mockgithub"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	classicPATValidatorKey = `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`
 )
+
+func TestAcceptClassicPATValidator(t *testing.T) {
+	brokenValidator := github.NewClassicPATValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		github.NewClassicPATValidator(),
+		velestest.WithTrueNegatives(github.ClassicPersonalAccessToken{
+			Token: `ghp_000000000000000000000000000000000000`,
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 func TestClassicPATValidator(t *testing.T) {
 	cancelledContext, cancel := context.WithCancel(t.Context())

--- a/veles/secrets/github/pat_finegrained_validator_test.go
+++ b/veles/secrets/github/pat_finegrained_validator_test.go
@@ -25,11 +25,27 @@ import (
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/github"
 	"github.com/google/osv-scalibr/veles/secrets/github/mockgithub"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	fineGrainedPATValidatorKey = `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`
 )
+
+func TestAcceptFineGrainedPATValidator(t *testing.T) {
+	brokenValidator := github.NewFineGrainedPATValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		github.NewFineGrainedPATValidator(),
+		velestest.WithTrueNegatives(github.FineGrainedPersonalAccessToken{
+			// Matches fineGrainedPATPattern: github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}
+			Token: `github_pat_0000000000000000000000_00000000000000000000000000000000000000000000000000000000000`,
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 func TestFineGrainedPATValidator(t *testing.T) {
 	cancelledContext, cancel := context.WithCancel(t.Context())

--- a/veles/secrets/gitlabpat/validator_test.go
+++ b/veles/secrets/gitlabpat/validator_test.go
@@ -15,7 +15,6 @@
 package gitlabpat_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -139,34 +138,5 @@ func TestValidator(t *testing.T) {
 				t.Errorf("v.Validate() returned diff (-want +got):\n%s", diff)
 			}
 		})
-	}
-}
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	client := &http.Client{
-		Transport: &redirectTransport{
-			redirectTo:     server.URL,
-			hostToRedirect: "gitlab.com",
-		},
-	}
-	validator := gitlabpat.NewValidator()
-	validator.HTTPC = client
-
-	usernamePat := gitlabpat.GitlabPAT{Pat: validatorTestPat}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	got, err := validator.Validate(ctx, usernamePat)
-
-	if !cmp.Equal(err, context.Canceled, cmpopts.EquateErrors()) {
-		t.Errorf("Validate() error = %v, want %v", err, context.Canceled)
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }

--- a/veles/secrets/gitlabpat/validator_test.go
+++ b/veles/secrets/gitlabpat/validator_test.go
@@ -25,9 +25,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/gitlabpat"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestPat = "glpat-bzox79Of-KE9FD2LjoXXF4CvyxA.01.0r0l8l6ir"
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := gitlabpat.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		gitlabpat.NewValidator(),
+		velestest.WithTrueNegatives(gitlabpat.GitlabPAT{
+			Pat: "glpat-osvscalibr-invalid0000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 type redirectTransport struct {
 	redirectTo     string

--- a/veles/secrets/grokxaiapikey/validator.go
+++ b/veles/secrets/grokxaiapikey/validator.go
@@ -87,6 +87,7 @@ func NewAPIValidator() *simplevalidate.Validator[GrokXAIAPIKey] {
 				"Authorization": "Bearer " + k.Key,
 			}
 		},
+		InvalidResponseCodes:   []int{http.StatusBadRequest},
 		StatusFromResponseBody: apiKeyStatusFromBody,
 		HTTPC: &http.Client{
 			Timeout: validationTimeout,

--- a/veles/secrets/grokxaiapikey/validator_test.go
+++ b/veles/secrets/grokxaiapikey/validator_test.go
@@ -26,9 +26,38 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	grokxaiapikey "github.com/google/osv-scalibr/veles/secrets/grokxaiapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestKey = "grokx-test12345678901234567890123456789012345678901234567890"
+
+func TestAcceptAPIValidator(t *testing.T) {
+	brokenValidator := grokxaiapikey.NewAPIValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		grokxaiapikey.NewAPIValidator(),
+		velestest.WithTrueNegatives(grokxaiapikey.GrokXAIAPIKey{
+			Key: "grokx-osvscalibr-invalid000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptManagementAPIValidator(t *testing.T) {
+	brokenValidator := grokxaiapikey.NewManagementAPIValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		grokxaiapikey.NewManagementAPIValidator(),
+		velestest.WithTrueNegatives(grokxaiapikey.GrokXAIManagementKey{
+			Key: "xai-token-osvscalibr-invalid000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockAPIServer creates a mock x.ai /v1/api-key endpoint for testing API validator.
 func mockAPIServer(t *testing.T, expectedKey string, statusCode int, body any) *httptest.Server {

--- a/veles/secrets/grokxaiapikey/validator_test.go
+++ b/veles/secrets/grokxaiapikey/validator_test.go
@@ -37,9 +37,7 @@ func TestAcceptAPIValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		grokxaiapikey.NewAPIValidator(),
-		velestest.WithTrueNegatives(grokxaiapikey.GrokXAIAPIKey{
-			Key: "grokx-osvscalibr-invalid000000000000000000000000000000000000000000",
-		}),
+		velestest.WithTrueNegatives(grokxaiapikey.GrokXAIAPIKey{Key: validatorTestKey}),
 		velestest.WithBrokenTransport(brokenValidator),
 	)
 }
@@ -51,9 +49,7 @@ func TestAcceptManagementAPIValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		grokxaiapikey.NewManagementAPIValidator(),
-		velestest.WithTrueNegatives(grokxaiapikey.GrokXAIManagementKey{
-			Key: "xai-token-osvscalibr-invalid000000000000000000000000000000000000",
-		}),
+		velestest.WithTrueNegatives(grokxaiapikey.GrokXAIManagementKey{Key: validatorTestKey}),
 		velestest.WithBrokenTransport(brokenValidator),
 	)
 }

--- a/veles/secrets/grokxaiapikey/validator_test.go
+++ b/veles/secrets/grokxaiapikey/validator_test.go
@@ -15,7 +15,6 @@
 package grokxaiapikey_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -192,34 +191,6 @@ func TestValidatorAPI(t *testing.T) {
 	}
 }
 
-func TestValidatorAPI_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"api_key_blocked": false, "api_key_disabled": false}`))
-	}))
-	defer server.Close()
-
-	validator := grokxaiapikey.NewAPIValidator()
-	validator.HTTPC = server.Client()
-	validator.Endpoint = server.URL + "/v1/api-key"
-
-	key := grokxaiapikey.GrokXAIAPIKey{Key: validatorTestKey}
-
-	// Create a cancelled context.
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context.
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-	}
-}
-
 func TestValidatorAPI_InvalidRequest(t *testing.T) {
 	// For API validator, an "invalid" key is communicated via the JSON flags.
 	// Create mock server that returns a 200 with api_key_blocked true for empty/invalid keys.
@@ -346,34 +317,6 @@ func TestValidatorManagement(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidatorManagement_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"code":7,"message":"team mismatch"}`))
-	}))
-	defer server.Close()
-
-	validator := grokxaiapikey.NewManagementAPIValidator()
-	validator.HTTPC = server.Client()
-	validator.Endpoint = server.URL + "/auth/teams/ffffffff-ffff-ffff-ffff-ffffffffffff/api-keys"
-
-	key := grokxaiapikey.GrokXAIManagementKey{Key: validatorTestKey}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/hashicorpvault/validator_test.go
+++ b/veles/secrets/hashicorpvault/validator_test.go
@@ -32,7 +32,7 @@ func TestAcceptTokenValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		NewTokenValidator("https://example.com"),
-		velestest.WithMalformedSecrets(Token{Token: ""}),
+		velestest.WithTrueNegatives(Token{Token: "token"}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[Token](),
 	)
@@ -45,7 +45,10 @@ func TestAcceptAppRoleValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		NewAppRoleValidator("https://example.com"),
-		velestest.WithMalformedSecrets(AppRoleCredentials{RoleID: "", SecretID: ""}),
+		velestest.WithTrueNegatives(AppRoleCredentials{
+			RoleID:   "12345678-1234-1234-1234-123456789012",
+			SecretID: "87654321-4321-4321-4321-210987654321",
+		}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[AppRoleCredentials](),
 	)

--- a/veles/secrets/hashicorpvault/validator_test.go
+++ b/veles/secrets/hashicorpvault/validator_test.go
@@ -23,7 +23,34 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
+
+func TestAcceptTokenValidator(t *testing.T) {
+	brokenValidator := NewTokenValidator("https://example.com")
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		NewTokenValidator("https://example.com"),
+		velestest.WithMalformedSecrets(Token{Token: ""}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[Token](),
+	)
+}
+
+func TestAcceptAppRoleValidator(t *testing.T) {
+	brokenValidator := NewAppRoleValidator("https://example.com")
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		NewAppRoleValidator("https://example.com"),
+		velestest.WithMalformedSecrets(AppRoleCredentials{RoleID: "", SecretID: ""}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[AppRoleCredentials](),
+	)
+}
 
 func TestTokenValidator_Validate(t *testing.T) {
 	tests := []struct {

--- a/veles/secrets/hashicorpvault/validator_test.go
+++ b/veles/secrets/hashicorpvault/validator_test.go
@@ -15,7 +15,6 @@
 package hashicorpvault
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -247,31 +246,6 @@ func TestValidator_NetworkError(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("Expected network error, got nil")
-	}
-	if status != veles.ValidationFailed {
-		t.Errorf("Expected ValidationFailed status, got %v", status)
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// This handler will never respond, allowing us to test context cancellation
-		select {}
-	}))
-	defer server.Close()
-
-	serverURL := server.URL
-	validator := NewTokenValidator(serverURL)
-	validator.HTTPC = server.Client()
-
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel() // Cancel immediately
-
-	token := Token{Token: "hvs.test-token"}
-	status, err := validator.Validate(ctx, token)
-
-	if err == nil {
-		t.Fatal("Expected context cancellation error, got nil")
 	}
 	if status != veles.ValidationFailed {
 		t.Errorf("Expected ValidationFailed status, got %v", status)

--- a/veles/secrets/hcp/validator_test.go
+++ b/veles/secrets/hcp/validator_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/hcp"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
@@ -35,6 +36,33 @@ const (
 	validatorTestClientSecret = "x2Nyv_C0NiJLEheDO5LuAmJj7v_SrY5cpWWCi38WCcmohTFzAl48zoiEFivQBU2n"
 	validatorTestAccessToken  = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2F1dGguaWRwLmhhc2hpY29ycC5jb20vIiwiYXVkIjpbImh0dHBzOi8vYXBpLmhhc2hpY29ycC5jbG91ZCJdLCJndHkiOiJjbGllbnQtY3JlZGVudGlhbHMiLCJodHRwczovL2Nsb3VkLmhhc2hpY29ycC5jb20vcHJpbmNpcGFsLXR5cGUiOiJzZXJ2aWNlIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 )
+
+func TestAcceptClientCredentialsValidator(t *testing.T) {
+	brokenValidator := hcp.NewClientCredentialsValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		hcp.NewClientCredentialsValidator(),
+		velestest.WithTrueNegatives(hcp.ClientCredentials{
+			ClientID:     validatorTestClientID,
+			ClientSecret: "wrong-secret",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptAccessTokenValidator(t *testing.T) {
+	brokenValidator := hcp.NewAccessTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		hcp.NewAccessTokenValidator(),
+		velestest.WithTrueNegatives(hcp.AccessToken{Token: "osvscalibr-not-a-real-hcp-access-token"}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTokenServer returns a server that emulates the HCP token endpoint behavior.
 func mockTokenServer(t *testing.T, expectID, expectSecret string, success bool) *httptest.Server {

--- a/veles/secrets/herokuplatformkey/validator_test.go
+++ b/veles/secrets/herokuplatformkey/validator_test.go
@@ -24,11 +24,26 @@ import (
 
 	"github.com/google/osv-scalibr/veles"
 	herokuplatformkey "github.com/google/osv-scalibr/veles/secrets/herokuplatformkey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	validatorTestKey = "HRKU-AALJCYR7SRzPkj9_BGqhi1jAI1J5P4WfD6ITENvdVydAPCnNcAlrMMahHrTo"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := herokuplatformkey.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		herokuplatformkey.NewValidator(),
+		velestest.WithTrueNegatives(herokuplatformkey.HerokuSecret{
+			Key: "HRKU-osvscalibr-invalid0000000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/herokuplatformkey/validator_test.go
+++ b/veles/secrets/herokuplatformkey/validator_test.go
@@ -15,7 +15,6 @@
 package herokuplatformkey_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -150,36 +149,5 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := herokuplatformkey.NewValidator()
-	validator.HTTPC = client
-
-	key := herokuplatformkey.HerokuSecret{Key: validatorTestKey}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }

--- a/veles/secrets/huggingfaceapikey/validator_test.go
+++ b/veles/secrets/huggingfaceapikey/validator_test.go
@@ -26,9 +26,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestKey = "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"
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := huggingfaceapikey.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		huggingfaceapikey.NewValidator(),
+		velestest.WithTrueNegatives(huggingfaceapikey.HuggingfaceAPIKey{
+			Key: "hf_osvscalibr_invalid000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/huggingfaceapikey/validator_test.go
+++ b/veles/secrets/huggingfaceapikey/validator_test.go
@@ -15,7 +15,6 @@
 package huggingfaceapikey_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -146,34 +145,6 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := huggingfaceapikey.NewValidator()
-	validator.HTTPC = client
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	key := huggingfaceapikey.HuggingfaceAPIKey{Key: validatorTestKey}
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/mistralapikey/validator_test.go
+++ b/veles/secrets/mistralapikey/validator_test.go
@@ -26,9 +26,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestKey = "abcdefghij1234567890ABCDEFGHIJ12"
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := mistralapikey.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		mistralapikey.NewValidator(),
+		velestest.WithTrueNegatives(mistralapikey.MistralAPIKey{
+			Key: "osvscalibrinvalidmistralkey000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server.
 type mockTransport struct {

--- a/veles/secrets/mistralapikey/validator_test.go
+++ b/veles/secrets/mistralapikey/validator_test.go
@@ -15,7 +15,6 @@
 package mistralapikey_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -142,42 +141,5 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	// Create a server that responds normally.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create client with custom transport.
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	// Create validator with mock client.
-	validator := mistralapikey.NewValidator()
-	validator.HTTPC = client
-
-	// Create a cancelled context.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	// Create test key.
-	key := mistralapikey.MistralAPIKey{Key: validatorTestKey}
-
-	// Test validation with cancelled context.
-	got, err := validator.Validate(ctx, key)
-
-	// Should return an error due to cancelled context.
-	if err == nil {
-		t.Error("Validate() expected error due to cancelled context, got nil")
-	}
-
-	// Status should be ValidationFailed.
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }

--- a/veles/secrets/npmjsaccesstoken/validator_test.go
+++ b/veles/secrets/npmjsaccesstoken/validator_test.go
@@ -15,7 +15,6 @@
 package npmjsaccesstoken_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -158,37 +157,6 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := npmjsaccesstoken.NewValidator()
-	validator.HTTPC = client
-
-	key := npmjsaccesstoken.NpmJsAccessToken{Token: validatorTestKey}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/npmjsaccesstoken/validator_test.go
+++ b/veles/secrets/npmjsaccesstoken/validator_test.go
@@ -24,9 +24,24 @@ import (
 
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestKey = "npm_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8"
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := npmjsaccesstoken.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		npmjsaccesstoken.NewValidator(),
+		velestest.WithTrueNegatives(npmjsaccesstoken.NpmJsAccessToken{
+			Token: "npm_osvscalibrinvalid00000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/openai/validator_test.go
+++ b/veles/secrets/openai/validator_test.go
@@ -23,12 +23,27 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/openai"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	projectValidatorTestKey = "sk-proj-12345678901234567890T3BlbkFJ" +
 		"12345678901234567890123456"
 )
+
+func TestAcceptProjectValidator(t *testing.T) {
+	brokenValidator := openai.NewProjectValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		openai.NewProjectValidator(),
+		velestest.WithTrueNegatives(openai.APIKey{
+			Key: "sk-proj-osvscalibr-invalid0000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockOpenAIServer creates a mock OpenAI API server for testing project keys
 func mockOpenAIServer(t *testing.T, expectedKey string, statusCode int) *httptest.Server {

--- a/veles/secrets/openrouter/validator_test.go
+++ b/veles/secrets/openrouter/validator_test.go
@@ -26,9 +26,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/openrouter"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestKey = "sk-or-v1-abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqr"
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := openrouter.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		openrouter.NewValidator(),
+		velestest.WithTrueNegatives(openrouter.APIKey{
+			Key: "sk-or-v1-osvscalibr-invalid000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/openrouter/validator_test.go
+++ b/veles/secrets/openrouter/validator_test.go
@@ -150,37 +150,6 @@ func TestValidator(t *testing.T) {
 	}
 }
 
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := openrouter.NewValidator()
-	validator.HTTPC = client
-
-	key := openrouter.APIKey{Key: validatorTestKey}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-	}
-}
-
 func TestValidator_InvalidRequest(t *testing.T) {
 	// Create mock server that returns 401 Unauthorized
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/veles/secrets/packagist/validator_test.go
+++ b/veles/secrets/packagist/validator_test.go
@@ -24,7 +24,80 @@ import (
 
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/packagist"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
+
+func TestAcceptAPIKeyValidator(t *testing.T) {
+	brokenValidator := packagist.NewAPIKeyValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		packagist.NewAPIKeyValidator(),
+		velestest.WithTrueNegatives(packagist.APIKey{
+			Key: "packagist_ack_osvscalibrinvalid000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptAPISecretValidator(t *testing.T) {
+	brokenValidator := packagist.NewAPISecretValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		packagist.NewAPISecretValidator(),
+		velestest.WithTrueNegatives(packagist.APISecret{
+			Secret: "osvscalibr-fake-secret",
+			Key:    "osvscalibr-fake-key",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptOrgReadTokenValidator(t *testing.T) {
+	brokenValidator := packagist.NewOrgReadTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		packagist.NewOrgReadTokenValidator(),
+		velestest.WithMalformedSecrets(packagist.OrgReadToken{Token: "tok", RepoURL: ""}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[packagist.OrgReadToken](),
+	)
+}
+
+func TestAcceptOrgUpdateTokenValidator(t *testing.T) {
+	brokenValidator := packagist.NewOrgUpdateTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		packagist.NewOrgUpdateTokenValidator(),
+		velestest.WithMalformedSecrets(packagist.OrgUpdateToken{Token: "tok", RepoURL: ""}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[packagist.OrgUpdateToken](),
+	)
+}
+
+func TestAcceptUserUpdateTokenValidator(t *testing.T) {
+	brokenValidator := packagist.NewUserUpdateTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		packagist.NewUserUpdateTokenValidator(),
+		velestest.WithMalformedSecrets(packagist.UserUpdateToken{
+			Token:    "tok",
+			Username: "",
+			RepoURL:  "",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[packagist.UserUpdateToken](),
+	)
+}
 
 func TestAPIKeyValidator(t *testing.T) {
 	cases := []struct {

--- a/veles/secrets/packagist/validator_test.go
+++ b/veles/secrets/packagist/validator_test.go
@@ -63,7 +63,7 @@ func TestAcceptOrgReadTokenValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		packagist.NewOrgReadTokenValidator(),
-		velestest.WithMalformedSecrets(packagist.OrgReadToken{Token: "tok", RepoURL: ""}),
+		velestest.WithTrueNegatives(packagist.OrgReadToken{Token: "tok", RepoURL: "http://example.com"}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[packagist.OrgReadToken](),
 	)
@@ -76,7 +76,7 @@ func TestAcceptOrgUpdateTokenValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		packagist.NewOrgUpdateTokenValidator(),
-		velestest.WithMalformedSecrets(packagist.OrgUpdateToken{Token: "tok", RepoURL: ""}),
+		velestest.WithTrueNegatives(packagist.OrgUpdateToken{Token: "tok", RepoURL: "http://example.com"}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[packagist.OrgUpdateToken](),
 	)
@@ -89,10 +89,10 @@ func TestAcceptUserUpdateTokenValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		packagist.NewUserUpdateTokenValidator(),
-		velestest.WithMalformedSecrets(packagist.UserUpdateToken{
+		velestest.WithTrueNegatives(packagist.UserUpdateToken{
 			Token:    "tok",
-			Username: "",
-			RepoURL:  "",
+			Username: "test",
+			RepoURL:  "http://example.com",
 		}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[packagist.UserUpdateToken](),

--- a/veles/secrets/paystacksecretkey/validator_test.go
+++ b/veles/secrets/paystacksecretkey/validator_test.go
@@ -26,11 +26,26 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	paystacksecretkey "github.com/google/osv-scalibr/veles/secrets/paystacksecretkey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	validatorTestSK = "sk_live_51PvZzqA"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := paystacksecretkey.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		paystacksecretkey.NewValidator(),
+		velestest.WithTrueNegatives(paystacksecretkey.PaystackSecret{
+			Key: "sk_live_osvscalibr_invalid000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/paystacksecretkey/validator_test.go
+++ b/veles/secrets/paystacksecretkey/validator_test.go
@@ -15,7 +15,6 @@
 package paystacksecretkey_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -142,36 +141,5 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := paystacksecretkey.NewValidator()
-	validator.HTTPC = client
-
-	key := paystacksecretkey.PaystackSecret{Key: validatorTestSK}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }

--- a/veles/secrets/perplexityapikey/validator_test.go
+++ b/veles/secrets/perplexityapikey/validator_test.go
@@ -15,7 +15,6 @@
 package perplexityapikey_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -142,37 +141,6 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := perplexityapikey.NewValidator()
-	validator.HTTPC = client
-
-	key := perplexityapikey.PerplexityAPIKey{Key: validatorTestKey}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/perplexityapikey/validator_test.go
+++ b/veles/secrets/perplexityapikey/validator_test.go
@@ -26,9 +26,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/perplexityapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestKey = "pplx-test123456789012345678901234567890123456789012345678"
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := perplexityapikey.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		perplexityapikey.NewValidator(),
+		velestest.WithTrueNegatives(perplexityapikey.PerplexityAPIKey{
+			Key: "pplx-osvscalibr-invalid000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/postmanapikey/validator_test.go
+++ b/veles/secrets/postmanapikey/validator_test.go
@@ -26,12 +26,41 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	postmanapikey "github.com/google/osv-scalibr/veles/secrets/postmanapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	validatorTestAPIKey        = "PMAK-68b96bd4ae8d2b0001db8a86-192b1cb49020c70a4d0c814ab71de822d7"
 	validatorTestCollectionKey = "PMAT-01K4A58P2HS2Q43TXHSXFRDBZX"
 )
+
+func TestAcceptAPIValidator(t *testing.T) {
+	brokenValidator := postmanapikey.NewAPIValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		postmanapikey.NewAPIValidator(),
+		velestest.WithTrueNegatives(postmanapikey.PostmanAPIKey{
+			Key: "PMAK-osvscalibr-invalid-000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptCollectionValidator(t *testing.T) {
+	brokenValidator := postmanapikey.NewCollectionValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		postmanapikey.NewCollectionValidator(),
+		velestest.WithTrueNegatives(postmanapikey.PostmanCollectionToken{
+			Key: "PMAT-osvscalibr-invalid-000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server for the configured hosts.
 type mockTransport struct {

--- a/veles/secrets/postmanapikey/validator_test.go
+++ b/veles/secrets/postmanapikey/validator_test.go
@@ -15,7 +15,6 @@
 package postmanapikey_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -207,33 +206,6 @@ func TestValidatorAPI(t *testing.T) {
 	}
 }
 
-func TestValidatorAPI_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(nil)
-	t.Cleanup(func() {
-		server.Close()
-	})
-
-	validator := postmanapikey.NewAPIValidator()
-	validator.HTTPC = server.Client()
-	validator.Endpoint = server.URL + "/me"
-
-	key := postmanapikey.PostmanAPIKey{Key: validatorTestAPIKey}
-
-	// Create context that is immediately cancelled
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if diff := cmp.Diff(cmpopts.AnyError, err, cmpopts.EquateErrors()); diff != "" {
-		t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-	}
-}
-
 func TestValidatorAPI_InvalidRequest(t *testing.T) {
 	// For API validator, an "invalid" key is communicated via 401 status.
 	server := mockAPIServer(t, "", http.StatusUnauthorized, map[string]any{
@@ -373,34 +345,6 @@ func TestValidatorCollection(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidatorCollection_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(nil)
-	t.Cleanup(func() {
-		server.Close()
-	})
-
-	validator := postmanapikey.NewCollectionValidator()
-	validator.HTTPC = server.Client()
-	validator.EndpointFunc = func(k postmanapikey.PostmanCollectionToken) (string, error) {
-		return server.URL + "/collections/aaaaaaaa-aaaaaaaa-aaaa-aaaa-aaaaaaaaaaaa?access_key=" + k.Key, nil
-	}
-	key := postmanapikey.PostmanCollectionToken{Key: validatorTestCollectionKey}
-
-	// Create context that is immediately cancelled
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if diff := cmp.Diff(cmpopts.AnyError, err, cmpopts.EquateErrors()); diff != "" {
-		t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/pypiapitoken/validator_test.go
+++ b/veles/secrets/pypiapitoken/validator_test.go
@@ -132,32 +132,6 @@ func TestValidator(t *testing.T) {
 	}
 }
 
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	validator := pypiapitoken.NewValidator()
-	validator.HTTPC = server.Client()
-	validator.Endpoint = server.URL + "/legacy/"
-
-	key := pypiapitoken.PyPIAPIToken{Token: validatorTestKey}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-	}
-}
-
 func TestValidator_InvalidRequest(t *testing.T) {
 	// Create a mock server that returns 401 Unauthorized
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/veles/secrets/pypiapitoken/validator_test.go
+++ b/veles/secrets/pypiapitoken/validator_test.go
@@ -25,9 +25,24 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/pypiapitoken"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestKey = `pypi-AgEIc433aS5vcmcffDgyZDA0MzFkLWMzZjEtNDlhNy1iOWQwLfflMjE5NmNkMjhjNQACKlszLCI22UBiYzQ2Yi05YjNhhTQ5NmItYWIxMHYhMGI3MmEyOWI5MzYiXQAABiCJBI80LFFz0JvS6UIj2LzgV9N-BQnBAD2123Dyu9xs33`
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := pypiapitoken.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		pypiapitoken.NewValidator(),
+		velestest.WithTrueNegatives(pypiapitoken.PyPIAPIToken{
+			Token: "pypi-osvscalibr-invalid0000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockPyPIServer creates a mock PyPI API server for testing
 func mockPyPIServer(t *testing.T, expectedKey string, serverResponseCode int) *httptest.Server {

--- a/veles/secrets/salesforceoauth2access/validator.go
+++ b/veles/secrets/salesforceoauth2access/validator.go
@@ -35,6 +35,6 @@ func NewValidator() *sv.Validator[Token] {
 			}
 		},
 		ValidResponseCodes:   []int{http.StatusOK},
-		InvalidResponseCodes: []int{http.StatusUnauthorized},
+		InvalidResponseCodes: []int{http.StatusUnauthorized, http.StatusForbidden},
 	}
 }

--- a/veles/secrets/salesforceoauth2access/validator_test.go
+++ b/veles/secrets/salesforceoauth2access/validator_test.go
@@ -40,9 +40,10 @@ func TestAcceptValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		salesforceoauth2access.NewValidator(),
-		velestest.WithTrueNegatives(salesforceoauth2access.Token{
-			Token: "00Dosvscalibr-not-a-real-access-token-invalid000000000000000000",
-		}),
+		velestest.WithTrueNegatives(
+			salesforceoauth2access.Token{Token: validatorTestToken},
+			salesforceoauth2access.Token{Token: "randomKey"},
+		),
 		velestest.WithBrokenTransport(brokenValidator),
 	)
 }

--- a/veles/secrets/salesforceoauth2access/validator_test.go
+++ b/veles/secrets/salesforceoauth2access/validator_test.go
@@ -26,11 +26,26 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/salesforceoauth2access"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	validatorTestToken = "00D123456789!AB_CDEF.ABC123456789ABC123456789ABC12ABC123456789ABC123456789ABC12"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := salesforceoauth2access.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		salesforceoauth2access.NewValidator(),
+		velestest.WithTrueNegatives(salesforceoauth2access.Token{
+			Token: "00Dosvscalibr-not-a-real-access-token-invalid000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/salesforceoauth2client/validator_test.go
+++ b/veles/secrets/salesforceoauth2client/validator_test.go
@@ -43,9 +43,10 @@ func TestAcceptValidator(t *testing.T) {
 		salesforceoauth2client.NewValidator(),
 		velestest.WithTrueNegatives(salesforceoauth2client.Credentials{
 			ID:     validatorTestClientID,
-			Secret: "wrong-secret",
+			Secret: validatorTestClientSecret,
 			URL:    validatorTestURL,
 		}),
+		velestest.WithoutOnline[salesforceoauth2client.Credentials](),
 		velestest.WithBrokenTransport(brokenValidator),
 	)
 }

--- a/veles/secrets/salesforceoauth2client/validator_test.go
+++ b/veles/secrets/salesforceoauth2client/validator_test.go
@@ -26,12 +26,29 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/salesforceoauth2client"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestClientID = "3MVG123456789.AB_CDEF.ABC123456789ABC123456789ABC1"
 const validatorTestClientSecret = "123456789ABCDEFABC1234567895123456789ABCDEFABC1234567895"
 const validatorTestURL = "yuvrajapp.my.salesforce.com"
 const validatorExpectedBase64Data = "M01WRzEyMzQ1Njc4OS5BQl9DREVGLkFCQzEyMzQ1Njc4OUFCQzEyMzQ1Njc4OUFCQzE6MTIzNDU2Nzg5QUJDREVGQUJDMTIzNDU2Nzg5NTEyMzQ1Njc4OUFCQ0RFRkFCQzEyMzQ1Njc4OTU="
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := salesforceoauth2client.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		salesforceoauth2client.NewValidator(),
+		velestest.WithTrueNegatives(salesforceoauth2client.Credentials{
+			ID:     validatorTestClientID,
+			Secret: "wrong-secret",
+			URL:    validatorTestURL,
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/salesforceoauth2jwt/validator_test.go
+++ b/veles/secrets/salesforceoauth2jwt/validator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/salesforceoauth2jwt"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
@@ -59,6 +60,23 @@ Twanj5YBWrq2yV2fqWgvyz3LIqlhmDNW89ThWmk7XYtD0em9dnEXlpH0JTxdQpCF
 tGOp/d/V3F66yalNSTXNbkA=
 -----END PRIVATE KEY-----`
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := salesforceoauth2jwt.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		salesforceoauth2jwt.NewValidator(),
+		velestest.WithTrueNegatives(salesforceoauth2jwt.Credentials{
+			ID:         testClientID,
+			Username:   "invalid@example.com",
+			PrivateKey: testPrivateKeyPEM,
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[salesforceoauth2jwt.Credentials](),
+	)
+}
 
 // mockTransport redirects login.salesforce.com to mock server
 type mockTransport struct {

--- a/veles/secrets/salesforceoauth2refresh/validator.go
+++ b/veles/secrets/salesforceoauth2refresh/validator.go
@@ -25,13 +25,13 @@ import (
 //
 // It performs a POST request to the Salesforce App token endpoint.
 // If the request returns HTTP 200, the credentials are valid.
-// If 401 Unauthorized, they are invalid.
+// If 401 Unauthorized or 400 Bad Request (invalid grant), they are invalid.
 func NewValidator() *sv.Validator[Credentials] {
 	return &sv.Validator[Credentials]{
 		Endpoint: "https://login.salesforce.com/services/oauth2/token",
 		Body: func(creds Credentials) (string, error) {
-			// Salesforce requires refresh token in body
-			return "refresh_token=" + creds.Refresh, nil
+			// Salesforce requires both grant_type and refresh_token in the body
+			return "grant_type=refresh_token&refresh_token=" + creds.Refresh, nil
 		},
 		HTTPMethod: http.MethodPost,
 		HTTPHeaders: func(creds Credentials) map[string]string {
@@ -39,9 +39,10 @@ func NewValidator() *sv.Validator[Credentials] {
 			encoded := base64.StdEncoding.EncodeToString([]byte(raw))
 			return map[string]string{
 				"Authorization": "Basic " + encoded,
+				"Content-Type":  "application/x-www-form-urlencoded",
 			}
 		},
 		ValidResponseCodes:   []int{http.StatusOK},
-		InvalidResponseCodes: []int{http.StatusUnauthorized},
+		InvalidResponseCodes: []int{http.StatusUnauthorized, http.StatusBadRequest},
 	}
 }

--- a/veles/secrets/salesforceoauth2refresh/validator_test.go
+++ b/veles/secrets/salesforceoauth2refresh/validator_test.go
@@ -46,7 +46,7 @@ func TestAcceptValidator(t *testing.T) {
 		velestest.WithTrueNegatives(salesforceoauth2refresh.Credentials{
 			ID:      validatorTestClientID,
 			Secret:  validatorTestClientSecret,
-			Refresh: "osvscalibr-not-a-real-refresh-token",
+			Refresh: "refresh_token",
 		}),
 		velestest.WithBrokenTransport(brokenValidator),
 	)

--- a/veles/secrets/salesforceoauth2refresh/validator_test.go
+++ b/veles/secrets/salesforceoauth2refresh/validator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/salesforceoauth2refresh"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
@@ -34,6 +35,22 @@ const (
 	validatorTestRefresh        = "123456789ABCDEFABC1234567895123459876ABCDEFABC1234567895"
 	validatorExpectedBase64Data = "M01WRzEyMzQ1Njc4OS5BQl9DREVGLkFCQzEyMzQ1Njc4OUFCQzEyMzQ1Njc4OUFCQzE6MTIzNDU2Nzg5QUJDREVGQUJDMTIzNDU2Nzg5NTEyMzQ1Njc4OUFCQ0RFRkFCQzEyMzQ1Njc4OTU="
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := salesforceoauth2refresh.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		salesforceoauth2refresh.NewValidator(),
+		velestest.WithTrueNegatives(salesforceoauth2refresh.Credentials{
+			ID:      validatorTestClientID,
+			Secret:  validatorTestClientSecret,
+			Refresh: "osvscalibr-not-a-real-refresh-token",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/sendgrid/validator_test.go
+++ b/veles/secrets/sendgrid/validator_test.go
@@ -15,7 +15,6 @@
 package sendgrid_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -134,34 +133,6 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"type":"free","reputation":99.7}`))
-	}))
-	defer server.Close()
-
-	validator := sendgrid.NewValidator()
-	validator.HTTPC = server.Client()
-	validator.Endpoint = server.URL + "/v3/user/account"
-	key := sendgrid.APIKey{Key: testSendGridAPIKey}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/sendgrid/validator_test.go
+++ b/veles/secrets/sendgrid/validator_test.go
@@ -24,7 +24,22 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/sendgrid"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := sendgrid.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		sendgrid.NewValidator(),
+		velestest.WithTrueNegatives(sendgrid.APIKey{
+			Key: "SG.osvscalibr-invalid0000000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockSendGridServer creates a mock SendGrid API server for testing.
 func mockSendGridServer(t *testing.T, expectedKey string, statusCode int, expectedEndpoint string) *httptest.Server {

--- a/veles/secrets/slacktoken/validator_test.go
+++ b/veles/secrets/slacktoken/validator_test.go
@@ -15,7 +15,6 @@
 package slacktoken_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -265,78 +264,6 @@ func TestAppConfigRefreshTokenValidator(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"ok":true"}`))
-	}))
-	defer server.Close()
-
-	t.Run("app_level_token", func(t *testing.T) {
-		validator := slacktoken.NewAppLevelTokenValidator()
-		validator.HTTPC = server.Client()
-		validator.Endpoint = server.URL + slacktoken.SlackAPIEndpoint
-		key := slacktoken.SlackAppLevelToken{Token: testAppLevelToken}
-
-		// Create a cancelled context
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
-
-		// Test validation with cancelled context
-		got, err := validator.Validate(ctx, key)
-
-		if err == nil {
-			t.Errorf("Validate() expected error due to context cancellation, got nil")
-		}
-		if got != veles.ValidationFailed {
-			t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-		}
-	})
-
-	// Test with App Config Access Token validator
-	t.Run("app_config_access_token", func(t *testing.T) {
-		validator := slacktoken.NewAppConfigAccessTokenValidator()
-		validator.HTTPC = server.Client()
-		validator.Endpoint = server.URL + slacktoken.SlackAPIEndpoint
-		key := slacktoken.SlackAppConfigAccessToken{Token: testAppConfigAccessToken}
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
-
-		// Test validation with cancelled context
-		got, err := validator.Validate(ctx, key)
-
-		if err == nil {
-			t.Errorf("Validate() expected error due to context cancellation, got nil")
-		}
-		if got != veles.ValidationFailed {
-			t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-		}
-	})
-
-	// Test with App Config Refresh Token validator
-	t.Run("app_config_refresh_token", func(t *testing.T) {
-		validator := slacktoken.NewAppConfigRefreshTokenValidator()
-		validator.HTTPC = server.Client()
-		validator.Endpoint = server.URL + slacktoken.SlackAPIEndpoint
-		key := slacktoken.SlackAppConfigRefreshToken{Token: testAppConfigRefreshToken}
-
-		// Create a cancelled context
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
-
-		// Test validation with cancelled context
-		got, err := validator.Validate(ctx, key)
-
-		if err == nil {
-			t.Errorf("Validate() expected error due to context cancellation, got nil")
-		}
-		if got != veles.ValidationFailed {
-			t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-		}
-	})
 }
 
 func TestValidator_InvalidRequest(t *testing.T) {

--- a/veles/secrets/slacktoken/validator_test.go
+++ b/veles/secrets/slacktoken/validator_test.go
@@ -25,7 +25,50 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/slacktoken"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
+
+func TestAcceptAppLevelTokenValidator(t *testing.T) {
+	brokenValidator := slacktoken.NewAppLevelTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		slacktoken.NewAppLevelTokenValidator(),
+		velestest.WithTrueNegatives(slacktoken.SlackAppLevelToken{
+			Token: "xapp-1-A000-OSVSCALIBR-00000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptAppConfigAccessTokenValidator(t *testing.T) {
+	brokenValidator := slacktoken.NewAppConfigAccessTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		slacktoken.NewAppConfigAccessTokenValidator(),
+		velestest.WithTrueNegatives(slacktoken.SlackAppConfigAccessToken{
+			Token: "xoxe.xoxp-1-MsNw-osvscalibr-invalid-000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptAppConfigRefreshTokenValidator(t *testing.T) {
+	brokenValidator := slacktoken.NewAppConfigRefreshTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		slacktoken.NewAppConfigRefreshTokenValidator(),
+		velestest.WithTrueNegatives(slacktoken.SlackAppConfigRefreshToken{
+			Token: "xoxe-1-OSVSCALIBR-invalid-000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockSlackServer creates a mock Slack API server for testing
 func mockSlackServer(t *testing.T, expectedKey string, responseBody string, expectedEndpoint string) *httptest.Server {

--- a/veles/secrets/squareapikey/validator_test.go
+++ b/veles/secrets/squareapikey/validator_test.go
@@ -15,7 +15,6 @@
 package squareapikey_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -255,30 +254,6 @@ func TestPersonalAccessTokenValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestPersonalAccessTokenValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"client_id":"sq0idp-test","token_type":"BEARER"}`))
-	}))
-	defer server.Close()
-
-	validator := setupPersonalAccessTokenValidator(t, server)
-
-	token := squareapikey.SquarePersonalAccessToken{Key: validatorTestToken}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	got, err := validator.Validate(ctx, token)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/squareapikey/validator_test.go
+++ b/veles/secrets/squareapikey/validator_test.go
@@ -27,9 +27,39 @@ import (
 	"github.com/google/osv-scalibr/veles"
 	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
 	"github.com/google/osv-scalibr/veles/secrets/squareapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const validatorTestToken = "EAAAl-fFiBHM5-4l4faqdYXgciyn9_MoC3hzKh3UfR0WOmrr_o4BOiPK8ZPiUXVs"
+
+func TestAcceptPersonalAccessTokenValidator(t *testing.T) {
+	brokenValidator := squareapikey.NewPersonalAccessTokenValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		squareapikey.NewPersonalAccessTokenValidator(),
+		velestest.WithTrueNegatives(squareapikey.SquarePersonalAccessToken{
+			Key: "EAAAinvalidtokeninvalidtokeninvalidtokeninvalidtokeninvalid",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptOAuthApplicationSecretValidator(t *testing.T) {
+	brokenValidator := squareapikey.NewOAuthApplicationSecretValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		squareapikey.NewOAuthApplicationSecretValidator(),
+		velestest.WithTrueNegatives(squareapikey.SquareOAuthApplicationSecret{
+			ID:  "sq0idp-wuPhZFY8etbvhybDEdHllQ",
+			Key: "sq0csp-INVALID_SECRET_INVALID_SECRET_INVALID",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/stripeapikeys/validator_test.go
+++ b/veles/secrets/stripeapikeys/validator_test.go
@@ -39,12 +39,41 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	stripeapikeys "github.com/google/osv-scalibr/veles/secrets/stripeapikeys"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	validatorTestSK = "sk_live_51PvZzqABcD1234EfGhIjKlMnOpQrStUvWxYz0123456789abcdefghijklmnopQRSTuvWXYZabcd12345678"
 	validatorTestRK = "rk_live_51PvZzABcDEfGhIjKlMnOpQrStUvWxYz0123456789abcdefGHIJKLMNOPQRSTUVWXYZabcd12345678"
 )
+
+func TestAcceptSecretKeyValidator(t *testing.T) {
+	brokenValidator := stripeapikeys.NewSecretKeyValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		stripeapikeys.NewSecretKeyValidator(),
+		velestest.WithTrueNegatives(stripeapikeys.StripeSecretKey{
+			Key: "sk_live_00000000000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptRestrictedKeyValidator(t *testing.T) {
+	brokenValidator := stripeapikeys.NewRestrictedKeyValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		stripeapikeys.NewRestrictedKeyValidator(),
+		velestest.WithTrueNegatives(stripeapikeys.StripeRestrictedKey{
+			Key: "rk_live_00000000000000000000000000000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server for the configured hosts.
 type mockTransport struct {

--- a/veles/secrets/stripeapikeys/validator_test.go
+++ b/veles/secrets/stripeapikeys/validator_test.go
@@ -29,7 +29,6 @@
 package stripeapikeys_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -176,37 +175,6 @@ func TestValidatorSecretKey(t *testing.T) {
 	}
 }
 
-func TestValidatorSecretKey_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(nil)
-	t.Cleanup(func() {
-		server.Close()
-	})
-
-	// Create client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := stripeapikeys.NewSecretKeyValidator()
-	validator.HTTPC = client
-
-	key := stripeapikeys.StripeSecretKey{Key: validatorTestSK}
-
-	// Create context that is immediately cancelled
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if diff := cmp.Diff(cmpopts.AnyError, err, cmpopts.EquateErrors()); diff != "" {
-		t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
-	}
-}
-
 func TestValidatorRestrictedKey(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -266,36 +234,5 @@ func TestValidatorRestrictedKey(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidatorRestrictedKey_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(nil)
-	t.Cleanup(func() {
-		server.Close()
-	})
-
-	// Create client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := stripeapikeys.NewRestrictedKeyValidator()
-	validator.HTTPC = client
-
-	key := stripeapikeys.StripeRestrictedKey{Key: validatorTestRK}
-
-	// Create context that is immediately cancelled
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if diff := cmp.Diff(cmpopts.AnyError, err, cmpopts.EquateErrors()); diff != "" {
-		t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }

--- a/veles/secrets/supabase/validator_test.go
+++ b/veles/secrets/supabase/validator_test.go
@@ -53,6 +53,10 @@ func TestAcceptProjectSecretKeyValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		supabase.NewProjectSecretKeyValidator(),
+		velestest.WithTrueNegatives(supabase.ProjectSecretKey{
+			Key:        validatorTestSecretKey,
+			ProjectRef: validatorTestProjectRef,
+		}),
 		velestest.WithMalformedSecrets(supabase.ProjectSecretKey{
 			Key:        validatorTestSecretKey,
 			ProjectRef: "",
@@ -69,6 +73,9 @@ func TestAcceptServiceRoleJWTValidator(t *testing.T) {
 	velestest.AcceptValidator(
 		t,
 		supabase.NewServiceRoleJWTValidator(),
+		velestest.WithTrueNegatives(supabase.ServiceRoleJWT{
+			Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxwaHlmeW1hZXBrbHB1dmFlY3J5Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2OTI2MTAzOSwiZXhwIjoyMDg0ODM3MDM5fQ.signature",
+		}),
 		velestest.WithMalformedSecrets(supabase.ServiceRoleJWT{Token: "not-a-jwt"}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[supabase.ServiceRoleJWT](),

--- a/veles/secrets/supabase/validator_test.go
+++ b/veles/secrets/supabase/validator_test.go
@@ -15,7 +15,6 @@
 package supabase_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -304,37 +303,6 @@ func TestSupabaseProjectSecretKeyValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestSupabasePATValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create a client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := supabase.NewPATValidator()
-	validator.HTTPC = client
-
-	pat := supabase.PAT{Token: validatorTestPAT}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, pat)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }
 

--- a/veles/secrets/supabase/validator_test.go
+++ b/veles/secrets/supabase/validator_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/supabase"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
@@ -31,6 +32,49 @@ const (
 	validatorTestSecretKey  = "sb_secret_abcdefghijklmnopqrstuvwxyz123456"
 	validatorTestProjectRef = "lphyfymaepklpuvaecry"
 )
+
+func TestAcceptPATValidator(t *testing.T) {
+	brokenValidator := supabase.NewPATValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		supabase.NewPATValidator(),
+		velestest.WithTrueNegatives(supabase.PAT{
+			Token: "sbp_osvscalibr000000000000000000000000000000",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
+
+func TestAcceptProjectSecretKeyValidator(t *testing.T) {
+	brokenValidator := supabase.NewProjectSecretKeyValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		supabase.NewProjectSecretKeyValidator(),
+		velestest.WithMalformedSecrets(supabase.ProjectSecretKey{
+			Key:        validatorTestSecretKey,
+			ProjectRef: "",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[supabase.ProjectSecretKey](),
+	)
+}
+
+func TestAcceptServiceRoleJWTValidator(t *testing.T) {
+	brokenValidator := supabase.NewServiceRoleJWTValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		supabase.NewServiceRoleJWTValidator(),
+		velestest.WithMalformedSecrets(supabase.ServiceRoleJWT{Token: "not-a-jwt"}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[supabase.ServiceRoleJWT](),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/telegrambotapitoken/validator_test.go
+++ b/veles/secrets/telegrambotapitoken/validator_test.go
@@ -29,7 +29,6 @@
 package telegrambotapitoken_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -159,36 +158,5 @@ func TestValidator(t *testing.T) {
 				t.Errorf("Validate() = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestValidator_ContextCancellation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create client with custom transport
-	client := &http.Client{
-		Transport: &mockTransport{testServer: server},
-	}
-
-	validator := telegrambotapitoken.NewValidator()
-	validator.HTTPC = client
-
-	key := telegrambotapitoken.TelegramBotAPIToken{Token: validatorTestToken}
-
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	// Test validation with cancelled context
-	got, err := validator.Validate(ctx, key)
-
-	if err == nil {
-		t.Errorf("Validate() expected error due to context cancellation, got nil")
-	}
-	if got != veles.ValidationFailed {
-		t.Errorf("Validate() = %v, want %v", got, veles.ValidationFailed)
 	}
 }

--- a/veles/secrets/telegrambotapitoken/validator_test.go
+++ b/veles/secrets/telegrambotapitoken/validator_test.go
@@ -41,11 +41,26 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/telegrambotapitoken"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
 
 const (
 	validatorTestToken = "4839574812:AAFD39kkdpWt3ywyRZergyOLMaJhac60qcK"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := telegrambotapitoken.NewValidator()
+	brokenValidator.HTTPC = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		telegrambotapitoken.NewValidator(),
+		velestest.WithTrueNegatives(telegrambotapitoken.TelegramBotAPIToken{
+			Token: "123456789:AAFAKE_osvscalibr_invalid_bot_token_not_real",
+		}),
+		velestest.WithBrokenTransport(brokenValidator),
+	)
+}
 
 // mockTransport redirects requests to the test server
 type mockTransport struct {

--- a/veles/secrets/urlcreds/validator_test.go
+++ b/veles/secrets/urlcreds/validator_test.go
@@ -58,6 +58,7 @@ func TestAcceptValidator(t *testing.T) {
 		t,
 		urlcreds.NewValidator(),
 		velestest.WithMalformedSecrets(urlcreds.Credentials{FullURL: ":::not-a-valid-url"}),
+		velestest.WithTrueNegatives(urlcreds.Credentials{FullURL: "http://admin:pass@domain.com/resource"}),
 		velestest.WithBrokenTransport(brokenValidator),
 		velestest.WithoutOnline[urlcreds.Credentials](),
 	)

--- a/veles/secrets/urlcreds/validator_test.go
+++ b/veles/secrets/urlcreds/validator_test.go
@@ -46,8 +46,22 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/secrets/urlcreds"
+	"github.com/google/osv-scalibr/veles/velestest"
 	"golang.org/x/crypto/ssh"
 )
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := urlcreds.NewValidator().(*urlcreds.Validator)
+	brokenValidator.Client = velestest.BrokenClient
+
+	velestest.AcceptValidator(
+		t,
+		urlcreds.NewValidator(),
+		velestest.WithMalformedSecrets(urlcreds.Credentials{FullURL: ":::not-a-valid-url"}),
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithoutOnline[urlcreds.Credentials](),
+	)
+}
 
 func TestValidator(t *testing.T) {
 	basicAuthHTTPSvr := mockBasicAuthHTTPServer(t, "admin", "pass")

--- a/veles/velestest/accept_validator.go
+++ b/veles/velestest/accept_validator.go
@@ -85,7 +85,7 @@ func WithoutOnline[S veles.Secret]() AcceptValidatorOption[S] {
 	}
 }
 
-// AcceptValidator is an acceptance test for Veles Detector implementations.
+// AcceptValidator is an acceptance test for Veles Validator implementations.
 func AcceptValidator[S veles.Secret](t *testing.T, v veles.Validator[S], opts ...AcceptValidatorOption[S]) {
 	t.Helper()
 

--- a/veles/velestest/accept_validator.go
+++ b/veles/velestest/accept_validator.go
@@ -35,11 +35,15 @@ type testConfig[S veles.Secret] struct {
 	withoutOnline bool
 }
 
+// AcceptValidatorOption allows to configure the acceptance test
 type AcceptValidatorOption[S veles.Secret] func(*testConfig[S])
 
-var BrokenClient = newBrokenTCPClient()
+// BrokenClient is an http.Client that simulates a network failure ("connection refused") on any dial attempt.
+// It is designed to be passed into the WithBrokenTransport option to verify that a Validator
+// implementation returns veles.ValidationFailed on network error.
+var BrokenClient = newBrokenClient()
 
-func newBrokenTCPClient() *http.Client {
+func newBrokenClient() *http.Client {
 	transport := &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return nil, &net.OpError{

--- a/veles/velestest/accept_validator.go
+++ b/veles/velestest/accept_validator.go
@@ -98,30 +98,23 @@ func AcceptValidator[S veles.Secret](t *testing.T, v veles.Validator[S], opts ..
 	}
 
 	// At least one sample secret is needed to test context cancellation and transport errors.
-	var sampleSecret S
-	hasSample := false
-	if len(cfg.trueNegatives) > 0 {
-		sampleSecret = cfg.trueNegatives[0]
-		hasSample = true
-	} else if len(cfg.malformed) > 0 {
-		sampleSecret = cfg.malformed[0]
-		hasSample = true
+	if len(cfg.trueNegatives) == 0 {
+		t.Fatal("AcceptValidator requires at least one test secret. Use WithTrueNegatives to provide invalid but syntactically correct secrets.")
 	}
-
-	if !hasSample {
-		t.Fatal("AcceptValidator requires at least one test secret. Use WithTrueNegatives or WithMalformedSecrets.")
-	}
+	sampleSecret := cfg.trueNegatives[0]
 
 	t.Run("cancelled-ctx", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
+		expected := ctx.Err()
+
 		status, err := cfg.v.Validate(ctx, sampleSecret)
 		if status != veles.ValidationFailed {
 			t.Errorf("Validate() with cancelled context returned status %v, want %v", status, veles.ValidationFailed)
 		}
-		if err == nil {
-			t.Fatal("Validate() with cancelled context returned nil error, want non-nil error")
+		if !errors.Is(err, expected) {
+			t.Errorf("Validate() with cancelled context returned error: %v, want: %v", err, expected)
 		}
 	})
 
@@ -135,7 +128,7 @@ func AcceptValidator[S veles.Secret](t *testing.T, v veles.Validator[S], opts ..
 			t.Errorf("Validate() with unreachable service returned status %v, want %v", status, veles.ValidationFailed)
 		}
 		if err == nil {
-			t.Fatal("Validate() with unreachable service returned nil error, want non-nil error")
+			t.Error("Validate() with unreachable service returned nil error, want non-nil error")
 		}
 	})
 

--- a/veles/velestest/accept_validator.go
+++ b/veles/velestest/accept_validator.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package velestest
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+)
+
+type testConfig[S veles.Secret] struct {
+	v                    veles.Validator[S]
+	vWithBrokenTransport veles.Validator[S]
+
+	trueNegatives []S
+	malformed     []S
+
+	withoutOnline bool
+}
+
+type AcceptValidatorOption[S veles.Secret] func(*testConfig[S])
+
+var BrokenClient = newBrokenTCPClient()
+
+func newBrokenTCPClient() *http.Client {
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return nil, &net.OpError{
+				Op:  "dial",
+				Net: network,
+				Err: errors.New("simulated connection refused"),
+			}
+		},
+	}
+
+	return &http.Client{
+		Transport: transport,
+	}
+}
+
+// WithBrokenTransport is used to verify the validator functionality when there are network errors.
+func WithBrokenTransport[S veles.Secret](v veles.Validator[S]) AcceptValidatorOption[S] {
+	return func(cfg *testConfig[S]) {
+		cfg.vWithBrokenTransport = v
+	}
+}
+
+// WithTrueNegatives provides secrets that are perfectly formatted (including metadata)
+// but contain fake credentials. They are expected to return veles.ValidationInvalid.
+func WithTrueNegatives[S veles.Secret](secrets ...S) AcceptValidatorOption[S] {
+	return func(cfg *testConfig[S]) {
+		cfg.trueNegatives = append(cfg.trueNegatives, secrets...)
+	}
+}
+
+// WithMalformedSecrets provides secrets that have invalid formats, missing metadata,
+// or broken local constraints. They are expected to return veles.ValidationFailed.
+func WithMalformedSecrets[S veles.Secret](secrets ...S) AcceptValidatorOption[S] {
+	return func(cfg *testConfig[S]) {
+		cfg.malformed = append(cfg.malformed, secrets...)
+	}
+}
+
+// WithoutOnline disables online testing.
+func WithoutOnline[S veles.Secret]() AcceptValidatorOption[S] {
+	return func(cfg *testConfig[S]) {
+		cfg.withoutOnline = true
+	}
+}
+
+// AcceptValidator is an acceptance test for Veles Detector implementations.
+func AcceptValidator[S veles.Secret](t *testing.T, v veles.Validator[S], opts ...AcceptValidatorOption[S]) {
+	t.Helper()
+
+	cfg := &testConfig[S]{
+		v: v,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// At least one sample secret is needed to test context cancellation and transport errors.
+	var sampleSecret S
+	hasSample := false
+	if len(cfg.trueNegatives) > 0 {
+		sampleSecret = cfg.trueNegatives[0]
+		hasSample = true
+	} else if len(cfg.malformed) > 0 {
+		sampleSecret = cfg.malformed[0]
+		hasSample = true
+	}
+
+	if !hasSample {
+		t.Fatal("AcceptValidator requires at least one test secret. Use WithTrueNegatives or WithMalformedSecrets.")
+	}
+
+	t.Run("cancelled-ctx", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		status, err := cfg.v.Validate(ctx, sampleSecret)
+		if status != veles.ValidationFailed {
+			t.Errorf("Validate() with cancelled context returned status %v, want %v", status, veles.ValidationFailed)
+		}
+		if err == nil {
+			t.Fatal("Validate() with cancelled context returned nil error, want non-nil error")
+		}
+	})
+
+	t.Run("unreachable-service", func(t *testing.T) {
+		if cfg.vWithBrokenTransport == nil {
+			t.Skip("No client with broken Transport provided")
+		}
+
+		status, err := cfg.vWithBrokenTransport.Validate(t.Context(), sampleSecret)
+		if status != veles.ValidationFailed {
+			t.Errorf("Validate() with unreachable service returned status %v, want %v", status, veles.ValidationFailed)
+		}
+		if err == nil {
+			t.Fatal("Validate() with unreachable service returned nil error, want non-nil error")
+		}
+	})
+
+	// Test malformed secrets
+	if len(cfg.malformed) > 0 {
+		t.Run("malformed-secrets", func(t *testing.T) {
+			for _, s := range cfg.malformed {
+				status, err := cfg.v.Validate(t.Context(), s)
+				if status != veles.ValidationFailed {
+					t.Errorf("Validate() with malformed secret returned status %v, want %v", status, veles.ValidationFailed)
+				}
+				if err == nil {
+					t.Errorf("Validate() with malformed secret returned ValidationFailed but nil error")
+				}
+			}
+		})
+	}
+
+	// Test true negatives (invalid tokens)
+	if len(cfg.trueNegatives) > 0 {
+		t.Run("true-negatives", func(t *testing.T) {
+			if cfg.withoutOnline {
+				t.Skip("skipping Validator online as the WithoutOnline option was used")
+			}
+			if os.Getenv("ONLINE") == "" {
+				t.Skip("skipping Validator online test, add ONLINE=1 to launch the test")
+			}
+
+			for _, s := range cfg.trueNegatives {
+				status, err := cfg.v.Validate(t.Context(), s)
+				if status != veles.ValidationInvalid {
+					t.Errorf("Validate() with true-negative secret returned status %v, want %v", status, veles.ValidationInvalid)
+				}
+				if err != nil {
+					t.Errorf("Validate() with true-negative secret returned unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/veles/velestest/accept_validator_test.go
+++ b/veles/velestest/accept_validator_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package velestest_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+func TestAcceptValidator(t *testing.T) {
+	brokenValidator := velestest.NewFakeValidator[velestest.FakeStringSecret](veles.ValidationFailed, errors.New("service unreachable"))
+	relaxedValidator := velestest.NewFakeValidator[velestest.FakeStringSecret](veles.ValidationInvalid, nil)
+
+	velestest.AcceptValidator(
+		t,
+		relaxedValidator,
+		velestest.WithBrokenTransport(brokenValidator),
+		velestest.WithTrueNegatives(velestest.FakeStringSecret{Value: "test-invalid"}),
+	)
+}


### PR DESCRIPTION
This PR adds acceptance validator tests.

After the addition of acceptance tests these plugin failed the test:

- [x] `github.com/google/osv-scalibr/veles/secrets/awsaccesskey` | An `errResp.Error.Code` was missing and the validator returned `veles.ValidationFailed` instead of `veles.ValidationInvalid`
- [x] `github.com/google/osv-scalibr/veles/secrets/cloudflareapitoken` | The service returns `http.StatusBadRequest` on malformed token
- [x] `github.com/google/osv-scalibr/veles/secrets/cratesioapitoken` | The service returns `http.StatusBadRequest` on malformed token
- [x] `github.com/google/osv-scalibr/veles/secrets/grokxaiapikey` | InvalidResponseCodes were not specified leading to false positives, needs further investigation
- [x] `github.com/google/osv-scalibr/veles/secrets/salesforceoauth2access` | The service returns 403 for bad ouauth token, needs further investigation
- [x] `github.com/google/osv-scalibr/veles/secrets/salesforceoauth2client` | The service is not testable online
- [x] `github.com/google/osv-scalibr/veles/secrets/salesforceoauth2refresh` | The request was poorly formatted and resulted in the validator always failing
- [x] `github.com/google/osv-scalibr/veles/secrets/gcshmackey` | The request creation was always failing because the host header was missing. I confirmed that the validator is now properly working.

<details>
<summary>Test output</summary>

```sh
➜  osv-scalibr git:(acceptance-tests-for-secrets-detector) ✗ ONLINE=1 go test \
github.com/google/osv-scalibr/veles/secrets/awsaccesskey \
github.com/google/osv-scalibr/veles/secrets/cloudflareapitoken \
github.com/google/osv-scalibr/veles/secrets/cratesioapitoken \
github.com/google/osv-scalibr/veles/secrets/grokxaiapikey \
github.com/google/osv-scalibr/veles/secrets/salesforceoauth2access \
github.com/google/osv-scalibr/veles/secrets/salesforceoauth2client \
github.com/google/osv-scalibr/veles/secrets/salesforceoauth2refresh \
-run 'TestAccept.*Validator' -v
=== RUN   TestAcceptValidator
=== RUN   TestAcceptValidator/cancelled-ctx
=== RUN   TestAcceptValidator/unreachable-service
=== RUN   TestAcceptValidator/true-negatives
StatusCode: 403 Forbidden
Response: <ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
  <Error>
    <Type>Sender</Type>
    <Code>InvalidClientTokenId</Code>
    <Message>The security token included in the request is invalid.</Message>
  </Error>
  <RequestId>e1de87b3-d8e9-4fec-873c-280dbd3bc366</RequestId>
</ErrorResponse>

    accept_validator.go:170: Validate() with true-negative secret returned status VALIDATION_FAILED, want VALIDATION_INVALID
    accept_validator.go:173: Validate() with true-negative secret returned unexpected error: unknown error code: "InvalidClientTokenId"
--- FAIL: TestAcceptValidator (0.47s)
    --- PASS: TestAcceptValidator/cancelled-ctx (0.00s)
    --- PASS: TestAcceptValidator/unreachable-service (0.00s)
    --- FAIL: TestAcceptValidator/true-negatives (0.47s)
FAIL
FAIL	github.com/google/osv-scalibr/veles/secrets/awsaccesskey	1.049s
=== RUN   TestAcceptValidator
=== RUN   TestAcceptValidator/cancelled-ctx
=== RUN   TestAcceptValidator/unreachable-service
=== RUN   TestAcceptValidator/true-negatives
StatusCode: 400 Bad Request
Response: {"success":false,"errors":[{"code":6003,"message":"Invalid request headers","error_chain":[{"code":6111,"message":"Invalid format for Authorization header"}]}],"messages":[],"result":null}
    accept_validator.go:170: Validate() with true-negative secret returned status VALIDATION_FAILED, want VALIDATION_INVALID
    accept_validator.go:173: Validate() with true-negative secret returned unexpected error: https://api.cloudflare.com/client/v4/zones: unexpected HTTP status 400
--- FAIL: TestAcceptValidator (0.30s)
    --- PASS: TestAcceptValidator/cancelled-ctx (0.00s)
    --- PASS: TestAcceptValidator/unreachable-service (0.00s)
    --- FAIL: TestAcceptValidator/true-negatives (0.30s)
FAIL
FAIL	github.com/google/osv-scalibr/veles/secrets/cloudflareapitoken	0.514s
=== RUN   TestAcceptValidator
=== RUN   TestAcceptValidator/cancelled-ctx
=== RUN   TestAcceptValidator/unreachable-service
=== RUN   TestAcceptValidator/true-negatives
StatusCode: 401 Unauthorized
Response: {"errors":[{"detail":"The given API token does not match the format used by crates.io. Tokens generated before 2020-07-14 were generated with an insecure random number generator, and have been revoked. You can generate a new token at https://crates.io/me. For more information please see https://blog.rust-lang.org/2020/07/14/crates-io-security-advisory.html. We apologize for any inconvenience."}]}
    accept_validator.go:170: Validate() with true-negative secret returned status VALIDATION_FAILED, want VALIDATION_INVALID
    accept_validator.go:173: Validate() with true-negative secret returned unexpected error: https://crates.io/api/v1/crates/osvscalibr361aa9c83e8d69e1/owners: unexpected HTTP status 401
--- FAIL: TestAcceptValidator (0.60s)
    --- PASS: TestAcceptValidator/cancelled-ctx (0.00s)
    --- PASS: TestAcceptValidator/unreachable-service (0.00s)
    --- FAIL: TestAcceptValidator/true-negatives (0.60s)
FAIL
FAIL	github.com/google/osv-scalibr/veles/secrets/cratesioapitoken	0.991s
=== RUN   TestAcceptAPIValidator
=== RUN   TestAcceptAPIValidator/cancelled-ctx
=== RUN   TestAcceptAPIValidator/unreachable-service
=== RUN   TestAcceptAPIValidator/true-negatives
StatusCode: 400 Bad Request
Response: {"code":"Client specified an invalid argument","error":"Incorrect API key provided: gr***00. You can obtain an API key from https://console.x.ai."}
    accept_validator.go:170: Validate() with true-negative secret returned status VALIDATION_VALID, want VALIDATION_INVALID
--- FAIL: TestAcceptAPIValidator (0.19s)
    --- PASS: TestAcceptAPIValidator/cancelled-ctx (0.00s)
    --- PASS: TestAcceptAPIValidator/unreachable-service (0.00s)
    --- FAIL: TestAcceptAPIValidator/true-negatives (0.19s)
=== RUN   TestAcceptManagementAPIValidator
=== RUN   TestAcceptManagementAPIValidator/cancelled-ctx
=== RUN   TestAcceptManagementAPIValidator/unreachable-service
=== RUN   TestAcceptManagementAPIValidator/true-negatives
StatusCode: 401 Unauthorized
Response: {"code":16, "message":"Invalid bearer token. Please ensure you use a valid management key.", "details":[]}
--- PASS: TestAcceptManagementAPIValidator (0.41s)
    --- PASS: TestAcceptManagementAPIValidator/cancelled-ctx (0.00s)
    --- PASS: TestAcceptManagementAPIValidator/unreachable-service (0.00s)
    --- PASS: TestAcceptManagementAPIValidator/true-negatives (0.41s)
FAIL
FAIL	github.com/google/osv-scalibr/veles/secrets/grokxaiapikey	1.343s
=== RUN   TestAcceptValidator
=== RUN   TestAcceptValidator/cancelled-ctx
=== RUN   TestAcceptValidator/unreachable-service
=== RUN   TestAcceptValidator/true-negatives
StatusCode: 403 Forbidden
Response: Bad_OAuth_Token
    accept_validator.go:170: Validate() with true-negative secret returned status VALIDATION_FAILED, want VALIDATION_INVALID
    accept_validator.go:173: Validate() with true-negative secret returned unexpected error: https://login.salesforce.com/services/oauth2/userinfo: unexpected HTTP status 403
--- FAIL: TestAcceptValidator (0.17s)
    --- PASS: TestAcceptValidator/cancelled-ctx (0.00s)
    --- PASS: TestAcceptValidator/unreachable-service (0.00s)
    --- FAIL: TestAcceptValidator/true-negatives (0.17s)
FAIL
FAIL	github.com/google/osv-scalibr/veles/secrets/salesforceoauth2access	1.282s
=== RUN   TestAcceptValidator
=== RUN   TestAcceptValidator/cancelled-ctx
=== RUN   TestAcceptValidator/unreachable-service
=== RUN   TestAcceptValidator/true-negatives
    accept_validator.go:170: Validate() with true-negative secret returned status VALIDATION_FAILED, want VALIDATION_INVALID
    accept_validator.go:173: Validate() with true-negative secret returned unexpected error: https://yuvrajapp.my.salesforce.com/services/oauth2/token: HTTP request failed: Post "https://yuvrajapp.my.salesforce.com/services/oauth2/token": dial tcp: lookup yuvrajapp.my.salesforce.com: no such host
--- FAIL: TestAcceptValidator (1.05s)
    --- PASS: TestAcceptValidator/cancelled-ctx (0.00s)
    --- PASS: TestAcceptValidator/unreachable-service (0.00s)
    --- FAIL: TestAcceptValidator/true-negatives (1.05s)
FAIL
FAIL	github.com/google/osv-scalibr/veles/secrets/salesforceoauth2client	2.333s
=== RUN   TestAcceptValidator
=== RUN   TestAcceptValidator/cancelled-ctx
=== RUN   TestAcceptValidator/unreachable-service
=== RUN   TestAcceptValidator/true-negatives
StatusCode: 400 Bad Request
Response: {"error":"unsupported_grant_type","error_description":"grant type not supported"}
    accept_validator.go:170: Validate() with true-negative secret returned status VALIDATION_FAILED, want VALIDATION_INVALID
    accept_validator.go:173: Validate() with true-negative secret returned unexpected error: https://login.salesforce.com/services/oauth2/token: unexpected HTTP status 400
--- FAIL: TestAcceptValidator (0.18s)
    --- PASS: TestAcceptValidator/cancelled-ctx (0.00s)
    --- PASS: TestAcceptValidator/unreachable-service (0.00s)
    --- FAIL: TestAcceptValidator/true-negatives (0.18s)
FAIL
FAIL	github.com/google/osv-scalibr/veles/secrets/salesforceoauth2refresh	1.112s
FAIL
```

</details>