### PR TITLE
PRP: Add extractor for GitHub Actions workflow dependencies

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -224,13 +224,14 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 
 ### Misc
 
-| Type                               | Extractor Plugin    |
-|------------------------------------| ------------------- |
-| Wordpress plugins                  | `wordpress/plugins` |
-| VSCode extensions                  | `vscode/extensions` |
-| Chrome extensions                  | `chrome/extensions` |
-| Maven entries in Bazel build files | `os/bazelmaven`     |
-| NetScaler installations            | `netscaler`         |
+| Type                                  | Extractor Plugin    |
+|---------------------------------------| ------------------- |
+| Wordpress plugins                     | `wordpress/plugins` |
+| VSCode extensions                     | `vscode/extensions` |
+| Chrome extensions                     | `chrome/extensions` |
+| Maven entries in Bazel build files    | `os/bazelmaven`     |
+| NetScaler installations               | `netscaler`         |
+| GitHub Actions workflow dependencies  | `github/actions`    |
 
 ### EmbeddedFS
 

--- a/extractor/convert.go
+++ b/extractor/convert.go
@@ -15,6 +15,8 @@
 package extractor
 
 import (
+	"strings"
+
 	hexpurl "github.com/google/osv-scalibr/extractor/filesystem/language/erlang/mixlock/purl"
 	gopurl "github.com/google/osv-scalibr/extractor/filesystem/language/golang/purl"
 	mavenpurl "github.com/google/osv-scalibr/extractor/filesystem/language/java/purl"
@@ -70,6 +72,8 @@ func typeSpecificPURL(p *Package) *purl.PackageURL {
 		return gopurl.MakePackageURL(p.Name, p.Version)
 	case purl.TypeHex:
 		return hexpurl.MakePackageURL(p.Name, p.Version)
+	case purl.TypeGithub:
+		return githubPURL(p.Name, p.Version)
 	case purl.TypeDebian, purl.TypeOpkg, purl.TypeFlatpak, purl.TypeApk, purl.TypeCOS, purl.TypeRPM,
 		purl.TypeSnap, purl.TypePacman, purl.TypePortage, purl.TypeNix:
 		return ospurl.MakePackageURL(p.Name, p.Version, p.PURLType, p.Metadata)
@@ -77,6 +81,26 @@ func typeSpecificPURL(p *Package) *purl.PackageURL {
 		return winpurl.MakePackageURL(p.Name, p.Version, p.Metadata)
 	}
 	return nil
+}
+
+// githubPURL builds a pkg:github PURL from a Package whose Name is in
+// "owner/repo" form (the canonical pkg:github format places the owner in
+// the namespace and the repo in the name).
+func githubPURL(name, version string) *purl.PackageURL {
+	owner, repo, ok := strings.Cut(name, "/")
+	if !ok || owner == "" || repo == "" {
+		return &purl.PackageURL{
+			Type:    purl.TypeGithub,
+			Name:    name,
+			Version: version,
+		}
+	}
+	return &purl.PackageURL{
+		Type:      purl.TypeGithub,
+		Namespace: owner,
+		Name:      repo,
+		Version:   version,
+	}
 }
 
 // toEcosystem converts a SCALIBR package structure into an OSV ecosystem value
@@ -122,6 +146,8 @@ func toEcosystem(p *Package) osvecosystem.Parsed {
 		return osvecosystem.FromEcosystem(osvconstants.EcosystemPub)
 	case purl.TypeDHI:
 		return osvecosystem.FromEcosystem(osvconstants.EcosystemDockerHardenedImages)
+	case purl.TypeGithub:
+		return osvecosystem.FromEcosystem(osvconstants.EcosystemGitHubActions)
 	}
 
 	// No Ecosystem defined for this package.

--- a/extractor/convert_test.go
+++ b/extractor/convert_test.go
@@ -190,6 +190,21 @@ func TestToPURL(t *testing.T) {
 				}),
 			},
 		},
