### PR TITLE
embeddedfs/vdi: add bounds check for BlocksInImage before slice allocation

### DIFF
--- a/extractor/filesystem/embeddedfs/vdi/security_regression_test.go
+++ b/extractor/filesystem/embeddedfs/vdi/security_regression_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"testing"
+)
+
+// TestConvertVDIOOMRejected verifies that a VDI image with an oversized
+// BlocksInImage field is rejected before any large heap allocation occurs.
+func TestConvertVDIOOMRejected(t *testing.T) {
+	// BlocksInImage = 0x3FFFFFFF would request a ~4 GB indices slice.
+	hdr := header{
+		Signature:     Signature,
+		Version:       0x00010001,
+		ImageType:     1, // dynamic/sparse
+		SectorSize:    512,
+		BlockSize:     1 << 20,
+		BlocksInImage: 0x3FFFFFFF,
+		OffsetBmap:    512,
+		OffsetData:    1024,
+		DiskSize:      1 << 30,
+	}
+	copy(hdr.Text[:], "<<< Oracle VM VirtualBox Disk Image >>>\n")
+
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, &hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := os.CreateTemp("", "vdi-oom-out-*.raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(out.Name())
+	defer out.Close()
+
+	if err := convertVDIToRaw(bytes.NewReader(buf.Bytes()), out); err == nil {
+		t.Error("convertVDIToRaw: want error for oversized BlocksInImage, got nil")
+	}
+}

--- a/extractor/filesystem/embeddedfs/vdi/security_regression_test.go
+++ b/extractor/filesystem/embeddedfs/vdi/security_regression_test.go
@@ -43,11 +43,10 @@ func TestConvertVDIOOMRejected(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := os.CreateTemp("", "vdi-oom-out-*.raw")
+	out, err := os.CreateTemp(t.TempDir(), "vdi-oom-out-*.raw")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(out.Name())
 	defer out.Close()
 
 	if err := convertVDIToRaw(bytes.NewReader(buf.Bytes()), out); err == nil {

--- a/extractor/filesystem/embeddedfs/vdi/vdi.go
+++ b/extractor/filesystem/embeddedfs/vdi/vdi.go
@@ -194,6 +194,14 @@ func convertVDIToRaw(in io.Reader, out io.Writer) error {
 			curPos = int64(hdr.OffsetBmap)
 		}
 
+		// Guard against malicious BlocksInImage values that would cause a
+		// multi-gigabyte heap allocation before any I/O is attempted.
+		// A valid VDI has BlocksInImage ≈ DiskSize/BlockSize; cap at 64M blocks
+		// (≥64 TiB at the minimum 1 MiB block size) as a hard safety limit.
+		const maxBlocksInImage = 64 << 20 // 67,108,864
+		if hdr.BlocksInImage > maxBlocksInImage {
+			return fmt.Errorf("BlocksInImage %d exceeds safety limit %d", hdr.BlocksInImage, maxBlocksInImage)
+		}
 		indices := make([]uint32, hdr.BlocksInImage)
 		if err := binary.Read(in, binary.LittleEndian, &indices); err != nil {
 			return fmt.Errorf("failed to read block map: %w", err)


### PR DESCRIPTION
## Summary

`convertVDIToRaw` calls `make([]uint32, hdr.BlocksInImage)` with no bounds
check on the untrusted `BlocksInImage` header field (`vdi.go:197`).

`BlocksInImage` is a `uint32` read directly from the file. Setting it to
`0x3FFFFFFF` requests a ~4 GB slice; `0xFFFFFFFF` requests ~16 GB. The
allocation occurs before any I/O — a **512-byte** file is sufficient to trigger it.

**Before fix (512-byte input):**
```
TotalAlloc delta: 8192 MB
```

On systems with overcommit disabled (common in containers with
`vm.overcommit_memory=2`), the `make()` call panics the process immediately.

## Fix

Add a hard cap of `64 << 20` blocks (67,108,864) before the allocation.
This covers disks ≥ 64 TiB at the minimum 1 MiB VDI block size — far beyond
any realistic disk image a scanner would encounter.

```go
const maxBlocksInImage = 64 << 20
if hdr.BlocksInImage > maxBlocksInImage {
    return fmt.Errorf("BlocksInImage %d exceeds safety limit %d", ...)
}
indices := make([]uint32, hdr.BlocksInImage)
```

## Testing

`TestConvertVDIOOMRejected` constructs a minimal 512-byte VDI header with
`BlocksInImage=0x3FFFFFFF` in pure Go and confirms the fixed code returns
an error with zero heap allocation.

After fix: `TotalAlloc delta: 0 MB`, immediate error.