### PR TITLE
extractor/r: add R installed packages extractor (DESCRIPTION files)

### DIFF
--- a/extractor/filesystem/language/r/rpkg/rpkg.go
+++ b/extractor/filesystem/language/r/rpkg/rpkg.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rpkg extracts installed R packages from DESCRIPTION files.
+//
+// When R packages are installed via install.packages(), BiocManager, or similar
+// tools, each package is placed in a library directory
+// (e.g. /usr/lib/R/library/<package>/) with a DESCRIPTION file containing
+// metadata in the Debian control file (DCF) format. This extractor scans for
+// those DESCRIPTION files to enumerate all installed R packages and match them
+// against the CRAN ecosystem in OSV.dev.
+//
+// File pattern: <R_lib_path>/<PackageName>/DESCRIPTION
+// Example: /usr/lib/R/library/ggplot2/DESCRIPTION
+package rpkg
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "r/rpkg"
+)
+
+// Extractor extracts installed R packages from DESCRIPTION files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the file is a DESCRIPTION file inside an R library directory.
+//
+// R library layout:
+//
+//	<lib>/<PackageName>/DESCRIPTION
+//
+// We match any file named "DESCRIPTION" where the grandparent directory name
+// looks like an R library root (contains typical R package directories like
+// "base", "utils", "stats" siblings, or is under a path containing "R/library",
+// "R/site-library", or "R/x86_64-pc-linux-gnu-library").
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := filepath.ToSlash(api.Path())
+
+	// The filename must be exactly "DESCRIPTION".
+	if filepath.Base(path) != "DESCRIPTION" {
+		return false
+	}
+
+	// The path must be at least 2 levels deep: <lib>/<pkg>/DESCRIPTION
+	parts := strings.Split(path, "/")
+	if len(parts) < 3 {
+		return false
+	}
+
+	// Accept paths that contain well-known R library directory patterns.
+	return isRLibraryPath(path)
+}
+
+// isRLibraryPath returns true if the given path looks like an R library package path.
+func isRLibraryPath(path string) bool {
+	rLibPatterns := []string{
+		"/R/library/",
+		"/R/site-library/",
+		"/R/x86_64-",
+		"/R/aarch64-",
+		"/R/arm-",
+		"site-packages/R/", // Some conda R environments
+		"lib/R/",
+		"Library/R/",  // macOS R library
+		"r-packages/", // Some Linux distros
+	}
+	for _, pat := range rLibPatterns {
+		if strings.Contains(path, pat) {
+			return true
+		}
+	}
+	return false
+}
+
+// Extract extracts the R package name and version from an R DESCRIPTION file.
+//
+// The DESCRIPTION file uses the Debian Control File (DCF) format, a simple
+// key-value format where each field is on its own line:
+//
+//	Package: ggplot2
+//	Version: 3.4.4
+//	Title: Create Elegant Data Visualisations Using the Grammar of Graphics
+//	...
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkg, err := parseDESCRIPTION(input)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("rpkg: parseDESCRIPTION(%s): %w", input.Path, err)
+	}
+	if pkg == nil {
+		return inventory.Inventory{}, nil
+	}
+	return inventory.Inventory{Packages: []*extractor.Package{pkg}}, nil
+}
+
+// parseDESCRIPTION parses an R DESCRIPTION file and returns an extractor.Package.
+// Returns nil if the file does not contain a valid R package (missing Package or Version fields).
+func parseDESCRIPTION(input *filesystem.ScanInput) (*extractor.Package, error) {
+	fields := make(map[string]string)
+
+	scanner := bufio.NewScanner(input.Reader)
+	var currentKey string
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip blank lines (DCF block separators — R DESCRIPTION has only one block).
+		if line == "" {
+			continue
+		}
+
+		// Continuation lines start with whitespace.
+		if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+			if currentKey != "" {
+				fields[currentKey] += " " + strings.TrimSpace(line)
+			}
+			continue
+		}
+
+		// Key: Value line
+		before, after, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		currentKey = strings.TrimSpace(before)
+		value := strings.TrimSpace(after)
+		fields[currentKey] = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	pkgName := fields["Package"]
+	version := fields["Version"]
+
+	// Both Package and Version are required to produce a meaningful inventory entry.
+	if pkgName == "" || version == "" {
+		return nil, nil
+	}
+
+	return &extractor.Package{
+		Name:     pkgName,
+		Version:  version,
+		PURLType: purl.TypeCran,
+		Location: extractor.LocationFromPath(input.Path),
+	}, nil
+}

