### PR TITLE
embeddedfs/vmdk: limit zlib grain decompression to prevent memory exhaustion

### DIFF
--- a/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
+++ b/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
@@ -29,14 +29,17 @@ func TestConvertVMDKZlibBombRejected(t *testing.T) {
 	// Craft a stream-optimized VMDK with a single grain whose zlib payload
 	// decompresses to more than grainBytes (65536 bytes).
 	const grainSize = 128 // sectors per grain
-	const grainBytes = grainSize * SectorSize // 65536
 	const overhead = 4
 
 	// Compress 1 MB of zeros — decompresses to 1 MB >> grainBytes (65536).
 	var zbuf bytes.Buffer
 	zw := zlib.NewWriter(&zbuf)
-	zw.Write(bytes.Repeat([]byte{0}, 1<<20)) // 1 MB
-	zw.Close()
+	if _, err := zw.Write(bytes.Repeat([]byte{0}, 1<<20)); err != nil { // 1 MB
+		t.Fatalf("zw.Write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zw.Close: %v", err)
+	}
 	compressed := zbuf.Bytes()
 
 	// Build header: CompressAlgorithm=1 → isStream=true; GDOffset=2 → skip readFooterIfGDAtEnd.
@@ -54,41 +57,45 @@ func TestConvertVMDKZlibBombRejected(t *testing.T) {
 	hdr.CompressAlgorithm = 1
 
 	var buf bytes.Buffer
-	binary.Write(&buf, binary.LittleEndian, &hdr)
+	bwrite := func(v any) {
+		if err := binary.Write(&buf, binary.LittleEndian, v); err != nil {
+			t.Fatalf("binary.Write: %v", err)
+		}
+	}
+
+	bwrite(&hdr)
 	// Pad to OverHead sectors.
 	buf.Write(make([]byte, overhead*SectorSize-buf.Len()))
 
 	// Grain marker: val(8 LE) + size(4 LE) + compressed payload, padded to sector.
-	binary.Write(&buf, binary.LittleEndian, uint64(0))               // LBA
-	binary.Write(&buf, binary.LittleEndian, uint32(len(compressed))) // compressed size
+	bwrite(uint64(0))               // LBA
+	bwrite(uint32(len(compressed))) // compressed size
 	buf.Write(compressed)
 	if pad := (SectorSize - (buf.Len() % SectorSize)) % SectorSize; pad > 0 {
 		buf.Write(make([]byte, pad))
 	}
 
 	// EOS marker.
-	binary.Write(&buf, binary.LittleEndian, uint64(0))  // val
-	binary.Write(&buf, binary.LittleEndian, uint32(0))  // size=0
-	binary.Write(&buf, binary.LittleEndian, uint32(0))  // type=EOS
+	bwrite(uint64(0)) // val
+	bwrite(uint32(0)) // size=0
+	bwrite(uint32(0)) // type=EOS
 	buf.Write(make([]byte, SectorSize-16))
 
 	// Write to temp file (convertVMDKToRaw requires a file path).
-	tmp, err := os.CreateTemp("", "vmdk-zlib-bomb-*.vmdk")
+	tmp, err := os.CreateTemp(t.TempDir(), "vmdk-zlib-bomb-*.vmdk")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmp.Name())
 	if _, err := tmp.Write(buf.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 	tmp.Close()
 
-	outRaw, err := os.CreateTemp("", "vmdk-zlib-bomb-out-*.raw")
+	outRaw, err := os.CreateTemp(t.TempDir(), "vmdk-zlib-bomb-out-*.raw")
 	if err != nil {
 		t.Fatal(err)
 	}
 	outRaw.Close()
-	defer os.Remove(outRaw.Name())
 
 	err = convertVMDKToRaw(tmp.Name(), outRaw.Name())
 	if err == nil {

--- a/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
+++ b/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vmdk
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"os"
+	"testing"
+)
+
+// TestConvertVMDKZlibBombRejected verifies that a stream-optimized VMDK
+// containing a decompression bomb (small compressed grain expanding far beyond
+// one grain size) is rejected rather than causing unbounded memory allocation.
+func TestConvertVMDKZlibBombRejected(t *testing.T) {
+	// Craft a stream-optimized VMDK with a single grain whose zlib payload
+	// decompresses to more than grainBytes (65536 bytes).
+	const grainSize = 128 // sectors per grain
+	const grainBytes = grainSize * SectorSize // 65536
+	const overhead = 4
+
+	// Compress 1 MB of zeros — decompresses to 1 MB >> grainBytes (65536).
+	var zbuf bytes.Buffer
+	zw := zlib.NewWriter(&zbuf)
+	zw.Write(bytes.Repeat([]byte{0}, 1<<20)) // 1 MB
+	zw.Close()
+	compressed := zbuf.Bytes()
+
+	// Build header: CompressAlgorithm=1 → isStream=true; GDOffset=2 → skip readFooterIfGDAtEnd.
+	var hdr sparseExtentHeader
+	hdr.MagicNumber = SparseMagic
+	hdr.Version = 1
+	hdr.Flags = (1 << 16) | (1 << 17) // HAS_COMPRESSED | HAS_METADATA
+	hdr.Capacity = 0x10000
+	hdr.GrainSize = grainSize
+	hdr.DescriptorOffset = 1
+	hdr.DescriptorSize = 1
+	hdr.NumGTEsPerGT = SectorSize / 4
+	hdr.GDOffset = 2
+	hdr.OverHead = overhead
+	hdr.CompressAlgorithm = 1
+
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.LittleEndian, &hdr)
+	// Pad to OverHead sectors.
+	buf.Write(make([]byte, overhead*SectorSize-buf.Len()))
+
+	// Grain marker: val(8 LE) + size(4 LE) + compressed payload, padded to sector.
+	binary.Write(&buf, binary.LittleEndian, uint64(0))               // LBA
+	binary.Write(&buf, binary.LittleEndian, uint32(len(compressed))) // compressed size
+	buf.Write(compressed)
+	if pad := (SectorSize - (buf.Len() % SectorSize)) % SectorSize; pad > 0 {
+		buf.Write(make([]byte, pad))
+	}
+
+	// EOS marker.
+	binary.Write(&buf, binary.LittleEndian, uint64(0))  // val
+	binary.Write(&buf, binary.LittleEndian, uint32(0))  // size=0
+	binary.Write(&buf, binary.LittleEndian, uint32(0))  // type=EOS
+	buf.Write(make([]byte, SectorSize-16))
+
+	// Write to temp file (convertVMDKToRaw requires a file path).
+	tmp, err := os.CreateTemp("", "vmdk-zlib-bomb-*.vmdk")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(buf.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	outRaw, err := os.CreateTemp("", "vmdk-zlib-bomb-out-*.raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outRaw.Close()
+	defer os.Remove(outRaw.Name())
+
+	err = convertVMDKToRaw(tmp.Name(), outRaw.Name())
+	if err == nil {
+		t.Error("convertVMDKToRaw: want error for decompression bomb, got nil")
+	}
+}

--- a/extractor/filesystem/embeddedfs/vmdk/vmdk.go
+++ b/extractor/filesystem/embeddedfs/vmdk/vmdk.go
@@ -317,10 +317,14 @@ func convertStreamOptimizedExtent(f *os.File, out *os.File, hdr sparseExtentHead
 				if zerr != nil {
 					return fmt.Errorf("zlib reader at lba %d: %w", lba, zerr)
 				}
-				dec, derr := io.ReadAll(zr)
+				// Limit decompression to one grain to prevent decompression bomb attacks.
+				dec, derr := io.ReadAll(io.LimitReader(zr, grainBytes+1))
 				zr.Close()
 				if derr != nil && !errors.Is(derr, io.EOF) {
 					return fmt.Errorf("zlib read at lba %d: %w", lba, derr)
+				}
+				if int64(len(dec)) > grainBytes {
+					return fmt.Errorf("decompressed grain at lba %d exceeds grain size %d", lba, grainBytes)
 				}
 				if int64(len(dec)) < grainBytes {
 					tmp := make([]byte, grainBytes)


### PR DESCRIPTION
## Summary

`convertStreamOptimizedExtent` calls `io.ReadAll` on a zlib reader for
compressed grains with no decompression size limit. A crafted
stream-optimized VMDK with a single grain whose payload compresses at
~1000:1 ratio (e.g., zeros) causes ~1.7 GB of heap allocation from a
512 KB input file. The function returns `nil` on success, making the
memory spike silent.

**Root cause** (`vmdk.go:320`, before this fix):
\`\`\`go
dec, derr := io.ReadAll(zr)  // no size limit
\`\`\`

The `else if size < uint32(grainBytes) || size > uint32(grainBytes)`
branch is equivalent to `size != grainBytes` and triggers for all
compressed grains, which is the normal case in stream-optimized VMDKs.

## Fix

Replace `io.ReadAll(zr)` with `io.ReadAll(io.LimitReader(zr, grainBytes+1))`
and return an error if the decompressed data exceeds the expected grain size.
A valid compressed grain decompresses to exactly `grainBytes`; anything larger
indicates a malformed or malicious file.

## Testing

`TestConvertVMDKZlibBombRejected` crafts a minimal malicious VMDK in pure Go
(1 MB of zeros compressed to ~1 KB, far exceeding `grainBytes = 65536`) and
confirms the fixed code returns an error rather than allocating memory.

Before fix: `TotalAlloc delta: 1735 MB` from a 512 KB file.  
After fix: `TotalAlloc delta: 0 MB`, immediate error returned.