+		{
+			name: "github_purl",
+			pkg: &extractor.Package{
+				Name:     "actions/checkout",
+				Version:  "v4",
+				PURLType: purl.TypeGithub,
+				Location: extractor.LocationFromPath("location"),
+			},
+			want: &purl.PackageURL{
+				Type:      purl.TypeGithub,
+				Namespace: "actions",
+				Name:      "checkout",
+				Version:   "v4",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -251,6 +266,15 @@ func TestToEcosystem(t *testing.T) {
 				PURLType: purl.TypeDHI,
 			},
 			want: osvecosystem.FromEcosystem(osvconstants.EcosystemDockerHardenedImages),
+		},
+		{
+			name: "github_actions_ecosystem",
+			pkg: &extractor.Package{
+				Name:     "actions/checkout",
+				Version:  "v4",
+				PURLType: purl.TypeGithub,
+			},
+			want: osvecosystem.FromEcosystem(osvconstants.EcosystemGitHubActions),
 		},
 	}
 

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -83,6 +83,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/podfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/bazelmaven"
 	chromeextensions "github.com/google/osv-scalibr/extractor/filesystem/misc/chrome/extensions"
+	"github.com/google/osv-scalibr/extractor/filesystem/misc/githubactions"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/netscaler"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/vscodeextensions"
 	wordpressplugins "github.com/google/osv-scalibr/extractor/filesystem/misc/wordpress/plugins"
@@ -447,6 +448,7 @@ var (
 		wordpressplugins.Name: {wordpressplugins.New},
 		chromeextensions.Name: {chromeextensions.New},
 		netscaler.Name:        {netscaler.New},
+		githubactions.Name:    {githubactions.New},
 	}
 
 	// MiscSource extractors for miscellaneous purposes.

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -448,15 +448,15 @@ var (
 		wordpressplugins.Name: {wordpressplugins.New},
 		chromeextensions.Name: {chromeextensions.New},
 		netscaler.Name:        {netscaler.New},
-		githubactions.Name:    {githubactions.New},
 	}
 
 	// MiscSource extractors for miscellaneous purposes.
 	MiscSource = InitMap{
-		asdf.Name:        {asdf.New},
-		mise.Name:        {mise.New},
-		nvm.Name:         {nvm.New},
-		nodeversion.Name: {nodeversion.New},
+		asdf.Name:          {asdf.New},
+		mise.Name:          {mise.New},
+		nvm.Name:           {nvm.New},
+		nodeversion.Name:   {nodeversion.New},
+		githubactions.Name: {githubactions.New},
 	}
 
 	// EmbeddedFS extractors.

