### PR TITLE
Use os.Root for real filesystem scan roots

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -68,8 +68,48 @@ func (r *ScanRoot) WithAbsolutePath() (*ScanRoot, error) {
 }
 
 // DirFS returns an FS implementation that accesses the real filesystem at the given root.
+//
+// The returned filesystem is rooted at root and prevents path traversal outside
+// that root, including through symlinks that resolve outside the root.
 func DirFS(root string) FS {
-	return os.DirFS(root).(FS)
+	if root == "" {
+		return os.DirFS(root).(FS)
+	}
+	return rootedFS{root: root}
+}
+
+type rootedFS struct {
+	root string
+}
+
+func (fsys rootedFS) Open(name string) (fs.File, error) {
+	root, err := os.OpenRoot(fsys.root)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
+	return root.Open(filepath.FromSlash(name))
+}
+
+func (fsys rootedFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	root, err := os.OpenRoot(fsys.root)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
+	return fs.ReadDir(root.FS(), filepath.ToSlash(name))
+}
+
+func (fsys rootedFS) Stat(name string) (fs.FileInfo, error) {
+	root, err := os.OpenRoot(fsys.root)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
+	return root.Stat(filepath.FromSlash(name))
 }
 
 // RealFSScanRoots returns a one-element ScanRoot array representing the given

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDirFSRejectsSymlinkEscape(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	outside := filepath.Join(base, "outside")
+
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatalf("os.MkdirAll(%q): %v", root, err)
+	}
+	if err := os.MkdirAll(outside, 0755); err != nil {
+		t.Fatalf("os.MkdirAll(%q): %v", outside, err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("outside"), 0644); err != nil {
+		t.Fatalf("os.WriteFile(outside): %v", err)
+	}
+	if err := os.Symlink("../outside", filepath.Join(root, "link")); err != nil {
+		t.Skipf("os.Symlink(): %v", err)
+	}
+
+	fsys := DirFS(root)
+
+	f, err := fsys.Open("link/secret.txt")
+	if err == nil {
+		_ = f.Close()
+		t.Fatalf("DirFS(%q).Open(%q) succeeded through a symlink outside the root", root, "link/secret.txt")
+	}
+}
+
+func TestDirFSAllowsInRootSymlink(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	target := filepath.Join(root, "target")
+
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatalf("os.MkdirAll(%q): %v", target, err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "file.txt"), []byte("inside"), 0644); err != nil {
+		t.Fatalf("os.WriteFile(target): %v", err)
+	}
+	if err := os.Symlink("target", filepath.Join(root, "link")); err != nil {
+		t.Skipf("os.Symlink(): %v", err)
+	}
+
+	fsys := DirFS(root)
+
+	f, err := fsys.Open("link/file.txt")
+	if err != nil {
+		t.Fatalf("DirFS(%q).Open(%q): %v", root, "link/file.txt", err)
+	}
+	defer f.Close()
+}


### PR DESCRIPTION
This change backs real filesystem scan roots with `os.Root` instead of using `os.DirFS` directly.

`os.Root` provides root-contained filesystem access and prevents opened paths from escaping the configured root, including through symlinks that resolve outside that root.

This makes scan-root containment enforcement part of the filesystem abstraction instead of requiring each extractor that opens additional files to implement its own symlink containment checks.

Tests cover:

- symlinks that resolve outside the scan root are rejected
- symlinks that resolve inside the scan root continue to work

Tested with:

```bash
go test ./fs -count=1 -v
go test ./extractor/filesystem/language/python/requirements -count=1 -v

```