--- a/extractor/filesystem/language/r/rpkg/rpkg_test.go
+++ b/extractor/filesystem/language/r/rpkg/rpkg_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpkg_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/r/rpkg"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestNew(t *testing.T) {
+	e, err := rpkg.New(&cpb.PluginConfig{})
+	if err != nil {
+		t.Fatalf("rpkg.New(): %v", err)
+	}
+	if e == nil {
+		t.Fatal("rpkg.New() returned nil")
+	}
+}
+
+func TestName(t *testing.T) {
+	e, _ := rpkg.New(&cpb.PluginConfig{})
+	if got, want := e.Name(), rpkg.Name; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}
+
+func TestFileRequired(t *testing.T) {
+	e, _ := rpkg.New(&cpb.PluginConfig{})
+
+	tests := []struct {
+		name     string
+		path     string
+		wantBool bool
+	}{
+		{
+			name:     "DESCRIPTION in R/library",
+			path:     "usr/lib/R/library/ggplot2/DESCRIPTION",
+			wantBool: true,
+		},
+		{
+			name:     "DESCRIPTION in R/site-library",
+			path:     "usr/local/lib/R/site-library/dplyr/DESCRIPTION",
+			wantBool: true,
+		},
+		{
+			name:     "DESCRIPTION in versioned x86_64 R lib",
+			path:     "home/user/R/x86_64-pc-linux-gnu-library/4.3/tidyverse/DESCRIPTION",
+			wantBool: true,
+		},
+		{
+			name:     "DESCRIPTION in aarch64 R lib",
+			path:     "home/user/R/aarch64-unknown-linux-gnu-library/4.2/Rcpp/DESCRIPTION",
+			wantBool: true,
+		},
+		{
+			name:     "DESCRIPTION in lib/R path",
+			path:     "usr/lib64/R/library/lattice/DESCRIPTION",
+			wantBool: true,
+		},
+		{
+			name:     "wrong filename - NAMESPACE",
+			path:     "usr/lib/R/library/ggplot2/NAMESPACE",
+			wantBool: false,
+		},
+		{
+			name:     "wrong filename - R file",
+			path:     "usr/lib/R/library/ggplot2/ggplot2.R",
+			wantBool: false,
+		},
+		{
+			name:     "DESCRIPTION in non-R path",
+			path:     "home/user/projects/myapp/DESCRIPTION",
+			wantBool: false,
+		},
+		{
+			name:     "DESCRIPTION at root",
+			path:     "DESCRIPTION",
+			wantBool: false,
+		},
+		{
+			name:     "DESCRIPTION in doc path",
+			path:     "usr/share/doc/libfoo/DESCRIPTION",
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{FileName: "DESCRIPTION", FileSize: 512}))
+			if got != tt.wantBool {
+				t.Errorf("FileRequired(%q) = %v, want %v", tt.path, got, tt.wantBool)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	e, _ := rpkg.New(&cpb.PluginConfig{})
+
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "ggplot2 package",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/ggplot2/DESCRIPTION",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "ggplot2",
+					Version:  "3.4.4",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/ggplot2/DESCRIPTION"),
+				},
+			},
+		},
+		{
+			Name: "dplyr with continuation lines",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/dplyr/DESCRIPTION",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "dplyr",
+					Version:  "1.1.4",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/dplyr/DESCRIPTION"),
+				},
+			},
+		},
+		{
+			Name: "invalid DESCRIPTION missing Package/Version",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid/DESCRIPTION",
+			},
+			WantPackages: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(context.Background(), &scanInput)
+			if err != nil && tt.WantErr == nil {
+				t.Fatalf("Extract() error = %v, wantErr = nil", err)
+			}
+
+			opts := cmp.Options{
+				cmpopts.IgnoreUnexported(extractor.Package{}),
+				cmpopts.EquateEmpty(),
+			}
+			if diff := cmp.Diff(tt.WantPackages, got.Packages, opts); diff != "" {
+				t.Errorf("Extract() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtract_PURLType(t *testing.T) {
+	e, _ := rpkg.New(&cpb.PluginConfig{})
+
+	scanInput := extracttest.GenerateScanInputMock(t, extracttest.ScanInputMockConfig{
+		Path: "testdata/ggplot2/DESCRIPTION",
+	})
+	defer extracttest.CloseTestScanInput(t, scanInput)
+
+	got, err := e.Extract(context.Background(), &scanInput)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got.Packages) != 1 {
+		t.Fatalf("got %d packages, want 1", len(got.Packages))
+	}
+
+	pkg := got.Packages[0]
+	if pkg.PURLType != purl.TypeCran {
+		t.Errorf("PURLType = %q, want %q", pkg.PURLType, purl.TypeCran)
+	}
+
+	p := pkg.PURL()
+	if p.Type != purl.TypeCran {
+		t.Errorf("PURL().Type = %q, want %q", p.Type, purl.TypeCran)
+	}
+	if p.Name != "ggplot2" {
+		t.Errorf("PURL().Name = %q, want %q", p.Name, "ggplot2")
+	}
+	if p.Version != "3.4.4" {
+		t.Errorf("PURL().Version = %q, want %q", p.Version, "3.4.4")
+	}
+}

