### PR TITLE
Fix Arbitrary File Overwrite via Path Traversal in Embedded Filesystem Extraction

### DIFF
--- a/extractor/filesystem/embeddedfs/common/common.go
+++ b/extractor/filesystem/embeddedfs/common/common.go
@@ -93,12 +93,12 @@ func normalizePath(p string) string {
 	return p
 }
 
-// filterEntriesFat32 removes ".", "..", and "lost+found" from FAT32 entries.
+// filterEntriesFat32 removes ".", "..", "lost+found", and "/"-containing entries from FAT32 entries.
 func filterEntriesFat32(entries []os.FileInfo) []os.FileInfo {
 	var filtered []os.FileInfo
 	for _, e := range entries {
 		name := e.Name()
-		if name == "." || name == ".." || name == "lost+found" {
+		if name == "." || name == ".." || name == "lost+found" || strings.Contains(name, "/") {
 			continue
 		}
 		filtered = append(filtered, e)
@@ -106,12 +106,12 @@ func filterEntriesFat32(entries []os.FileInfo) []os.FileInfo {
 	return filtered
 }
 
-// filterEntriesExt removes ".", "..", and "lost+found" from ext4 entries.
+// filterEntriesExt removes ".", "..", "lost+found", and "/"-containing entries from ext4 entries.
 func filterEntriesExt(entries []fs.DirEntry) []fs.DirEntry {
 	var filtered []fs.DirEntry
 	for _, e := range entries {
 		name := e.Name()
-		if name == "." || name == ".." || name == "lost+found" {
+		if name == "." || name == ".." || name == "lost+found" || strings.Contains(name, "/") {
 			continue
 		}
 		filtered = append(filtered, e)
@@ -119,12 +119,12 @@ func filterEntriesExt(entries []fs.DirEntry) []fs.DirEntry {
 	return filtered
 }
 
-// filterEntriesNtfs removes ".", "..", and "$"-prefixed entries from NTFS entries.
+// filterEntriesNtfs removes ".", "..", "$"-prefixed, and "/"-containing entries from NTFS entries.
 func filterEntriesNtfs(entries []*parser.FileInfo) []*parser.FileInfo {
 	var filtered []*parser.FileInfo
 	for _, e := range entries {
 		name := e.Name
-		if name == "" || name == "." || name == ".." || strings.HasPrefix(name, "$") {
+		if name == "" || name == "." || name == ".." || strings.HasPrefix(name, "$") || strings.Contains(name, "/") {
 			continue
 		}
 		filtered = append(filtered, e)


### PR DESCRIPTION
**Note: I have reported this issue to Google OSS VRP**

The embedded filesystem extraction logic previously trusted file path entries from untrusted filesystem images without sufficient validation. This allowed specially crafted entries such as paths containing / to be interpreted outside the intended extraction root.

An attacker could exploit this behavior to perform directory traversal during extraction, potentially causing the tool to overwrite arbitrary files on the host system. When executed with elevated privileges, this could lead to modification of system-protected paths and compromise host integrity.

This change introduces strict validation and sanitization of all extracted paths. All non-conforming entries are skipped.

Impact:
	* Eliminates a path traversal primitive in filesystem extraction
	* Prevents writes outside the intended extraction root
	* Strengthens security when processing untrusted filesystem images