--- a/extractor/filesystem/misc/githubactions/githubactions.go
+++ b/extractor/filesystem/misc/githubactions/githubactions.go
@@ -1,0 +1,279 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package githubactions extracts GitHub Actions workflow dependencies from
+// .github/workflows/*.{yml,yaml} files.
+package githubactions
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/log"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"gopkg.in/yaml.v3"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "github/actions"
+
+	// defaultMaxFileSizeBytes is the default maximum file size the extractor will
+	// attempt to extract. If a file is encountered that is larger than this
+	// limit, the file is ignored by FileRequired.
+	defaultMaxFileSizeBytes = 10 * units.MiB
+
+	workflowsDir = ".github/workflows"
+)
+
+// commitSHARegexp matches a 40-character hexadecimal Git commit SHA.
+var commitSHARegexp = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+
+// Extractor extracts GitHub Actions dependencies from workflow files.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New returns a GitHub Actions workflow dependency extractor.
+//
+// For most use cases, initialize with:
+// ```
+// e := New(&cpb.PluginConfig{})
+// ```
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSize := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSize = cfg.GetMaxFileSizeBytes()
+	}
+	return &Extractor{maxFileSizeBytes: maxFileSize}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the file is a GitHub Actions workflow file,
+// i.e. is located directly under a .github/workflows/ directory and has a
+// .yml or .yaml extension.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := filepath.ToSlash(api.Path())
+	ext := filepath.Ext(path)
+	if ext != ".yml" && ext != ".yaml" {
+		return false
+	}
+	dir := filepath.ToSlash(filepath.Dir(path))
+	if dir != workflowsDir && !strings.HasSuffix(dir, "/"+workflowsDir) {
+		return false
+	}
+
+	fi, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if e.maxFileSizeBytes > 0 && fi.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fi.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fi.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract extracts GitHub Actions dependencies from a workflow file passed
+// through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := parse(input.Reader, input.Path)
+	if err != nil {
+		e.reportFileExtracted(input.Path, input.Info, err)
+		return inventory.Inventory{}, fmt.Errorf("githubactions.parse(%q): %w", input.Path, err)
+	}
+
+	e.reportFileExtracted(input.Path, input.Info, nil)
+	return inventory.Inventory{Packages: pkgs}, nil
+}
+
+func (e Extractor) reportFileExtracted(path string, fileinfo fs.FileInfo, err error) {
+	if e.Stats == nil {
+		return
+	}
+	var fileSizeBytes int64
+	if fileinfo != nil {
+		fileSizeBytes = fileinfo.Size()
+	}
+	e.Stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+		Path:          path,
+		Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+func parse(r io.Reader, path string) ([]*extractor.Package, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		// Files inside .github/workflows/ are not always valid workflow files
+		// (e.g. partial templates). Don't fail the scan.
+		log.Debugf("githubactions: yaml unmarshal failed for %s: %v", path, err)
+		return nil, nil
+	}
+	if len(root.Content) == 0 {
+		return nil, nil
+	}
+
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return nil, nil
+	}
+
+	jobs := mappingValue(doc, "jobs")
+	if jobs == nil || jobs.Kind != yaml.MappingNode {
+		return nil, nil
+	}
+
+	var pkgs []*extractor.Package
+	// MappingNode content alternates [key, value, key, value, ...].
+	for i := 0; i+1 < len(jobs.Content); i += 2 {
+		jobNode := jobs.Content[i+1]
+		if jobNode.Kind != yaml.MappingNode {
+			continue
+		}
+		pkgs = append(pkgs, packagesFromJob(jobNode, path)...)
+	}
+	return pkgs, nil
+}
+
+// packagesFromJob extracts dependencies from a single job node, covering both
+// reusable workflow references (jobs.<id>.uses) and step references
+// (jobs.<id>.steps[].uses).
+func packagesFromJob(job *yaml.Node, path string) []*extractor.Package {
+	var pkgs []*extractor.Package
+
+	if uses := mappingValue(job, "uses"); uses != nil && uses.Kind == yaml.ScalarNode {
+		if pkg := packageFromUses(uses.Value, uses.Line, path); pkg != nil {
+			pkgs = append(pkgs, pkg)
+		}
+	}
+
+	steps := mappingValue(job, "steps")
+	if steps == nil || steps.Kind != yaml.SequenceNode {
+		return pkgs
+	}
+	for _, step := range steps.Content {
+		if step.Kind != yaml.MappingNode {
+			continue
+		}
+		uses := mappingValue(step, "uses")
+		if uses == nil || uses.Kind != yaml.ScalarNode {
+			continue
+		}
+		if pkg := packageFromUses(uses.Value, uses.Line, path); pkg != nil {
+			pkgs = append(pkgs, pkg)
+		}
+	}
+	return pkgs
+}
+
+// packageFromUses parses a `uses:` value and returns the corresponding Package,
+// or nil if the value does not reference a versioned GitHub action / reusable
+// workflow (e.g. local actions like ./action and Docker actions are skipped).
+func packageFromUses(uses string, line int, path string) *extractor.Package {
+	uses = strings.TrimSpace(uses)
+	// Local actions (./path, ../path) live in the same repository and have
+	// no independent version, so they are not GitHub Actions ecosystem deps.
+	if strings.HasPrefix(uses, "./") || strings.HasPrefix(uses, "../") {
+		return nil
+	}
+	// Docker action references aren't GitHub Actions ecosystem packages.
+	if strings.HasPrefix(uses, "docker://") {
+		return nil
+	}
+
+	atIdx := strings.LastIndex(uses, "@")
+	if atIdx <= 0 || atIdx == len(uses)-1 {
+		return nil
+	}
+	repoRef, ref := uses[:atIdx], uses[atIdx+1:]
+
+	// owner/repo[/sub/path]
+	parts := strings.SplitN(repoRef, "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return nil
+	}
+	name := parts[0] + "/" + parts[1]
+
+	pkg := &extractor.Package{
+		Name:     name,
+		Version:  ref,
+		PURLType: purl.TypeGithub,
+		Location: extractor.LocationFromPathAndLine(path, line),
+		SourceCode: &extractor.SourceCodeIdentifier{
+			Repo: "https://github.com/" + name,
+		},
+	}
+	if commitSHARegexp.MatchString(ref) {
+		pkg.SourceCode.Commit = ref
+	}
+	return pkg
+}
+
+// mappingValue returns the value node associated with key in a YAML mapping
+// node, or nil if the key isn't present.
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		k := node.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/misc/githubactions/githubactions_test.go
+++ b/extractor/filesystem/misc/githubactions/githubactions_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubactions_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/misc/githubactions"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/inventory/location"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "workflow_file_yml_at_repo_root",
+			path: ".github/workflows/ci.yml",
+			want: true,
+		},
+		{
+			name: "workflow_file_yaml_at_repo_root",
+			path: ".github/workflows/release.yaml",
+			want: true,
+		},
+		{
+			name: "workflow_file_inside_subdirectory_repo",
+			path: "src/myrepo/.github/workflows/build.yml",
+			want: true,
+		},
+		{
+			name: "absolute_style_path_with_workflows",
+			path: "home/user/proj/.github/workflows/test.yml",
+			want: true,
+		},
+		{
+			name: "yml_under_workflows_subdir_should_not_match",
+			path: ".github/workflows/sub/build.yml",
+			want: false,
+		},
+		{
+			name: "yml_under_dot_github_but_not_workflows",
+			path: ".github/dependabot.yml",
+			want: false,
+		},
+		{
+			name: "yml_under_workflows_but_not_dot_github",
+			path: "workflows/build.yml",
+			want: false,
+		},
+		{
+			name: "non_yaml_extension_under_workflows",
+			path: ".github/workflows/notes.txt",
+			want: false,
+		},
+		{
+			name: "markdown_file_under_workflows",
+			path: ".github/workflows/README.md",
+			want: false,
+		},
+		{
+			name: "unrelated_yaml_file",
+			path: "config/app.yml",
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			extr, err := githubactions.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("githubactions.New() error: %v", err)
+			}
+			fi := fakefs.FakeFileInfo{FileName: tc.path, FileSize: 1024}
+			got := extr.FileRequired(simplefileapi.New(tc.path, fi))
+			if got != tc.want {
+				t.Errorf("FileRequired(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFileRequired_FileSizeLimit(t *testing.T) {
+	extr, err := githubactions.New(&cpb.PluginConfig{MaxFileSizeBytes: 100})
+	if err != nil {
+		t.Fatalf("githubactions.New() error: %v", err)
+	}
+	path := ".github/workflows/big.yml"
+	fi := fakefs.FakeFileInfo{FileName: path, FileSize: 200}
+	if extr.FileRequired(simplefileapi.New(path, fi)) {
+		t.Errorf("FileRequired(%q) = true, want false (over size limit)", path)
+	}
+}
+
+func loc(path string, line int) extractor.PackageLocation {
+	return extractor.PackageLocation{
+		Descriptor: &location.Location{
+			File: &location.File{
+				Path:       path,
+				LineNumber: line,
+			},
+		},
+	}
+}
+
+func sourceCode(repo, commit string) *extractor.SourceCodeIdentifier {
+	return &extractor.SourceCodeIdentifier{Repo: repo, Commit: commit}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantPackages []*extractor.Package
+	}{
+		{
+			name: "valid_workflow_with_steps_and_reusable_workflows",
+			path: "testdata/valid.yml",
+			wantPackages: []*extractor.Package{
+				{
+					Name:       "actions/checkout",
+					Version:    "v4",
+					PURLType:   purl.TypeGithub,
+					Location:   loc("testdata/valid.yml", 11),
+					SourceCode: sourceCode("https://github.com/actions/checkout", ""),
+				},
+				{
+					Name:     "actions/setup-node",
+					Version:  "8e5e7e5ab8b370d6c329ec480221332ada57f0ab",
+					PURLType: purl.TypeGithub,
+					Location: loc("testdata/valid.yml", 12),
+					SourceCode: sourceCode(
+						"https://github.com/actions/setup-node",
+						"8e5e7e5ab8b370d6c329ec480221332ada57f0ab",
+					),
+				},
+				{
+					Name:       "actions/setup-python",
+					Version:    "v5.0.0",
+					PURLType:   purl.TypeGithub,
+					Location:   loc("testdata/valid.yml", 13),
+					SourceCode: sourceCode("https://github.com/actions/setup-python", ""),
+				},
+				{
+					Name:       "docker/build-push-action",
+					Version:    "v6",
+					PURLType:   purl.TypeGithub,
+					Location:   loc("testdata/valid.yml", 16),
+					SourceCode: sourceCode("https://github.com/docker/build-push-action", ""),
+				},
+				{
+					Name:       "octo-org/example-repo",
+					Version:    "v1.2.3",
+					PURLType:   purl.TypeGithub,
+					Location:   loc("testdata/valid.yml", 21),
+					SourceCode: sourceCode("https://github.com/octo-org/example-repo", ""),
+				},
+				{
+					Name:     "octo-org/example-repo",
+					Version:  "1234567890abcdef1234567890abcdef12345678",
+					PURLType: purl.TypeGithub,
+					Location: loc("testdata/valid.yml", 24),
+					SourceCode: sourceCode(
+						"https://github.com/octo-org/example-repo",
+						"1234567890abcdef1234567890abcdef12345678",
+					),
+				},
+			},
+		},
+		{
+			name: "edge_cases_skip_local_docker_and_malformed",
+			path: "testdata/edge_cases.yaml",
+			wantPackages: []*extractor.Package{
+				{
+					Name:       "actions/checkout",
+					Version:    "v4",
+					PURLType:   purl.TypeGithub,
+					Location:   loc("testdata/edge_cases.yaml", 12),
+					SourceCode: sourceCode("https://github.com/actions/checkout", ""),
+				},
+				{
+					Name:       "github/codeql-action",
+					Version:    "v3",
+					PURLType:   purl.TypeGithub,
+					Location:   loc("testdata/edge_cases.yaml", 17),
+					SourceCode: sourceCode("https://github.com/github/codeql-action", ""),
+				},
+				{
+					Name:       "github/codeql-action",
+					Version:    "v3",
+					PURLType:   purl.TypeGithub,
+					Location:   loc("testdata/edge_cases.yaml", 18),
+					SourceCode: sourceCode("https://github.com/github/codeql-action", ""),
+				},
+				{
+					Name:       "actions/cache",
+					Version:    "main",
+					PURLType:   purl.TypeGithub,
+					Location:   loc("testdata/edge_cases.yaml", 23),
+					SourceCode: sourceCode("https://github.com/actions/cache", ""),
+				},
+				{
+					Name:       "actions/upload-artifact",
+					Version:    "v4",
+					PURLType:   purl.TypeGithub,
+					Location:   loc("testdata/edge_cases.yaml", 24),
+					SourceCode: sourceCode("https://github.com/actions/upload-artifact", ""),
+				},
+			},
+		},
+		{
+			name:         "no_jobs_section",
+			path:         "testdata/no_jobs.yml",
+			wantPackages: nil,
+		},
+		{
+			name:         "empty_file",
+			path:         "testdata/empty.yml",
+			wantPackages: nil,
+		},
+		{
+			name:         "invalid_yaml_no_packages_no_error",
+			path:         "testdata/invalid.yml",
+			wantPackages: nil,
+		},
+		{
+			name:         "jobs_field_is_a_list_not_a_map",
+			path:         "testdata/jobs_not_map.yml",
+			wantPackages: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			extr, err := githubactions.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("githubactions.New() error: %v", err)
+			}
+			input := extracttest.GenerateScanInputMock(t, extracttest.ScanInputMockConfig{Path: tc.path})
+			defer extracttest.CloseTestScanInput(t, input)
+
+			got, err := extr.Extract(t.Context(), &input)
+			if err != nil {
+				t.Fatalf("%s.Extract(%q) unexpected error: %v", extr.Name(), tc.path, err)
+			}
+			wantInv := inventory.Inventory{Packages: tc.wantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tc.path, diff)
+			}
+		})
+	}
+}
+
+func TestExtract_PURLAndEcosystem(t *testing.T) {
+	extr, err := githubactions.New(&cpb.PluginConfig{})
+	if err != nil {
+		t.Fatalf("githubactions.New() error: %v", err)
+	}
+	input := extracttest.GenerateScanInputMock(t, extracttest.ScanInputMockConfig{
+		Path: "testdata/valid.yml",
+	})
+	defer extracttest.CloseTestScanInput(t, input)
+
+	inv, err := extr.Extract(t.Context(), &input)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(inv.Packages) == 0 {
+		t.Fatalf("Extract returned no packages")
+	}
+	pkg := inv.Packages[0]
+	gotPURL := pkg.PURL().String()
+	wantPURL := "pkg:github/actions/checkout@v4"
+	if gotPURL != wantPURL {
+		t.Errorf("PURL = %q, want %q", gotPURL, wantPURL)
+	}
+	gotEco := pkg.Ecosystem().String()
+	wantEco := "GitHub Actions"
+	if gotEco != wantEco {
+		t.Errorf("Ecosystem = %q, want %q", gotEco, wantEco)
+	}
+}

