### PR TITLE
embeddedfs/vmdk: cap stream marker data size and footer sector count to prevent OOM

### DIFF
--- a/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
+++ b/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
@@ -1,0 +1,158 @@
+package vmdk
+
+import (
+	"encoding/binary"
+	"os"
+	"runtime"
+	"testing"
+)
+
+// craftStreamOptimizedVMDKMarkerBomb builds a minimal stream-optimized VMDK
+// whose first stream marker has size=0xffffffff.
+// readStreamMarker calls make([]byte, size) before io.ReadFull returns EOF.
+func craftStreamOptimizedVMDKMarkerBomb(t *testing.T) string {
+	t.Helper()
+
+	hdr := make([]byte, SectorSize) // 512 bytes, all-zero baseline
+	le := binary.LittleEndian
+
+	le.PutUint32(hdr[0:], SparseMagic) // MagicNumber
+	le.PutUint32(hdr[4:], 1)           // Version = 1
+	le.PutUint32(hdr[8:], 0x00030000)  // Flags = flagHasCompressed | flagHasMetadata
+	le.PutUint64(hdr[12:], 1)          // Capacity = 1 sector
+	le.PutUint64(hdr[20:], 128)        // GrainSize = 128 (default)
+	// DescriptorOffset/DescriptorSize/NumGTEsPerGT/RGDOffset = 0
+	le.PutUint64(hdr[56:], 1) // GDOffset = 1 (not GDAtEnd)
+	le.PutUint64(hdr[64:], 2) // OverHead = 2 → stream starts at byte 1024
+	hdr[72] = 0               // UncleanShutdown
+	hdr[73] = '\n'            // SingleEndLineChar
+	hdr[74] = ' '             // NonEndLineChar
+	hdr[75] = '\r'            // DoubleEndLineChar1
+	hdr[76] = '\n'            // DoubleEndLineChar2
+	le.PutUint16(hdr[77:], 1) // CompressAlgorithm = 1 (deflate)
+
+	// Pad to byte 1024 (sector 2 = OverHead * SectorSize)
+	pad := make([]byte, SectorSize) // one more sector of zeros
+
+	// Stream marker at byte 1024: val=0 (8 bytes) + size=0xffffffff (4 bytes)
+	marker := make([]byte, 12)
+	le.PutUint64(marker[0:], 0)          // val = LBA 0
+	le.PutUint32(marker[8:], 0xffffffff) // size = ~4 GB → make([]byte, 4294967295)
+
+	f, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-markerbomb-*.vmdk")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	for _, b := range [][]byte{hdr, pad, marker} {
+		if _, err := f.Write(b); err != nil {
+			f.Close()
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestConvertVMDKStreamMarkerSizeRejected(t *testing.T) {
+	inputPath := craftStreamOptimizedVMDKMarkerBomb(t)
+
+	outFile, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-out-*.raw")
+	if err != nil {
+		t.Fatalf("CreateTemp output: %v", err)
+	}
+	outFile.Close()
+
+	t.Logf("Malicious stream-optimized VMDK: 1036 bytes on disk")
+	t.Logf("Marker size = 0xffffffff => make([]byte, 4294967295) = ~4 GB attempted without fix")
+
+	var msBefore, msAfter runtime.MemStats
+	runtime.ReadMemStats(&msBefore)
+
+	convertErr := convertVMDKToRaw(inputPath, outFile.Name())
+
+	runtime.ReadMemStats(&msAfter)
+	allocMB := (msAfter.TotalAlloc - msBefore.TotalAlloc) >> 20
+
+	t.Logf("convertVMDKToRaw err: %v", convertErr)
+	t.Logf("TotalAlloc delta: %d MB", allocMB)
+
+	if convertErr == nil {
+		t.Errorf("expected error for malicious marker size=0xffffffff, got nil")
+	}
+	if allocMB > 50 {
+		t.Errorf("TotalAlloc delta %d MB exceeds 50 MB — marker size bounds check missing", allocMB)
+	}
+}
+
+// craftStreamOptimizedVMDKFooterBomb builds a stream-optimized VMDK with a
+// FOOTER metadata marker (size=0, typ=3) whose sector-count val is 0x100000
+// (~512 MB allocation via make([]byte, val*SectorSize)).
+func craftStreamOptimizedVMDKFooterBomb(t *testing.T) string {
+	t.Helper()
+
+	hdr := make([]byte, SectorSize)
+	le := binary.LittleEndian
+	le.PutUint32(hdr[0:], SparseMagic)
+	le.PutUint32(hdr[4:], 1)
+	le.PutUint32(hdr[8:], 0x00030000) // stream-optimized flags
+	le.PutUint64(hdr[12:], 1)
+	le.PutUint64(hdr[20:], 128)
+	le.PutUint64(hdr[56:], 1) // GDOffset != GDAtEnd
+	le.PutUint64(hdr[64:], 2) // OverHead = 2 → stream at byte 1024
+	hdr[73] = '\n'
+	hdr[74] = ' '
+	hdr[75] = '\r'
+	hdr[76] = '\n'
+	le.PutUint16(hdr[77:], 1)
+
+	pad := make([]byte, SectorSize)
+
+	// Metadata marker: size=0 (→ read typ), val=0x100000 sectors (~512 MB), typ=3 (FOOTER)
+	meta := make([]byte, 16)
+	le.PutUint64(meta[0:], 0x100000) // val = 1M sectors → 512 MB allocation
+	le.PutUint32(meta[8:], 0)        // size = 0 → metadata path
+	le.PutUint32(meta[12:], 3)       // typ = 3 (FOOTER) → make([]byte, val*SectorSize)
+
+	f, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-footerbomb-*.vmdk")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	for _, b := range [][]byte{hdr, pad, meta} {
+		if _, err := f.Write(b); err != nil {
+			f.Close()
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestConvertVMDKFooterSectorCountRejected(t *testing.T) {
+	inputPath := craftStreamOptimizedVMDKFooterBomb(t)
+
+	outFile, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-out-*.raw")
+	if err != nil {
+		t.Fatalf("CreateTemp output: %v", err)
+	}
+	outFile.Close()
+
+	t.Logf("Malicious FOOTER marker: val=0x100000 sectors => ~512 MB allocation without fix")
+
+	var msBefore, msAfter runtime.MemStats
+	runtime.ReadMemStats(&msBefore)
+
+	convertErr := convertVMDKToRaw(inputPath, outFile.Name())
+
+	runtime.ReadMemStats(&msAfter)
+	allocMB := (msAfter.TotalAlloc - msBefore.TotalAlloc) >> 20
+
+	t.Logf("convertVMDKToRaw err: %v", convertErr)
+	t.Logf("TotalAlloc delta: %d MB", allocMB)
+
+	if convertErr == nil {
+		t.Errorf("expected error for malicious footer val=0x100000, got nil")
+	}
+	if allocMB > 50 {
+		t.Errorf("TotalAlloc delta %d MB exceeds 50 MB — footer sector count bounds check missing", allocMB)
+	}
+}

--- a/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
+++ b/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
@@ -1,6 +1,8 @@
 package vmdk
 
 import (
+	"bytes"
+	"compress/zlib"
 	"encoding/binary"
 	"os"
 	"runtime"
@@ -125,6 +127,89 @@ func craftStreamOptimizedVMDKFooterBomb(t *testing.T) string {
 	}
 	f.Close()
 	return f.Name()
+}
+
+// craftStreamOptimizedVMDKGrainOverflow builds a stream-optimized VMDK whose
+// GrainSize is an oversized power of two (2^62). It passes the old
+// power-of-two check, but int64(grainSec)*SectorSize overflows int64 and wraps
+// to 0, so the subsequent grain-alignment arithmetic divides by zero.
+func craftStreamOptimizedVMDKGrainOverflow(t *testing.T) string {
+	t.Helper()
+
+	hdr := make([]byte, SectorSize)
+	le := binary.LittleEndian
+	le.PutUint32(hdr[0:], SparseMagic)
+	le.PutUint32(hdr[4:], 1)
+	le.PutUint32(hdr[8:], 0x00030000)     // stream-optimized flags
+	le.PutUint64(hdr[12:], 1)             // Capacity = 1 sector
+	le.PutUint64(hdr[20:], uint64(1)<<62) // GrainSize = 2^62 (power of two, overflows *512)
+	le.PutUint64(hdr[56:], 1)             // GDOffset != GDAtEnd
+	le.PutUint64(hdr[64:], 2)             // OverHead = 2 → stream at byte 1024
+	hdr[73] = '\n'
+	hdr[74] = ' '
+	hdr[75] = '\r'
+	hdr[76] = '\n'
+	le.PutUint16(hdr[77:], 1)
+
+	pad := make([]byte, SectorSize)
+
+	// A valid zlib-compressed grain so parsing reaches the alignment math.
+	var zbuf bytes.Buffer
+	zw := zlib.NewWriter(&zbuf)
+	if _, err := zw.Write([]byte("grain")); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+	comp := zbuf.Bytes()
+
+	marker := make([]byte, 12)
+	le.PutUint64(marker[0:], 0)                 // val = LBA 0
+	le.PutUint32(marker[8:], uint32(len(comp))) // size = compressed length
+
+	// Pad the grain marker out to a sector boundary, then append an EOS marker.
+	consumed := 12 + len(comp)
+	grainPad := (SectorSize - (consumed % SectorSize)) % SectorSize
+	eos := make([]byte, 16) // val=0, size=0, typ=0 (EOS)
+
+	f, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-grainoverflow-*.vmdk")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	for _, b := range [][]byte{hdr, pad, marker, comp, make([]byte, grainPad), eos} {
+		if _, err := f.Write(b); err != nil {
+			f.Close()
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestConvertVMDKGrainSizeOverflowHandled(t *testing.T) {
+	inputPath := craftStreamOptimizedVMDKGrainOverflow(t)
+
+	outFile, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-out-*.raw")
+	if err != nil {
+		t.Fatalf("CreateTemp output: %v", err)
+	}
+	outFile.Close()
+
+	t.Logf("GrainSize = 2^62 => int64(grainSec)*SectorSize overflows to 0 without the cap")
+
+	// Without the MaxGrainSec cap, grainBytes wraps to 0 and the grain-alignment
+	// arithmetic panics with an integer divide-by-zero. The cap forces a fallback
+	// to DefaultGrainSec, so the conversion completes without panicking.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("convertVMDKToRaw panicked on oversized GrainSize: %v", r)
+		}
+	}()
+
+	if err := convertVMDKToRaw(inputPath, outFile.Name()); err != nil {
+		t.Logf("convertVMDKToRaw err (non-fatal, must not panic): %v", err)
+	}
 }
 
 func TestConvertVMDKFooterSectorCountRejected(t *testing.T) {

--- a/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
+++ b/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
@@ -224,6 +224,89 @@ func craftStreamOptimizedVMDKFooterBomb(t *testing.T) string {
 	return f.Name()
 }
 
+// craftStreamOptimizedVMDKGrainOverflow builds a stream-optimized VMDK whose
+// GrainSize is an oversized power of two (2^62). It passes the old
+// power-of-two check, but int64(grainSec)*SectorSize overflows int64 and wraps
+// to 0, so the subsequent grain-alignment arithmetic divides by zero.
+func craftStreamOptimizedVMDKGrainOverflow(t *testing.T) string {
+	t.Helper()
+
+	hdr := make([]byte, SectorSize)
+	le := binary.LittleEndian
+	le.PutUint32(hdr[0:], SparseMagic)
+	le.PutUint32(hdr[4:], 1)
+	le.PutUint32(hdr[8:], 0x00030000)     // stream-optimized flags
+	le.PutUint64(hdr[12:], 1)             // Capacity = 1 sector
+	le.PutUint64(hdr[20:], uint64(1)<<62) // GrainSize = 2^62 (power of two, overflows *512)
+	le.PutUint64(hdr[56:], 1)             // GDOffset != GDAtEnd
+	le.PutUint64(hdr[64:], 2)             // OverHead = 2 → stream at byte 1024
+	hdr[73] = '\n'
+	hdr[74] = ' '
+	hdr[75] = '\r'
+	hdr[76] = '\n'
+	le.PutUint16(hdr[77:], 1)
+
+	pad := make([]byte, SectorSize)
+
+	// A valid zlib-compressed grain so parsing reaches the alignment math.
+	var zbuf bytes.Buffer
+	zw := zlib.NewWriter(&zbuf)
+	if _, err := zw.Write([]byte("grain")); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+	comp := zbuf.Bytes()
+
+	marker := make([]byte, 12)
+	le.PutUint64(marker[0:], 0)                 // val = LBA 0
+	le.PutUint32(marker[8:], uint32(len(comp))) // size = compressed length
+
+	// Pad the grain marker out to a sector boundary, then append an EOS marker.
+	consumed := 12 + len(comp)
+	grainPad := (SectorSize - (consumed % SectorSize)) % SectorSize
+	eos := make([]byte, 16) // val=0, size=0, typ=0 (EOS)
+
+	f, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-grainoverflow-*.vmdk")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	for _, b := range [][]byte{hdr, pad, marker, comp, make([]byte, grainPad), eos} {
+		if _, err := f.Write(b); err != nil {
+			f.Close()
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestConvertVMDKGrainSizeOverflowHandled(t *testing.T) {
+	inputPath := craftStreamOptimizedVMDKGrainOverflow(t)
+
+	outFile, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-out-*.raw")
+	if err != nil {
+		t.Fatalf("CreateTemp output: %v", err)
+	}
+	outFile.Close()
+
+	t.Logf("GrainSize = 2^62 => int64(grainSec)*SectorSize overflows to 0 without the cap")
+
+	// Without the MaxGrainSec cap, grainBytes wraps to 0 and the grain-alignment
+	// arithmetic panics with an integer divide-by-zero. The cap forces a fallback
+	// to DefaultGrainSec, so the conversion completes without panicking.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("convertVMDKToRaw panicked on oversized GrainSize: %v", r)
+		}
+	}()
+
+	if err := convertVMDKToRaw(inputPath, outFile.Name()); err != nil {
+		t.Logf("convertVMDKToRaw err (non-fatal, must not panic): %v", err)
+	}
+}
+
 func TestConvertVMDKFooterSectorCountRejected(t *testing.T) {
 	inputPath := craftStreamOptimizedVMDKFooterBomb(t)
 

--- a/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
+++ b/extractor/filesystem/embeddedfs/vmdk/security_regression_test.go
@@ -19,6 +19,7 @@ import (
 	"compress/zlib"
 	"encoding/binary"
 	"os"
+	"runtime"
 	"testing"
 )
 
@@ -100,5 +101,155 @@ func TestConvertVMDKZlibBombRejected(t *testing.T) {
 	err = convertVMDKToRaw(tmp.Name(), outRaw.Name())
 	if err == nil {
 		t.Error("convertVMDKToRaw: want error for decompression bomb, got nil")
+	}
+}
+
+// craftStreamOptimizedVMDKMarkerBomb builds a minimal stream-optimized VMDK
+// whose first stream marker has size=0xffffffff.
+// readStreamMarker calls make([]byte, size) before io.ReadFull returns EOF.
+func craftStreamOptimizedVMDKMarkerBomb(t *testing.T) string {
+	t.Helper()
+
+	hdr := make([]byte, SectorSize) // 512 bytes, all-zero baseline
+	le := binary.LittleEndian
+
+	le.PutUint32(hdr[0:], SparseMagic) // MagicNumber
+	le.PutUint32(hdr[4:], 1)           // Version = 1
+	le.PutUint32(hdr[8:], 0x00030000)  // Flags = flagHasCompressed | flagHasMetadata
+	le.PutUint64(hdr[12:], 1)          // Capacity = 1 sector
+	le.PutUint64(hdr[20:], 128)        // GrainSize = 128 (default)
+	// DescriptorOffset/DescriptorSize/NumGTEsPerGT/RGDOffset = 0
+	le.PutUint64(hdr[56:], 1) // GDOffset = 1 (not GDAtEnd)
+	le.PutUint64(hdr[64:], 2) // OverHead = 2 → stream starts at byte 1024
+	hdr[72] = 0               // UncleanShutdown
+	hdr[73] = '\n'            // SingleEndLineChar
+	hdr[74] = ' '             // NonEndLineChar
+	hdr[75] = '\r'            // DoubleEndLineChar1
+	hdr[76] = '\n'            // DoubleEndLineChar2
+	le.PutUint16(hdr[77:], 1) // CompressAlgorithm = 1 (deflate)
+
+	// Pad to byte 1024 (sector 2 = OverHead * SectorSize)
+	pad := make([]byte, SectorSize) // one more sector of zeros
+
+	// Stream marker at byte 1024: val=0 (8 bytes) + size=0xffffffff (4 bytes)
+	marker := make([]byte, 12)
+	le.PutUint64(marker[0:], 0)          // val = LBA 0
+	le.PutUint32(marker[8:], 0xffffffff) // size = ~4 GB → make([]byte, 4294967295)
+
+	f, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-markerbomb-*.vmdk")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	for _, b := range [][]byte{hdr, pad, marker} {
+		if _, err := f.Write(b); err != nil {
+			f.Close()
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestConvertVMDKStreamMarkerSizeRejected(t *testing.T) {
+	inputPath := craftStreamOptimizedVMDKMarkerBomb(t)
+
+	outFile, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-out-*.raw")
+	if err != nil {
+		t.Fatalf("CreateTemp output: %v", err)
+	}
+	outFile.Close()
+
+	t.Logf("Malicious stream-optimized VMDK: 1036 bytes on disk")
+	t.Logf("Marker size = 0xffffffff => make([]byte, 4294967295) = ~4 GB attempted without fix")
+
+	var msBefore, msAfter runtime.MemStats
+	runtime.ReadMemStats(&msBefore)
+
+	convertErr := convertVMDKToRaw(inputPath, outFile.Name())
+
+	runtime.ReadMemStats(&msAfter)
+	allocMB := (msAfter.TotalAlloc - msBefore.TotalAlloc) >> 20
+
+	t.Logf("convertVMDKToRaw err: %v", convertErr)
+	t.Logf("TotalAlloc delta: %d MB", allocMB)
+
+	if convertErr == nil {
+		t.Errorf("expected error for malicious marker size=0xffffffff, got nil")
+	}
+	if allocMB > 50 {
+		t.Errorf("TotalAlloc delta %d MB exceeds 50 MB — marker size bounds check missing", allocMB)
+	}
+}
+
+// craftStreamOptimizedVMDKFooterBomb builds a stream-optimized VMDK with a
+// FOOTER metadata marker (size=0, typ=3) whose sector-count val is 0x100000
+// (~512 MB allocation via make([]byte, val*SectorSize)).
+func craftStreamOptimizedVMDKFooterBomb(t *testing.T) string {
+	t.Helper()
+
+	hdr := make([]byte, SectorSize)
+	le := binary.LittleEndian
+	le.PutUint32(hdr[0:], SparseMagic)
+	le.PutUint32(hdr[4:], 1)
+	le.PutUint32(hdr[8:], 0x00030000) // stream-optimized flags
+	le.PutUint64(hdr[12:], 1)
+	le.PutUint64(hdr[20:], 128)
+	le.PutUint64(hdr[56:], 1) // GDOffset != GDAtEnd
+	le.PutUint64(hdr[64:], 2) // OverHead = 2 → stream at byte 1024
+	hdr[73] = '\n'
+	hdr[74] = ' '
+	hdr[75] = '\r'
+	hdr[76] = '\n'
+	le.PutUint16(hdr[77:], 1)
+
+	pad := make([]byte, SectorSize)
+
+	// Metadata marker: size=0 (→ read typ), val=0x100000 sectors (~512 MB), typ=3 (FOOTER)
+	meta := make([]byte, 16)
+	le.PutUint64(meta[0:], 0x100000) // val = 1M sectors → 512 MB allocation
+	le.PutUint32(meta[8:], 0)        // size = 0 → metadata path
+	le.PutUint32(meta[12:], 3)       // typ = 3 (FOOTER) → make([]byte, val*SectorSize)
+
+	f, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-footerbomb-*.vmdk")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	for _, b := range [][]byte{hdr, pad, meta} {
+		if _, err := f.Write(b); err != nil {
+			f.Close()
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestConvertVMDKFooterSectorCountRejected(t *testing.T) {
+	inputPath := craftStreamOptimizedVMDKFooterBomb(t)
+
+	outFile, err := os.CreateTemp(t.TempDir(), "scalibr-vmdk-out-*.raw")
+	if err != nil {
+		t.Fatalf("CreateTemp output: %v", err)
+	}
+	outFile.Close()
+
+	t.Logf("Malicious FOOTER marker: val=0x100000 sectors => ~512 MB allocation without fix")
+
+	var msBefore, msAfter runtime.MemStats
+	runtime.ReadMemStats(&msBefore)
+
+	convertErr := convertVMDKToRaw(inputPath, outFile.Name())
+
+	runtime.ReadMemStats(&msAfter)
+	allocMB := (msAfter.TotalAlloc - msBefore.TotalAlloc) >> 20
+
+	t.Logf("convertVMDKToRaw err: %v", convertErr)
+	t.Logf("TotalAlloc delta: %d MB", allocMB)
+
+	if convertErr == nil {
+		t.Errorf("expected error for malicious footer val=0x100000, got nil")
+	}
+	if allocMB > 50 {
+		t.Errorf("TotalAlloc delta %d MB exceeds 50 MB — footer sector count bounds check missing", allocMB)
 	}
 }

--- a/extractor/filesystem/embeddedfs/vmdk/vmdk.go
+++ b/extractor/filesystem/embeddedfs/vmdk/vmdk.go
@@ -260,6 +260,13 @@ func readStreamMarker(f *os.File) (val uint64, size uint32, typ uint32, data []b
 		return val, size, typ, nil, nil
 	}
 	if size > 0 {
+		// Cap grain payload size to prevent OOM from attacker-controlled uint32.
+		// Grain data is always <= grainBytes (max ~2 MB for spec-compliant images);
+		// 64 MB is a generous safety ceiling.
+		const maxMarkerDataBytes = 64 << 20 // 64 MB
+		if size > maxMarkerDataBytes {
+			return 0, 0, 0, nil, fmt.Errorf("stream marker data size %d exceeds safety limit %d", size, maxMarkerDataBytes)
+		}
 		data = make([]byte, size)
 		if _, err = io.ReadFull(f, data); err != nil {
 			return val, size, 0, nil, err
@@ -356,6 +363,12 @@ func convertStreamOptimizedExtent(f *os.File, out *os.File, hdr sparseExtentHead
 			}
 		case 3: // FOOTER
 			if val > 0 {
+				// Cap footer metadata sectors: a footer header is exactly 512 bytes
+				// (1 sector). Any legitimate value is 1; cap at 4 to be safe.
+				const maxFooterSectors = 4
+				if val > maxFooterSectors {
+					return fmt.Errorf("footer marker sector count %d exceeds safety limit %d", val, maxFooterSectors)
+				}
 				meta := make([]byte, int64(val*SectorSize))
 				if _, err := io.ReadFull(f, meta); err != nil {
 					return fmt.Errorf("read footer meta: %w", err)

--- a/extractor/filesystem/embeddedfs/vmdk/vmdk.go
+++ b/extractor/filesystem/embeddedfs/vmdk/vmdk.go
@@ -46,6 +46,10 @@ const (
 	GDAtEnd = 0xFFFFFFFFFFFFFFFF
 	// DefaultGrainSec is default sectors if header invalid (64KiB).
 	DefaultGrainSec = 128
+	// MaxGrainSec is the maximum number of sectors per grain accepted by the
+	// stream parser. It matches the validateHeader bound and prevents int64
+	// overflow when multiplied by SectorSize.
+	MaxGrainSec = 128
 )
 
 // sparseExtentHeader defines the VMDK sparse extent header structure.
@@ -291,7 +295,10 @@ func convertStreamOptimizedExtent(f *os.File, out *os.File, hdr sparseExtentHead
 		}
 	}
 	grainSec := hdr.GrainSize
-	if grainSec == 0 || (grainSec&(grainSec-1)) != 0 {
+	// grainSec must be a non-zero power of two within the spec range. The upper
+	// bound also keeps int64(grainSec)*SectorSize from overflowing (an oversized
+	// power of two would otherwise wrap to 0 or a negative value below).
+	if grainSec == 0 || grainSec > MaxGrainSec || (grainSec&(grainSec-1)) != 0 {
 		grainSec = DefaultGrainSec
 	}
 	grainBytes := int64(grainSec) * SectorSize
@@ -329,12 +336,16 @@ func convertStreamOptimizedExtent(f *os.File, out *os.File, hdr sparseExtentHead
 				if derr != nil && !errors.Is(derr, io.EOF) {
 					return fmt.Errorf("zlib read at lba %d: %w", lba, derr)
 				}
-				if int64(len(dec)) < grainBytes {
-					tmp := make([]byte, grainBytes)
-					copy(tmp, dec)
-					dec = tmp
-				} else if int64(len(dec)) > grainBytes {
-					tmp := make([]byte, int64(len(dec))+(-int64(len(dec))%grainBytes))
+				// Align the decompressed grain up to a whole multiple of grainBytes
+				// so it writes on a grain boundary. A grain normally decompresses to
+				// exactly grainBytes; pad (never truncate) for shorter or longer
+				// outputs. Rounding up keeps every decompressed byte.
+				aligned := ((int64(len(dec)) + grainBytes - 1) / grainBytes) * grainBytes
+				if aligned < grainBytes {
+					aligned = grainBytes
+				}
+				if int64(len(dec)) != aligned {
+					tmp := make([]byte, aligned)
 					copy(tmp, dec)
 					dec = tmp
 				}
@@ -379,7 +390,7 @@ func convertStreamOptimizedExtent(f *os.File, out *os.File, hdr sparseExtentHead
 					if err := binary.Read(br, binary.LittleEndian, &foot); err == nil {
 						hdr = foot
 						grainSec = hdr.GrainSize
-						if grainSec == 0 || (grainSec&(grainSec-1)) != 0 {
+						if grainSec == 0 || grainSec > MaxGrainSec || (grainSec&(grainSec-1)) != 0 {
 							grainSec = DefaultGrainSec
 						}
 						grainBytes = int64(grainSec) * SectorSize

--- a/extractor/filesystem/embeddedfs/vmdk/vmdk.go
+++ b/extractor/filesystem/embeddedfs/vmdk/vmdk.go
@@ -46,6 +46,10 @@ const (
 	GDAtEnd = 0xFFFFFFFFFFFFFFFF
 	// DefaultGrainSec is default sectors if header invalid (64KiB).
 	DefaultGrainSec = 128
+	// MaxGrainSec is the maximum number of sectors per grain accepted by the
+	// stream parser. It matches the validateHeader bound and prevents int64
+	// overflow when multiplied by SectorSize.
+	MaxGrainSec = 128
 )
 
 // sparseExtentHeader defines the VMDK sparse extent header structure.
@@ -291,7 +295,10 @@ func convertStreamOptimizedExtent(f *os.File, out *os.File, hdr sparseExtentHead
 		}
 	}
 	grainSec := hdr.GrainSize
-	if grainSec == 0 || (grainSec&(grainSec-1)) != 0 {
+	// grainSec must be a non-zero power of two within the spec range. The upper
+	// bound also keeps int64(grainSec)*SectorSize from overflowing (an oversized
+	// power of two would otherwise wrap to 0 or a negative value below).
+	if grainSec == 0 || grainSec > MaxGrainSec || (grainSec&(grainSec-1)) != 0 {
 		grainSec = DefaultGrainSec
 	}
 	grainBytes := int64(grainSec) * SectorSize
@@ -379,7 +386,7 @@ func convertStreamOptimizedExtent(f *os.File, out *os.File, hdr sparseExtentHead
 					if err := binary.Read(br, binary.LittleEndian, &foot); err == nil {
 						hdr = foot
 						grainSec = hdr.GrainSize
-						if grainSec == 0 || (grainSec&(grainSec-1)) != 0 {
+						if grainSec == 0 || grainSec > MaxGrainSec || (grainSec&(grainSec-1)) != 0 {
 							grainSec = DefaultGrainSec
 						}
 						grainBytes = int64(grainSec) * SectorSize


### PR DESCRIPTION
## Summary

Two unchecked allocations in the stream-optimized VMDK parser allow a crafted
file to exhaust process memory.

### Bug 1:  — unchecked  uint32

 allocates `make([]byte, size)` where `size` is a
`uint32` field read directly from the untrusted marker header.

**Craft:** 1036-byte VMDK with stream marker `size = 0xffffffff`.  
**Effect:** 4 GB heap allocation. The function returns **nil** (silent OOM)
because the subsequent `io.ReadFull` returns `io.EOF` which the caller
treats as end-of-stream.

Confirmed live:
```
TotalAlloc delta: 4096 MB   (1036-byte input, nil error returned)
```

### Bug 2: FOOTER marker — unchecked `val * SectorSize` allocation

The `case 3 (FOOTER)` handler allocates
`make([]byte, int64(val*SectorSize))` where `val` is a `uint64`
sector count from the marker header — no bounds check.

**Craft:** set `val = 0x100000` (1M sectors × 512 = 512 MB).  
Confirmed live: TotalAlloc delta ~512 MB.

## Fix

1. Add `const maxMarkerDataBytes = 64 << 20` (64 MB) guard in
   `readStreamMarker` before `make([]byte, size)`.
2. Add `const maxFooterSectors = 4` guard in the FOOTER switch case
   before `make([]byte, val*SectorSize)`. Footer headers are always
   512 bytes (1 sector); 4 sectors is generous.

## Tests

- `TestConvertVMDKStreamMarkerSizeRejected`: 1036-byte bomb, expects
  error + TotalAlloc delta < 50 MB.
- `TestConvertVMDKFooterSectorCountRejected`: 1040-byte FOOTER bomb,
  expects error + TotalAlloc delta < 50 MB.

All existing VMDK tests continue to pass.