### PR TITLE
Constrain Python requirements recursive includes to the scan root

### DIFF
--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -19,6 +19,7 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -149,13 +150,13 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	pkgs = append(pkgs, newRepos...)
 
 	// Process all the recursive files that we found.
-	extraPKG := extractFromExtraPaths(input.Path, extraPaths, input.FS)
+	extraPKG := extractFromExtraPaths(input.Path, extraPaths, input.FS, input.Root)
 	pkgs = append(pkgs, extraPKG...)
 
 	return inventory.Inventory{Packages: pkgs}, nil
 }
 
-func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.FS) []*extractor.Package {
+func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.FS, root string) []*extractor.Package {
 	// File paths with packages already found in this extraction.
 	// We store these to remove duplicates in diamond dependency cases and prevent
 	// infinite loops in misconfigured lockfiles with cyclical deps.
@@ -166,6 +167,11 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 		inc := extraPaths[0]
 		extraPaths = extraPaths[1:]
 		if _, exists := found[inc.path]; exists {
+			continue
+		}
+		if !pathWithinScanRoot(root, inc.path) {
+			log.Warnf("skipping recursive requirements include outside scan root: %s", inc.path)
+			found[inc.path] = true
 			continue
 		}
 		newPKG, newPaths, err := openAndExtractFromFile(inc.path, fs)
@@ -186,6 +192,36 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 	}
 
 	return pkgs
+}
+
+func pathWithinScanRoot(root, path string) bool {
+	if root == "" {
+		// Virtual filesystems do not expose a real host path that can be
+		// symlink-resolved. Keep existing behavior for virtual scan roots.
+		return true
+	}
+
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	rootReal, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return false
+	}
+
+	target := filepath.Join(rootAbs, filepath.FromSlash(path))
+	targetReal, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return false
+	}
+
+	rel, err := filepath.Rel(rootReal, targetReal)
+	if err != nil {
+		return false
+	}
+
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel)
 }
 
 func openAndExtractFromFile(path string, fs scalibrfs.FS) ([]*extractor.Package, pathQueue, error) {

--- a/extractor/filesystem/language/python/requirements/requirements_test.go
+++ b/extractor/filesystem/language/python/requirements/requirements_test.go
@@ -16,6 +16,7 @@ package requirements_test
 
 import (
 	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -635,4 +636,124 @@ func TestExtract(t *testing.T) {
 // where only the Descriptor is set (no Related files).
 func loc(path string, line int) extractor.PackageLocation {
 	return extractor.PackageLocation{Descriptor: &location.Location{File: &location.File{Path: path, LineNumber: line}}}
+}
+
+func TestExtract_RecursiveIncludeSymlinkEscapeRejected(t *testing.T) {
+	base := t.TempDir()
+	scanRoot := filepath.Join(base, "service-a")
+	outsideRoot := filepath.Join(base, "service-b")
+
+	if err := os.MkdirAll(scanRoot, 0755); err != nil {
+		t.Fatalf("os.MkdirAll(%q): %v", scanRoot, err)
+	}
+	if err := os.MkdirAll(outsideRoot, 0755); err != nil {
+		t.Fatalf("os.MkdirAll(%q): %v", outsideRoot, err)
+	}
+
+	requirementsPath := filepath.Join(scanRoot, "requirements.txt")
+	if err := os.WriteFile(requirementsPath, []byte("-r deps/requirements.txt\n"), 0644); err != nil {
+		t.Fatalf("os.WriteFile(%q): %v", requirementsPath, err)
+	}
+
+	if err := os.Symlink("../service-b", filepath.Join(scanRoot, "deps")); err != nil {
+		t.Skipf("os.Symlink(): %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(outsideRoot, "requirements.txt"), []byte("django==1.2\n"), 0644); err != nil {
+		t.Fatalf("os.WriteFile(outside requirements): %v", err)
+	}
+
+	r, err := os.Open(requirementsPath)
+	if err != nil {
+		t.Fatalf("os.Open(%q): %v", requirementsPath, err)
+	}
+	defer r.Close()
+
+	info, err := r.Stat()
+	if err != nil {
+		t.Fatalf("Stat(): %v", err)
+	}
+
+	e, err := requirements.New(&cpb.PluginConfig{})
+	if err != nil {
+		t.Fatalf("requirements.New(): %v", err)
+	}
+
+	input := &filesystem.ScanInput{
+		FS:     scalibrfs.DirFS(scanRoot),
+		Path:   "requirements.txt",
+		Root:   scanRoot,
+		Info:   info,
+		Reader: r,
+	}
+
+	got, err := e.Extract(t.Context(), input)
+	if err != nil {
+		t.Fatalf("Extract(): %v", err)
+	}
+
+	if containsPackageName(got.Packages, "django") {
+		t.Fatalf("Extract() included outside-root package django from %q: %+v", outsideRoot, got.Packages)
+	}
+}
+
+func TestExtract_RecursiveIncludeInRootStillWorks(t *testing.T) {
+	base := t.TempDir()
+	scanRoot := filepath.Join(base, "service-a")
+	depsDir := filepath.Join(scanRoot, "deps")
+
+	if err := os.MkdirAll(depsDir, 0755); err != nil {
+		t.Fatalf("os.MkdirAll(%q): %v", depsDir, err)
+	}
+
+	requirementsPath := filepath.Join(scanRoot, "requirements.txt")
+	if err := os.WriteFile(requirementsPath, []byte("-r deps/requirements.txt\n"), 0644); err != nil {
+		t.Fatalf("os.WriteFile(%q): %v", requirementsPath, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(depsDir, "requirements.txt"), []byte("six==1.16.0\n"), 0644); err != nil {
+		t.Fatalf("os.WriteFile(in-root requirements): %v", err)
+	}
+
+	r, err := os.Open(requirementsPath)
+	if err != nil {
+		t.Fatalf("os.Open(%q): %v", requirementsPath, err)
+	}
+	defer r.Close()
+
+	info, err := r.Stat()
+	if err != nil {
+		t.Fatalf("Stat(): %v", err)
+	}
+
+	e, err := requirements.New(&cpb.PluginConfig{})
+	if err != nil {
+		t.Fatalf("requirements.New(): %v", err)
+	}
+
+	input := &filesystem.ScanInput{
+		FS:     scalibrfs.DirFS(scanRoot),
+		Path:   "requirements.txt",
+		Root:   scanRoot,
+		Info:   info,
+		Reader: r,
+	}
+
+	got, err := e.Extract(t.Context(), input)
+	if err != nil {
+		t.Fatalf("Extract(): %v", err)
+	}
+
+	if !containsPackageName(got.Packages, "six") {
+		t.Fatalf("Extract() did not include in-root package six: %+v", got.Packages)
+	}
+}
+
+func containsPackageName(pkgs []*extractor.Package, name string) bool {
+	for _, p := range pkgs {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This change prevents Python requirements recursive includes (`-r` / `--requirement`) from resolving outside the configured scan root through repository symlinks.

Previously, a requirements file inside the scan root could include `-r deps/requirements.txt`, where `deps` is a repository symlink resolving outside the scan root. The extractor would follow the include and attribute dependency metadata from the outside-root file to the scanned project.

This change validates recursive include targets against the scan root after symlink resolution. Include targets that resolve outside the scan root are skipped. In-root recursive includes continue to work.

Regression tests cover:

- recursive include through a symlink that resolves outside the scan root
- normal in-root recursive include behavior

Tested with:

```bash
go test ./extractor/filesystem/language/python/requirements -count=1 -v