--- a/extractor/filesystem/misc/githubactions/testdata/edge_cases.yaml
+++ b/extractor/filesystem/misc/githubactions/testdata/edge_cases.yaml
@@ -1,0 +1,33 @@
+name: edges
+
+on: [push]
+
+jobs:
+  local-and-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./local-action
+      - uses: ../another-local
+      - uses: docker://alpine:3.18
+      - uses: actions/checkout@v4
+
+  subpath-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/analyze@v3
+
+  branch-and-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@main
+      - uses: actions/upload-artifact@v4
+
+  malformed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nobody
+      - uses: "@noref"
+      - uses: ""
+      - uses: actions/no-version@
+      - run: echo "no uses here"

--- a/extractor/filesystem/misc/githubactions/testdata/invalid.yml
+++ b/extractor/filesystem/misc/githubactions/testdata/invalid.yml
@@ -1,0 +1,6 @@
+name: bad
+on: [push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: not-a-list

--- a/extractor/filesystem/misc/githubactions/testdata/jobs_not_map.yml
+++ b/extractor/filesystem/misc/githubactions/testdata/jobs_not_map.yml
@@ -1,0 +1,3 @@
+name: bad
+jobs:
+  - this should be a map not a list

--- a/extractor/filesystem/misc/githubactions/testdata/no_jobs.yml
+++ b/extractor/filesystem/misc/githubactions/testdata/no_jobs.yml
@@ -1,0 +1,3 @@
+name: only-metadata
+
+on: [push]

--- a/extractor/filesystem/misc/githubactions/testdata/valid.yml
+++ b/extractor/filesystem/misc/githubactions/testdata/valid.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - uses: actions/setup-python@v5.0.0
+      - name: Install
+        run: npm ci
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+
+  reusable-call:
+    uses: octo-org/example-repo/.github/workflows/reusable.yml@v1.2.3
+
+  pinned-call:
+    uses: octo-org/example-repo/.github/workflows/reusable.yml@1234567890abcdef1234567890abcdef12345678


### PR DESCRIPTION
Add a new filesystem extractor that parses GitHub Actions workflow files (.github/workflows/*.yml and .github/workflows/*.yaml) and extracts action and reusable-workflow dependencies declared via `uses:` syntax. Each package is reported with name=owner/repo, version=ref, PURL type=github, and ecosystem=GitHub Actions, along with the source repo URL and the commit hash when the ref is a pinned 40-character SHA (so pinned actions are distinguished from mutable tag/branch refs). Both step uses (jobs.<id>.steps[].uses) and reusable workflow uses (jobs.<id>.uses) are handled, sub-path action references are normalised to owner/repo, and local actions and docker:// references are skipped. Includes line-number tracking and unit tests.

https://github.com/google/osv-scalibr/issues/1956