### PR TITLE
datasource: stop applying settings.xml auth to added Maven registries

### DIFF
--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -75,6 +75,11 @@ type MavenRegistry struct {
 	ID               string
 	ReleasesEnabled  bool
 	SnapshotsEnabled bool
+
+	// settings.xml credentials are keyed by server ID only. Repositories
+	// discovered from pom.xml are untrusted input, so they must not inherit
+	// those credentials unless a caller explicitly opts in.
+	AllowSettingsAuth bool
 }
 
 // NewMavenRegistryAPIClient returns a new MavenRegistryAPIClient.
@@ -87,6 +92,7 @@ func NewMavenRegistryAPIClient(ctx context.Context, registry MavenRegistry, loca
 		// Gives the default registry an ID so it is not overwritten by registry without an ID in pom.xml.
 		registry.ID = "default"
 	}
+	registry.AllowSettingsAuth = true
 	u, err := url.Parse(registry.URL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Maven registry %s: %w", registry.URL, err)
@@ -168,6 +174,7 @@ func (m *MavenRegistryAPIClient) updateDefaultRegistry(ctx context.Context, regi
 		return err
 	}
 	log.Infof("The default Maven registry is being overwritten from %s to %s", m.defaultRegistry.URL, registry.URL)
+	registry.AllowSettingsAuth = true
 	registry.Parsed = u
 	m.defaultRegistry = registry
 	if registry.Parsed.Scheme == artifactRegistryScheme {
@@ -278,7 +285,7 @@ func (m *MavenRegistryAPIClient) getProject(ctx context.Context, registry MavenR
 	}
 
 	var project maven.Project
-	if err := m.get(ctx, m.registryAuths[registry.ID], registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, version, fmt.Sprintf("%s-%s.pom", artifactID, snapshot)}, &project); err != nil {
+	if err := m.get(ctx, m.registryAuth(registry), registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, version, fmt.Sprintf("%s-%s.pom", artifactID, snapshot)}, &project); err != nil {
 		return maven.Project{}, err
 	}
 
@@ -288,7 +295,7 @@ func (m *MavenRegistryAPIClient) getProject(ctx context.Context, registry MavenR
 // getVersionMetadata fetches a version level maven-metadata.xml and parses it to maven.Metadata.
 func (m *MavenRegistryAPIClient) getVersionMetadata(ctx context.Context, registry MavenRegistry, groupID, artifactID, version string) (maven.Metadata, error) {
 	var metadata maven.Metadata
-	if err := m.get(ctx, m.registryAuths[registry.ID], registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, version, "maven-metadata.xml"}, &metadata); err != nil {
+	if err := m.get(ctx, m.registryAuth(registry), registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, version, "maven-metadata.xml"}, &metadata); err != nil {
 		return maven.Metadata{}, err
 	}
 
@@ -298,11 +305,19 @@ func (m *MavenRegistryAPIClient) getVersionMetadata(ctx context.Context, registr
 // GetArtifactMetadata fetches an artifact level maven-metadata.xml and parses it to maven.Metadata.
 func (m *MavenRegistryAPIClient) getArtifactMetadata(ctx context.Context, registry MavenRegistry, groupID, artifactID string) (maven.Metadata, error) {
 	var metadata maven.Metadata
-	if err := m.get(ctx, m.registryAuths[registry.ID], registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, "maven-metadata.xml"}, &metadata); err != nil {
+	if err := m.get(ctx, m.registryAuth(registry), registry, []string{strings.ReplaceAll(groupID, ".", "/"), artifactID, "maven-metadata.xml"}, &metadata); err != nil {
 		return maven.Metadata{}, err
 	}
 
 	return metadata, nil
+}
+
+func (m *MavenRegistryAPIClient) registryAuth(registry MavenRegistry) *HTTPAuthentication {
+	if !registry.AllowSettingsAuth {
+		return nil
+	}
+
+	return m.registryAuths[registry.ID]
 }
 
 func (m *MavenRegistryAPIClient) get(ctx context.Context, auth *HTTPAuthentication, registry MavenRegistry, paths []string, dst any) error {

--- a/clients/datasource/maven_registry_auth_test.go
+++ b/clients/datasource/maven_registry_auth_test.go
@@ -17,6 +17,9 @@ package datasource
 import (
 	"encoding/base64"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/google/osv-scalibr/clients/clienttest"
@@ -95,5 +98,114 @@ func TestWithoutRegistriesMaintainsAuthData(t *testing.T) {
 
 	if len(GetVersions) != 1 {
 		t.Errorf("WithoutRegistries() returned client with %d versions, want 1", len(GetVersions))
+	}
+}
+
+func TestDefaultRegistryUsesSettingsAuth(t *testing.T) {
+	var authHeaders []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", "Basic realm=\"Registry\"")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		_, _ = w.Write([]byte(`
+	<project>
+	  <groupId>org.example</groupId>
+	  <artifactId>x.y.z</artifactId>
+	  <version>1.0.0</version>
+	</project>
+	`))
+	}))
+	defer srv.Close()
+
+	client, err := NewMavenRegistryAPIClient(t.Context(), MavenRegistry{
+		URL:             srv.URL,
+		ID:              "trusted",
+		ReleasesEnabled: true,
+	}, "", true)
+	if err != nil {
+		t.Fatalf("NewMavenRegistryAPIClient() error = %v", err)
+	}
+	client.registryAuths = map[string]*HTTPAuthentication{
+		"trusted": {
+			SupportedMethods: []HTTPAuthMethod{AuthBasic},
+			Username:         "demo-user",
+			Password:         "demo-pass",
+		},
+	}
+
+	if _, err := client.GetProject(t.Context(), "org.example", "x.y.z", "1.0.0"); err != nil {
+		t.Fatalf("GetProject() error = %v", err)
+	}
+
+	want := []string{"", "Basic ZGVtby11c2VyOmRlbW8tcGFzcw=="}
+	if !reflect.DeepEqual(authHeaders, want) {
+		t.Fatalf("authorization headers got = %v, want %v", authHeaders, want)
+	}
+}
+
+func TestAddedRegistryDoesNotUseSettingsAuth(t *testing.T) {
+	var attackerAuthHeaders []string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerAuthHeaders = append(attackerAuthHeaders, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", "Basic realm=\"Attacker\"")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		_, _ = w.Write([]byte(`
+	<project>
+	  <groupId>org.example</groupId>
+	  <artifactId>x.y.z</artifactId>
+	  <version>1.0.0</version>
+	</project>
+	`))
+	}))
+	defer attacker.Close()
+
+	trusted := clienttest.NewMockHTTPServer(t)
+	trusted.SetResponse(t, "org/example/x.y.z/1.0.0/x.y.z-1.0.0.pom", []byte(`
+	<project>
+	  <groupId>org.example</groupId>
+	  <artifactId>x.y.z</artifactId>
+	  <version>1.0.0</version>
+	</project>
+	`))
+
+	client, err := NewMavenRegistryAPIClient(t.Context(), MavenRegistry{
+		URL:             trusted.URL,
+		ID:              "trusted",
+		ReleasesEnabled: true,
+	}, "", true)
+	if err != nil {
+		t.Fatalf("NewMavenRegistryAPIClient() error = %v", err)
+	}
+	client.registryAuths = map[string]*HTTPAuthentication{
+		"attacker": {
+			SupportedMethods: []HTTPAuthMethod{AuthBasic},
+			Username:         "demo-user",
+			Password:         "demo-pass",
+		},
+	}
+
+	if err := client.AddRegistry(t.Context(), MavenRegistry{
+		URL:             attacker.URL,
+		ID:              "attacker",
+		ReleasesEnabled: true,
+	}); err != nil {
+		t.Fatalf("AddRegistry() error = %v", err)
+	}
+
+	if _, err := client.GetProject(t.Context(), "org.example", "x.y.z", "1.0.0"); err != nil {
+		t.Fatalf("GetProject() error = %v", err)
+	}
+
+	want := []string{""}
+	if !reflect.DeepEqual(attackerAuthHeaders, want) {
+		t.Fatalf("attacker authorization headers got = %v, want %v", attackerAuthHeaders, want)
 	}
 }


### PR DESCRIPTION
## Summary
- keep `settings.xml` authentication for the default or user-selected Maven registry
- stop applying those credentials to additional registries discovered from scanned `pom.xml` content
- add regression coverage for both the trusted default-registry path and the untrusted added-registry path

## Why
`settings.xml` credentials are keyed only by Maven server ID. When a scanned `pom.xml` adds a registry with an attacker-controlled `id` and `url`, the current client can pair that ID with local credentials and forward them after a `401` challenge.

Additional registries discovered from scanned project content are untrusted input, so they should not inherit `settings.xml` authentication by default.

Refs google/osv-scanner#2672

## Testing
- `go test ./clients/datasource -run 'Test(DefaultRegistryUsesSettingsAuth|TestAddedRegistryDoesNotUseSettingsAuth)'`
- `go test ./clients/resolution/... ./common/... ./guidedremediation/...`
