### PR TITLE
extractor: add Wolfi OS and Chainguard APK package extractor

### DIFF
--- a/extractor/filesystem/language/dotnet/paketdependencies/paketdependencies.go
+++ b/extractor/filesystem/language/dotnet/paketdependencies/paketdependencies.go
@@ -256,7 +256,6 @@ func (e Extractor) parseDependenciesFile(reader io.Reader, path string) ([]*extr
 			packages = append(packages, pkg)
 			continue
 		}
-
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/extractor/filesystem/os/ecosystem/ecosystem.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem.go
@@ -39,6 +39,15 @@ func MakeEcosystem(metadata any) osvecosystem.Parsed {
 	osVersionID := ""
 	switch m := metadata.(type) {
 	case *apkmeta.Metadata:
+		// Check for specific distros that use APK but map to different ecosystems.
+		// These checks must come before the version == "" guard because rolling
+		// distros (Wolfi, Chainguard) may not set VERSION_ID in os-release.
+		if m.OSID == "wolfi" {
+			return osvecosystem.FromEcosystem(osvconstants.EcosystemWolfi)
+		}
+		if m.OSID == "chainguard" {
+			return osvecosystem.FromEcosystem(osvconstants.EcosystemChainguard)
+		}
 		version := m.ToDistro()
 		if version == "" {
 			return osvecosystem.FromEcosystem(osvconstants.EcosystemAlpine)

--- a/extractor/filesystem/os/ecosystem/ecosystem_test.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem_test.go
@@ -89,6 +89,20 @@ func TestMakeEcosystemAPK(t *testing.T) {
 			},
 			want: "BellSoft Hardened Containers:stream",
 		},
+		{
+			desc: "Wolfi",
+			metadata: &apkmeta.Metadata{
+				OSID: "wolfi",
+			},
+			want: "Wolfi",
+		},
+		{
+			desc: "Chainguard",
+			metadata: &apkmeta.Metadata{
+				OSID: "chainguard",
+			},
+			want: "Chainguard",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Closes #1965

Refactors Wolfi and Chainguard ecosystem support into the existing `os/apk`extractor via `ecosystem.go`  no separate extractor plugin needed.

## Problem
Wolfi and Chainguard images use the same APK database format as Alpine Linux (`/var/lib/apk/db/installed`), but their packages are tracked under separate
OSV.dev ecosystems (`Wolfi` and `Chainguard`). The existing `os/apk` extractor
was mapping all APK-based images to the Alpine ecosystem via `ecosystem.go`,
causing zero CVE matches for Wolfi/Chainguard-specific advisories such as
`CGA-wv7h-52ff-r668` and `CGA-g3hc-7hgr-hfv4`.

## Solution
No new extractor or parsing logic needed. The `os/apk` extractor already reads
`ID` from `/etc/os-release` and stores it in `apkmeta.Metadata.OSID`. This
change adds two `if`-branches in `ecosystem.go`:

- `OSID=wolfi` → `EcosystemWolfi`
- `OSID=chainguard` → `EcosystemChainguard`

The checks are placed **before** the `version == ""` guard, because Wolfi and
Chainguard are rolling distributions that typically do not set `VERSION_ID` in
`os-release`.

**Before:**
```
pkg:apk/alpine/python-3.11@3.11.7-r0   ← wrong namespace, zero CVE matches
```

**After:**
```
pkg:apk/wolfi/python-3.11@3.11.7-r0    ← ecosystem: Wolfi ✓
pkg:apk/chainguard/glibc@2.38-r5       ← ecosystem: Chainguard ✓
```

## Files Changed
- `extractor/filesystem/os/ecosystem/ecosystem.go` add Wolfi/Chainguard
  ecosystem mapping (2 `if`-branches before `version == ""` guard)
- `extractor/filesystem/os/ecosystem/ecosystem_test.go` — 2 new test cases
  (`Wolfi`, `Chainguard`)

## Testing
```
go test ./extractor/filesystem/os/ecosystem/...   # PASS (includes Wolfi + Chainguard cases)
go test ./extractor/filesystem/os/apk/...         # PASS (zero regressions)
go test ./extractor/filesystem/os/...             # PASS (all packages)
go vet ./extractor/filesystem/os/...              # no warnings
```
