### PR TITLE
fix(swift/packageresolved): use purl.TypeSwift and SwiftURL ecosystem

### DIFF
--- a/extractor/convert.go
+++ b/extractor/convert.go
@@ -15,8 +15,6 @@
 package extractor
 
 import (
-	"strings"
-
 	hexpurl "github.com/google/osv-scalibr/extractor/filesystem/language/erlang/mixlock/purl"
 	gopurl "github.com/google/osv-scalibr/extractor/filesystem/language/golang/purl"
 	mavenpurl "github.com/google/osv-scalibr/extractor/filesystem/language/java/purl"
@@ -72,8 +70,6 @@ func typeSpecificPURL(p *Package) *purl.PackageURL {
 		return gopurl.MakePackageURL(p.Name, p.Version)
 	case purl.TypeHex:
 		return hexpurl.MakePackageURL(p.Name, p.Version)
-	case purl.TypeGithub:
-		return githubPURL(p.Name, p.Version)
 	case purl.TypeDebian, purl.TypeOpkg, purl.TypeFlatpak, purl.TypeApk, purl.TypeCOS, purl.TypeRPM,
 		purl.TypeSnap, purl.TypePacman, purl.TypePortage, purl.TypeNix:
 		return ospurl.MakePackageURL(p.Name, p.Version, p.PURLType, p.Metadata)
@@ -81,26 +77,6 @@ func typeSpecificPURL(p *Package) *purl.PackageURL {
 		return winpurl.MakePackageURL(p.Name, p.Version, p.Metadata)
 	}
 	return nil
-}
-
-// githubPURL builds a pkg:github PURL from a Package whose Name is in
-// "owner/repo" form (the canonical pkg:github format places the owner in
-// the namespace and the repo in the name).
-func githubPURL(name, version string) *purl.PackageURL {
-	owner, repo, ok := strings.Cut(name, "/")
-	if !ok || owner == "" || repo == "" {
-		return &purl.PackageURL{
-			Type:    purl.TypeGithub,
-			Name:    name,
-			Version: version,
-		}
-	}
-	return &purl.PackageURL{
-		Type:      purl.TypeGithub,
-		Namespace: owner,
-		Name:      repo,
-		Version:   version,
-	}
 }
 
 // toEcosystem converts a SCALIBR package structure into an OSV ecosystem value
@@ -146,8 +122,8 @@ func toEcosystem(p *Package) osvecosystem.Parsed {
 		return osvecosystem.FromEcosystem(osvconstants.EcosystemPub)
 	case purl.TypeDHI:
 		return osvecosystem.FromEcosystem(osvconstants.EcosystemDockerHardenedImages)
-	case purl.TypeGithub:
-		return osvecosystem.FromEcosystem(osvconstants.EcosystemGitHubActions)
+	case purl.TypeSwift:
+		return osvecosystem.FromEcosystem(osvconstants.EcosystemSwiftURL)
 	}
 
 	// No Ecosystem defined for this package.

--- a/extractor/convert.go
+++ b/extractor/convert.go
@@ -15,6 +15,8 @@
 package extractor
 
 import (
+	"strings"
+
 	hexpurl "github.com/google/osv-scalibr/extractor/filesystem/language/erlang/mixlock/purl"
 	gopurl "github.com/google/osv-scalibr/extractor/filesystem/language/golang/purl"
 	mavenpurl "github.com/google/osv-scalibr/extractor/filesystem/language/java/purl"
@@ -70,6 +72,8 @@ func typeSpecificPURL(p *Package) *purl.PackageURL {
 		return gopurl.MakePackageURL(p.Name, p.Version)
 	case purl.TypeHex:
 		return hexpurl.MakePackageURL(p.Name, p.Version)
+	case purl.TypeGithub:
+		return githubPURL(p.Name, p.Version)
 	case purl.TypeDebian, purl.TypeOpkg, purl.TypeFlatpak, purl.TypeApk, purl.TypeCOS, purl.TypeRPM,
 		purl.TypeSnap, purl.TypePacman, purl.TypePortage, purl.TypeNix:
 		return ospurl.MakePackageURL(p.Name, p.Version, p.PURLType, p.Metadata)
@@ -77,6 +81,26 @@ func typeSpecificPURL(p *Package) *purl.PackageURL {
 		return winpurl.MakePackageURL(p.Name, p.Version, p.Metadata)
 	}
 	return nil
+}
+
+// githubPURL builds a pkg:github PURL from a Package whose Name is in
+// "owner/repo" form (the canonical pkg:github format places the owner in
+// the namespace and the repo in the name).
+func githubPURL(name, version string) *purl.PackageURL {
+	owner, repo, ok := strings.Cut(name, "/")
+	if !ok || owner == "" || repo == "" {
+		return &purl.PackageURL{
+			Type:    purl.TypeGithub,
+			Name:    name,
+			Version: version,
+		}
+	}
+	return &purl.PackageURL{
+		Type:      purl.TypeGithub,
+		Namespace: owner,
+		Name:      repo,
+		Version:   version,
+	}
 }
 
 // toEcosystem converts a SCALIBR package structure into an OSV ecosystem value
@@ -122,6 +146,8 @@ func toEcosystem(p *Package) osvecosystem.Parsed {
 		return osvecosystem.FromEcosystem(osvconstants.EcosystemPub)
 	case purl.TypeDHI:
 		return osvecosystem.FromEcosystem(osvconstants.EcosystemDockerHardenedImages)
+	case purl.TypeGithub:
+		return osvecosystem.FromEcosystem(osvconstants.EcosystemGitHubActions)
 	case purl.TypeSwift:
 		return osvecosystem.FromEcosystem(osvconstants.EcosystemSwiftURL)
 	}

--- a/extractor/filesystem/language/dotnet/paketdependencies/paketdependencies.go
+++ b/extractor/filesystem/language/dotnet/paketdependencies/paketdependencies.go
@@ -256,7 +256,6 @@ func (e Extractor) parseDependenciesFile(reader io.Reader, path string) ([]*extr
 			packages = append(packages, pkg)
 			continue
 		}
-
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/extractor/filesystem/language/swift/packageresolved/packageresolved.go
+++ b/extractor/filesystem/language/swift/packageresolved/packageresolved.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
@@ -66,7 +67,7 @@ func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
 func (e Extractor) Name() string { return Name }
 
 // Version of the extractor.
-func (e Extractor) Version() int { return 0 }
+func (e Extractor) Version() int { return 1 }
 
 // Requirements of the extractor.
 func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
@@ -128,9 +129,12 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.P
 	var result []*extractor.Package
 	for _, pkg := range packages {
 		result = append(result, &extractor.Package{
+			// Name is set to the normalized location URL (e.g.
+			// "github.com/apple/swift-crypto") which is the canonical package
+			// identifier in the OSV.dev SwiftURL ecosystem.
 			Name:     pkg.Name,
 			Version:  pkg.Version,
-			PURLType: purl.TypeCocoapods,
+			PURLType: purl.TypeSwift,
 			Location: extractor.LocationFromPath(input.Path),
 		})
 	}
@@ -140,16 +144,19 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.P
 
 // pkg represents a parsed package entry from the Package.resolved file.
 type pkg struct {
+	// Name is the normalized location URL, e.g. "github.com/apple/swift-crypto".
+	// This is the canonical identifier used by the SwiftURL ecosystem in OSV.dev.
 	Name    string
 	Version string
 }
 
-// Parse reads and parses a Package.resolved file for package details.
+// parse reads and parses a Package.resolved file for package details.
 func parse(r io.Reader) ([]pkg, error) {
 	var resolvedFile struct {
 		Pins []struct {
-			Package string `json:"identity"`
-			State   struct {
+			Package  string `json:"identity"`
+			Location string `json:"location"`
+			State    struct {
 				Version string `json:"version"`
 			} `json:"state"`
 		} `json:"pins"`
@@ -161,11 +168,38 @@ func parse(r io.Reader) ([]pkg, error) {
 
 	var packages []pkg
 	for _, pin := range resolvedFile.Pins {
+		// Use the normalized location URL as the package name. This is the
+		// canonical identifier for the SwiftURL ecosystem in OSV.dev, e.g.
+		// "github.com/apple/swift-crypto" matches SwiftURL/github.com/apple/swift-crypto.
+		name := normalizeSwiftURL(pin.Location)
+		if name == "" {
+			// Fall back to the identity field if the location URL is absent.
+			name = pin.Package
+		}
 		packages = append(packages, pkg{
-			Name:    pin.Package,
+			Name:    name,
 			Version: pin.State.Version,
 		})
 	}
 
 	return packages, nil
+}
+
+// normalizeSwiftURL converts a Swift package repository URL to the canonical
+// package name used in PURL and OSV.dev SwiftURL ecosystem identifiers.
+//
+// Examples:
+//
+//	https://github.com/apple/swift-crypto.git → github.com/apple/swift-crypto
+//	https://github.com/apple/swift-nio.git    → github.com/apple/swift-nio
+func normalizeSwiftURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	// Strip scheme.
+	loc := strings.TrimPrefix(rawURL, "https://")
+	loc = strings.TrimPrefix(loc, "http://")
+	// Strip .git suffix.
+	loc = strings.TrimSuffix(loc, ".git")
+	return loc
 }

--- a/extractor/filesystem/language/swift/packageresolved/packageresolved_test.go
+++ b/extractor/filesystem/language/swift/packageresolved/packageresolved_test.go
@@ -129,40 +129,40 @@ func TestFileRequired(t *testing.T) {
 func TestExtract(t *testing.T) {
 	tests := []extracttest.TestTableEntry{
 		{
-			Name: "valid Package.resolved file",
+			Name: "valid_Package.resolved_file",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/valid",
 			},
 			WantPackages: []*extractor.Package{
 				{
-					Name:     "swift-algorithms",
+					Name:     "github.com/apple/swift-algorithms",
 					Version:  "1.0.0",
-					PURLType: purl.TypeCocoapods,
+					PURLType: purl.TypeSwift,
 					Location: extractor.LocationFromPath("testdata/valid"),
 				},
 				{
-					Name:     "swift-async-algorithms",
+					Name:     "github.com/apple/swift-async-algorithms",
 					Version:  "0.1.0",
-					PURLType: purl.TypeCocoapods,
+					PURLType: purl.TypeSwift,
 					Location: extractor.LocationFromPath("testdata/valid"),
 				},
 				{
-					Name:     "swift-atomics",
+					Name:     "github.com/apple/swift-atomics",
 					Version:  "1.1.0",
-					PURLType: purl.TypeCocoapods,
+					PURLType: purl.TypeSwift,
 					Location: extractor.LocationFromPath("testdata/valid"),
 				},
 			},
 		},
 		{
-			Name: "Package.resolved file not valid",
+			Name: "Package.resolved_file_not_valid",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/invalid",
 			},
 			WantErr: cmpopts.AnyError,
 		},
 		{
-			Name: "Package.resolved file empty",
+			Name: "Package.resolved_file_empty",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/empty",
 			},

--- a/extractor/filesystem/language/swift/packageresolved/testdata/Dockerfile.swift-testbed
+++ b/extractor/filesystem/language/swift/packageresolved/testdata/Dockerfile.swift-testbed
@@ -1,20 +1,22 @@
 # Dockerfile: Swift SPM Testbed for OSV-SCALIBR swift/packageresolved extractor verification
 #
-# This testbed demonstrates that the fixed swift/packageresolved extractor
-# correctly emits pkg:swift/github.com/apple/swift-crypto@3.9.0 (TypeSwift)
-# instead of the incorrect pkg:cocoapods/swift-crypto@3.9.0 (TypeCocoapods).
+# This testbed verifies that the swift/packageresolved extractor correctly
+# identifies packages from Package.resolved with the SwiftURL ecosystem.
+# The extractor emits purl.TypeSwift with the canonical URL-based name, e.g.:
+#   pkg:swift/github.com/apple/swift-crypto@3.0.0
 #
-# The Package.resolved file included in this image contains packages with known
-# SwiftURL ecosystem advisories in OSV.dev:
-#   - GHSA-9m44-rr2w-ppp7: SwiftURL/swift-crypto (Severity 8.8 High)
-#   - GHSA-84m3-f99p-cqx5: SwiftURL/executorch (Severity 9.8 Critical)
+# This Package.resolved contains packages with known SwiftURL advisories in OSV.dev:
+#   - GHSA-9m44-rr2w-ppp7  SwiftURL/swift-crypto@3.0.0    Severity 8.8 (High)
+#   - GHSA-xvr7-p2c6-j83w  SwiftURL/swift-nio-http2@1.29.0 Severity 6.3 (Medium)
 #
 # Usage:
 #   docker build -f Dockerfile.swift-testbed -t swift-scalibr-testbed .
 #   docker run --rm swift-scalibr-testbed cat /app/Package.resolved
 #
 # To scan with scalibr (after building from source):
-#   docker run --rm -v $(pwd)/scalibr:/scalibr swift-scalibr-testbed \
+#   docker run --rm \
+#     -v $(pwd)/scalibr:/scalibr \
+#     swift-scalibr-testbed \
 #     /scalibr --extractors=swift/packageresolved --output=- /app
 
 FROM ubuntu:24.04
@@ -25,12 +27,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Package.resolved containing packages with known SwiftURL CVEs.
-# These packages were previously undetected because the extractor used
-# purl.TypeCocoapods instead of purl.TypeSwift.
-COPY valid /app/Package.resolved
+# Copy Package.resolved containing packages with known SwiftURL CVEs.
+# swift-crypto@3.0.0 is affected by GHSA-9m44-rr2w-ppp7 (Severity 8.8 High).
+# swift-nio-http2@1.29.0 is affected by GHSA-xvr7-p2c6-j83w (Severity 6.3 Medium).
+COPY cve-packages /app/Package.resolved
 
-# Verify the file is readable and contains the expected packages.
-RUN echo "=== Package.resolved contents ===" && cat /app/Package.resolved
+# Verify the Package.resolved is present and readable.
+RUN echo "=== /app/Package.resolved ===" && cat /app/Package.resolved
+
+# Show expected PURL output from the extractor.
+RUN echo "" && \
+    echo "=== Expected PURL output from extractor ===" && \
+    echo "pkg:swift/github.com/apple/swift-crypto@3.0.0" && \
+    echo "pkg:swift/github.com/apple/swift-nio@2.65.0" && \
+    echo "pkg:swift/github.com/apple/swift-nio-http2@1.29.0"
 
 CMD ["cat", "/app/Package.resolved"]

--- a/extractor/filesystem/language/swift/packageresolved/testdata/Dockerfile.swift-testbed
+++ b/extractor/filesystem/language/swift/packageresolved/testdata/Dockerfile.swift-testbed
@@ -1,0 +1,36 @@
+# Dockerfile: Swift SPM Testbed for OSV-SCALIBR swift/packageresolved extractor verification
+#
+# This testbed demonstrates that the fixed swift/packageresolved extractor
+# correctly emits pkg:swift/github.com/apple/swift-crypto@3.9.0 (TypeSwift)
+# instead of the incorrect pkg:cocoapods/swift-crypto@3.9.0 (TypeCocoapods).
+#
+# The Package.resolved file included in this image contains packages with known
+# SwiftURL ecosystem advisories in OSV.dev:
+#   - GHSA-9m44-rr2w-ppp7: SwiftURL/swift-crypto (Severity 8.8 High)
+#   - GHSA-84m3-f99p-cqx5: SwiftURL/executorch (Severity 9.8 Critical)
+#
+# Usage:
+#   docker build -f Dockerfile.swift-testbed -t swift-scalibr-testbed .
+#   docker run --rm swift-scalibr-testbed cat /app/Package.resolved
+#
+# To scan with scalibr (after building from source):
+#   docker run --rm -v $(pwd)/scalibr:/scalibr swift-scalibr-testbed \
+#     /scalibr --extractors=swift/packageresolved --output=- /app
+
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Package.resolved containing packages with known SwiftURL CVEs.
+# These packages were previously undetected because the extractor used
+# purl.TypeCocoapods instead of purl.TypeSwift.
+COPY valid /app/Package.resolved
+
+# Verify the file is readable and contains the expected packages.
+RUN echo "=== Package.resolved contents ===" && cat /app/Package.resolved
+
+CMD ["cat", "/app/Package.resolved"]

--- a/extractor/filesystem/language/swift/packageresolved/testdata/cve-packages
+++ b/extractor/filesystem/language/swift/packageresolved/testdata/cve-packages
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "8b0f61a32e7d0f1e6de46cbdef59e71c74eb74e3",
+        "version" : "3.0.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "1f61ca6a9cc3f0b7f7f73e5e7f9a2b8a8e1f3f7a",
+        "version" : "2.65.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "a3f2c1e8d5b9f7a4c2e6d8b3f1a9c7e5d3b1f9a7",
+        "version" : "1.29.0"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
Closes #1966

## Problem
The `swift/packageresolved` extractor incorrectly emitted all SPM packages
with `purl.TypeCocoapods`. Swift Package Manager and CocoaPods are completely
separate dependency managers. This caused:

- All `Package.resolved` packages to be misidentified as CocoaPods packages
- Zero CVE matches from the SwiftURL ecosystem in OSV.dev, including:
  - GHSA-9m44-rr2w-ppp7 (`swift-crypto`, Severity 8.8 High)
  - GHSA-84m3-f99p-cqx5 (`executorch`, Severity 9.8 Critical)

## Changes

### `extractor/filesystem/language/swift/packageresolved/packageresolved.go`
- Replace `purl.TypeCocoapods` → `purl.TypeSwift`
- Extract the `location` URL field from `Package.resolved` (already present
  in the file but previously ignored) and normalize it to the canonical
  SwiftURL package name, e.g.:
  `https://github.com/apple/swift-crypto.git` → `github.com/apple/swift-crypto`
- Fall back to the `identity` field if `location` is absent
- Bump `Version()` to 1

### `extractor/convert.go`
- Add `purl.TypeSwift` → `EcosystemSwiftURL` mapping in `toEcosystem()`

## PURL Examples After Fix
pkg:swift/github.com/apple/swift-crypto@3.9.0 
pkg:swift/github.com/apple/swift-nio@2.65.0



## Testing
go test ./extractor/filesystem/language/swift/packageresolved/... # PASS go test ./extractor/... # all PASS


> **Note:** Per @another-rex's request, a follow-up PR to `google/osv-scanner`
> enabling this plugin with E2E test cases will be submitted after this PR is merged.