### PR TITLE
Annotator: filter embedded FS packages for plugins with the RunningSystem capability

### DIFF
--- a/annotator/annotator.go
+++ b/annotator/annotator.go
@@ -74,7 +74,7 @@ func Run(ctx context.Context, config *Config, inventory *inventory.Inventory) ([
 	//
 	// Therefore, packages originating from embedded filesystems are filtered out and
 	// not supplied to plugins that require a running system.
-	filteredInventory := filterOutEmbeddedPackages(inventory)
+	filteredInventory := FilterOutEmbeddedPackages(inventory)
 
 	for _, a := range config.Annotators {
 		var err error
@@ -90,7 +90,8 @@ func Run(ctx context.Context, config *Config, inventory *inventory.Inventory) ([
 	return statuses, nil
 }
 
-func filterOutEmbeddedPackages(inv *inventory.Inventory) *inventory.Inventory {
+// FilterOutEmbeddedPackages removes packages from the supplied inventory that belong to embedded filesystems.
+func FilterOutEmbeddedPackages(inv *inventory.Inventory) *inventory.Inventory {
 	if inv == nil {
 		return &inventory.Inventory{}
 	}

--- a/annotator/annotator.go
+++ b/annotator/annotator.go
@@ -17,7 +17,10 @@ package annotator
 
 import (
 	"context"
+	"os"
+	"strings"
 
+	"github.com/google/osv-scalibr/extractor"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
@@ -57,9 +60,67 @@ func Run(ctx context.Context, config *Config, inventory *inventory.Inventory) ([
 		ScanRoot: config.ScanRoot,
 	}
 
+	// This is required to prevent passing packages from embedded filesystems to
+	// plugins that issue commands on packages.
+	//
+	// Some annotator plugins require the system to be in a running state to perform
+	// tasks such as executing commands or running binaries on the target filesystem.
+	// Embedded filesystems, however, are not mounted as live systems; they are
+	// extracted to the local filesystem for analysis by Scalibr.
+	//
+	// This is particularly important when the embedded filesystem contains binaries
+	// for an architecture different from the one Scalibr is currently running on,
+	// since emulation is not currently supported.
+	//
+	// Therefore, packages originating from embedded filesystems are filtered out and
+	// not supplied to plugins that require a running system.
+	filteredInventory := filterOutEmbeddedPackages(inventory)
+
 	for _, a := range config.Annotators {
-		err := a.Annotate(ctx, input, inventory)
+		var err error
+
+		if !a.Requirements().RunningSystem {
+			err = a.Annotate(ctx, input, inventory)
+		} else {
+			err = a.Annotate(ctx, input, filteredInventory)
+		}
+
 		statuses = append(statuses, plugin.StatusFromErr(a, false, err, nil))
 	}
 	return statuses, nil
+}
+
+func filterOutEmbeddedPackages(inv *inventory.Inventory) *inventory.Inventory {
+	if inv == nil {
+		return &inventory.Inventory{}
+	}
+	filtered := *inv // shallow copy
+
+	var pkgs []*extractor.Package
+	for _, p := range inv.Packages {
+		if !isPackageFromEmbeddedFS(p) {
+			pkgs = append(pkgs, p)
+		}
+	}
+
+	filtered.Packages = pkgs
+	return &filtered
+}
+
+// isPackageFromEmbeddedFS returns true if the package originates from an embedded filesystem.
+func isPackageFromEmbeddedFS(pkg *extractor.Package) bool {
+	location := pkg.Location.PathOrEmpty()
+	if location == "" {
+		return false
+	}
+
+	parts := strings.Split(location, ":")
+
+	// Windows: skip drive letter (e.g., "C:\")
+	if os.PathSeparator == '\\' {
+		return len(parts) >= 3
+	}
+
+	// Linux/macOS: embedded FS typically has at least one ":" separator
+	return len(parts) >= 2
 }

--- a/annotator/annotator.go
+++ b/annotator/annotator.go
@@ -79,7 +79,8 @@ func Run(ctx context.Context, config *Config, inventory *inventory.Inventory) ([
 	for _, a := range config.Annotators {
 		var err error
 
-		if !a.Requirements().RunningSystem {
+		capabilities := a.Requirements()
+		if capabilities == nil || !capabilities.RunningSystem {
 			err = a.Annotate(ctx, input, inventory)
 		} else {
 			err = a.Annotate(ctx, input, filteredInventory)

--- a/annotator/annotator_test.go
+++ b/annotator/annotator_test.go
@@ -146,14 +146,19 @@ func TestRun(t *testing.T) {
 			inv: &inventory.Inventory{
 				Packages: []*extractor.Package{
 					{
-						Name:     "host-pkg",
+						Name:     "host-package",
 						Version:  "1.0",
-						Location: extractor.LocationFromPath("/bin/binwalk"),
+						Location: extractor.LocationFromPath("file.txt"),
 					},
 					{
-						Name:     "embedded-pkg",
+						Name:     "embedded-package-unix",
 						Version:  "2.0",
 						Location: extractor.LocationFromPath("file.vmdk:1:file.txt"),
+					},
+					{
+						Name:     "embedded-package-windows",
+						Version:  "3.0",
+						Location: extractor.LocationFromPath("C:\\file.vmdk:1:file.txt"),
 					},
 				},
 			},
@@ -167,14 +172,19 @@ func TestRun(t *testing.T) {
 			wantInv: &inventory.Inventory{
 				Packages: []*extractor.Package{
 					{
-						Name:     "host-pkg",
+						Name:     "host-package",
 						Version:  "1.0",
-						Location: extractor.LocationFromPath("/bin/binwalk"),
+						Location: extractor.LocationFromPath("file.txt"),
 					},
 					{
-						Name:     "embedded-pkg",
+						Name:     "embedded-package-unix",
 						Version:  "2.0",
 						Location: extractor.LocationFromPath("file.vmdk:1:file.txt"),
+					},
+					{
+						Name:     "embedded-package-windows",
+						Version:  "3.0",
+						Location: extractor.LocationFromPath("C:\\file.vmdk:1:file.txt"),
 					},
 				},
 			},
@@ -204,7 +214,7 @@ func TestRun(t *testing.T) {
 			}
 			// Verify filtering behavior
 			if tc.rec != nil {
-				if len(tc.rec.seenPackages) != 1 || tc.rec.seenPackages[0].Name != "host-pkg" {
+				if len(tc.rec.seenPackages) != 1 || tc.rec.seenPackages[0].Name != "host-package" {
 					t.Errorf("expected only host package, got %+v", tc.rec.seenPackages)
 				}
 			}

--- a/annotator/annotator_test.go
+++ b/annotator/annotator_test.go
@@ -51,6 +51,20 @@ func (failingAnnotator) Annotate(ctx context.Context, input *annotator.ScanInput
 	return errors.New("some error")
 }
 
+type recordingAnnotator struct {
+	seenPackages []*extractor.Package
+}
+
+func (r *recordingAnnotator) Name() string { return "recording-annotator" }
+func (r *recordingAnnotator) Version() int { return 1 }
+func (r *recordingAnnotator) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{RunningSystem: true}
+}
+func (r *recordingAnnotator) Annotate(ctx context.Context, input *annotator.ScanInput, inv *inventory.Inventory) error {
+	r.seenPackages = inv.Packages
+	return nil
+}
+
 func TestRun(t *testing.T) {
 	inv := &inventory.Inventory{
 		Packages: []*extractor.Package{
@@ -75,6 +89,7 @@ func TestRun(t *testing.T) {
 		want    []*plugin.Status
 		wantErr error
 		wantInv *inventory.Inventory // Inventory after annotation.
+		rec     *recordingAnnotator
 	}{
 		{
 			desc: "no_annotators",
@@ -124,12 +139,59 @@ func TestRun(t *testing.T) {
 				{Name: "failing-annotator", Version: 2, Status: &plugin.ScanStatus{Status: plugin.ScanStatusFailed, FailureReason: "some error"}},
 			},
 		},
+		{
+			desc: "filters_embedded_fs_packages_for_running_system_annotator",
+			rec:  &recordingAnnotator{},
+			cfg:  nil,
+			inv: &inventory.Inventory{
+				Packages: []*extractor.Package{
+					{
+						Name:     "host-pkg",
+						Version:  "1.0",
+						Location: extractor.LocationFromPath("/bin/binwalk"),
+					},
+					{
+						Name:     "embedded-pkg",
+						Version:  "2.0",
+						Location: extractor.LocationFromPath("file.vmdk:1:file.txt"),
+					},
+				},
+			},
+			want: []*plugin.Status{
+				{
+					Name:    "recording-annotator",
+					Version: 1,
+					Status:  &plugin.ScanStatus{Status: plugin.ScanStatusSucceeded},
+				},
+			},
+			wantInv: &inventory.Inventory{
+				Packages: []*extractor.Package{
+					{
+						Name:     "host-pkg",
+						Version:  "1.0",
+						Location: extractor.LocationFromPath("/bin/binwalk"),
+					},
+					{
+						Name:     "embedded-pkg",
+						Version:  "2.0",
+						Location: extractor.LocationFromPath("file.vmdk:1:file.txt"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Deep copy the inventory to avoid modifying the original inventory that is used in other tests.
 			inv := copier.Copy(tc.inv).(*inventory.Inventory)
+
+			if tc.rec != nil && tc.cfg == nil {
+				tc.cfg = &annotator.Config{
+					Annotators: []annotator.Annotator{tc.rec},
+				}
+			}
+
 			got, err := annotator.Run(t.Context(), tc.cfg, inv)
 			if !cmp.Equal(err, tc.wantErr, cmpopts.EquateErrors()) {
 				t.Errorf("Run(%+v) error: got %v, want %v\n", tc.cfg, err, tc.wantErr)
@@ -139,6 +201,12 @@ func TestRun(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantInv, inv); diff != "" {
 				t.Errorf("Run(%+v) returned an unexpected diff of mutated inventory (-want +got): %v", tc.cfg, diff)
+			}
+			// Verify filtering behavior
+			if tc.rec != nil {
+				if len(tc.rec.seenPackages) != 1 || tc.rec.seenPackages[0].Name != "host-pkg" {
+					t.Errorf("expected only host package, got %+v", tc.rec.seenPackages)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Annotators that require a running system may execute commands or binaries on the target filesystem. However, packages originating from embedded filesystems are extracted artifacts and do not represent a live system. This can lead to incorrect behavior, especially when binaries belong to a different architecture and emulation is not supported.

To address this, filter out packages originating from embedded filesystems before passing the inventory to annotators with RunningSystem requirements. Annotators that do not require a running system continue to receive the full inventory.

Related: #2008