--- a/extractor/filesystem/language/r/rpkg/testdata/dplyr/DESCRIPTION
+++ b/extractor/filesystem/language/r/rpkg/testdata/dplyr/DESCRIPTION
@@ -1,0 +1,8 @@
+Package: dplyr
+Version: 1.1.4
+Title: A Grammar of Data Manipulation
+Author: Hadley Wickham [aut, cre]
+Maintainer: Hadley Wickham <hadley@rstudio.com>
+Description: A fast, consistent tool for working with data frame like objects,
+    both in memory and out of memory.
+License: MIT + file LICENSE

--- a/extractor/filesystem/language/r/rpkg/testdata/ggplot2/DESCRIPTION
+++ b/extractor/filesystem/language/r/rpkg/testdata/ggplot2/DESCRIPTION
@@ -1,0 +1,10 @@
+Package: ggplot2
+Version: 3.4.4
+Title: Create Elegant Data Visualisations Using the Grammar of Graphics
+Author: Hadley Wickham [aut, cre]
+Maintainer: Hadley Wickham <hadley@rstudio.com>
+Description: A system for declaratively creating graphics,
+    based on "The Grammar of Graphics".
+License: MIT + file LICENSE
+URL: https://ggplot2.tidyverse.org
+BugReports: https://github.com/tidyverse/ggplot2/issues

--- a/extractor/filesystem/language/r/rpkg/testdata/invalid/DESCRIPTION
+++ b/extractor/filesystem/language/r/rpkg/testdata/invalid/DESCRIPTION
@@ -1,0 +1,2 @@
+License: GPL-2
+Description: Missing the required Package and Version fields.

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -74,6 +74,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/uvlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/wheelegg"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/r/renvlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/r/rpkg"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ruby/gemfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ruby/gemspec"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargoauditable"
@@ -259,7 +260,10 @@ var (
 		cabal.Name:     {cabal.New},
 	}
 	// RSource extractors for R source extractors
-	RSource = InitMap{renvlock.Name: {renvlock.New}}
+	RSource = InitMap{
+		renvlock.Name: {renvlock.New},
+		rpkg.Name:     {rpkg.New},
+	}
 	// RubySource extractors for Ruby.
 	RubySource = InitMap{
 		gemspec.Name:     {gemspec.New},


### PR DESCRIPTION
Closes #2037
Add an inventory extractor for installed R packages by parsing
DESCRIPTION files in R library directories (e.g. /usr/lib/R/library/).

- Complements r/renvlock (which only covers renv.lock)
- Covers all R packages installed via install.packages() or BiocManager
- Uses DCF parser with bufio.Scanner - no new dependencies
- Emits pkg:cran/<name>@<version> PURLs
- Unit tests included