### PR TITLE
feat(extractor): register os/chisel to default

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -38,6 +38,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Chrome extensions |                                | `chrome/extensions`                          |
 | COS               | cos-package-info.json          | `os/cos`                                     |
 | DPKG              | e.g. Debian, Ubuntu            | `os/dpkg`                                    |
+| Chisel            |                                | `os/chisel`                                  |
 | Nix               |                                | `os/nix`                                     |
 | OPKG              | e.g. OpenWrt                   | `os/dpkg`                                    |
 | RPM               | e.g. RHEL, CentOS, Rocky Linux | `os/rpm`                                     |

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -87,6 +87,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/vscodeextensions"
 	wordpressplugins "github.com/google/osv-scalibr/extractor/filesystem/misc/wordpress/plugins"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/apk"
+	"github.com/google/osv-scalibr/extractor/filesystem/os/chisel"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/chocolatey"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/cos"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/dpkg"
@@ -337,6 +338,7 @@ var (
 		macports.Name:   {macports.New},
 		winget.Name:     {winget.New},
 		chocolatey.Name: {chocolatey.New},
+		chisel.Name:     {chisel.New},
 	}
 
 	// SecretExtractors for Extractor interface.


### PR DESCRIPTION
## Description

This PR adds the `os/chisel` extractor to the default extractor list following the instruction steps 10 and 11 in [new_extractor.md](https://github.com/google/osv-scalibr/blob/main/docs/new_extractor.md) doc.

## Notes for reviewer:

I've put Chisel as a new inventory type instead of appending it to the extractor of `DPKG`, since the ultimate goal for the `os/chisel` extractor is to be able to provide a finer-grained inventory info, not only for the packages, but also for the slices and corresponding files, which will eventually diverge from `os/dpkg` extractor.