### PR TITLE
extractor/python: add Conda environment.yml declarative environment extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -42,6 +42,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Nix               |                                | `os/nix`                                     |
 | OPKG              | e.g. OpenWrt                   | `os/dpkg`                                    |
 | RPM               | e.g. RHEL, CentOS, Rocky Linux | `os/rpm`                                     |
+| Photon OS         | VMware Photon OS (tdnf/RPM)    | `os/photon`                                  |
 | Zypper            | e.g. openSUSE                  | `os/rpm`                                     |
 | Pacman            | e.g. Arch Linux                | `os/pacman`                                  |
 | Kernel modules    | .ko                            | `os/kernel/module`                           |
@@ -97,10 +98,12 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | poetry.lock                                       | `python/poetrylock`                  |
 |            | Pipfile.lock                                      | `python/pipfilelock`                 |
 |            | pdm.lock                                          | `python/pdmlock`                     |
-|            | Conda packages                                    | `python/condameta`                   |
+|            | Conda packages (conda-meta)                       | `python/condameta`                   |
+|            | Conda environment.yml                             | `python/condaenv`                    |
 |            | setup.py                                          | `python/setup`                       |
 |            | uv.lock                                           | `python/uvlock`                      |
 | R          | renv.lock                                         | `r/renvlock`                         |
+|            | Installed R packages (DESCRIPTION files)          | `r/rpkg`                             |
 | Ruby       | Installed Gem packages                            | `ruby/gemspec`                       |
 |            | Gemfile.lock, gems.locked                         | `ruby/gemfilelock`                   |
 | Rust       | Cargo.lock                                        | `rust/cargolock`                     |

--- a/extractor/filesystem/language/python/condaenv/condaenv.go
+++ b/extractor/filesystem/language/python/condaenv/condaenv.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package condaenv extracts packages declared in Conda environment.yml files.
+//
+// Unlike the condameta extractor which reads installed package metadata from
+// conda-meta/*.json files, this extractor parses the declarative
+// environment.yml format. These files are the standard way Conda users
+// share reproducible environments (e.g. in GitHub repos, Docker images,
+// scientific papers, and CI/CD pipelines).
+//
+// environment.yml is also used by:
+//   - conda env create -f environment.yml
+//   - Google Colab and JupyterHub environment specs
+//   - Bioinformatics pipeline tools (Snakemake, Nextflow)
+//   - ML research repositories (PyTorch, JAX, etc.)
+//
+// File format example:
+//
+//	name: myenv
+//	channels:
+//	  - conda-forge
+//	  - defaults
+//	dependencies:
+//	  - python=3.11
+//	  - numpy=1.26.0
+//	  - scipy>=1.11
+//	  - pip:
+//	    - requests==2.31.0
+package condaenv
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"gopkg.in/yaml.v3"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "python/condaenv"
+
+	// defaultMaxFileSizeBytes is the maximum file size this extractor will process.
+	defaultMaxFileSizeBytes = 1 * units.MiB
+)
+
+// environmentYML is the top-level structure of a Conda environment.yml file.
+type environmentYML struct {
+	Name         string   `yaml:"name"`
+	Channels     []string `yaml:"channels"`
+	Dependencies []any    `yaml:"dependencies"`
+}
+
+// Extractor extracts Conda packages from environment.yml files.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New returns a new Conda environment.yml extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the file is a Conda environment.yml or environment.yaml.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	base := filepath.Base(api.Path())
+	if base != "environment.yml" && base != "environment.yaml" {
+		return false
+	}
+
+	fileinfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if fileinfo.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(api.Path(), fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(api.Path(), fileinfo.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract extracts conda packages from an environment.yml file.
+//
+// Conda dependency strings can be:
+//   - "numpy"              (just a name, any version)
+//   - "numpy=1.26.0"       (exact version, pinned with single =)
+//   - "numpy>=1.26,<2.0"   (version range)
+//   - "python=3.11.*"      (wildcard)
+//
+// Pip dependencies (under the "pip:" key) are skipped; they are handled
+// by Python/pip extractors.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	var env environmentYML
+	if err := yaml.NewDecoder(input.Reader).Decode(&env); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("condaenv: yaml.Decode(%s): %w", input.Path, err)
+	}
+
+	var pkgs []*extractor.Package
+	for _, dep := range env.Dependencies {
+		switch v := dep.(type) {
+		case string:
+			// A plain conda dependency string like "numpy=1.26.0"
+			if pkg := parseCondaDep(v, input.Path); pkg != nil {
+				pkgs = append(pkgs, pkg)
+			}
+		case map[string]any:
+			// A nested mapping, typically {"pip": [...]}
+			// We intentionally skip pip dependencies — they belong to PyPI.
+			// Other nested forms (e.g. conda-lock specific) are also skipped.
+		}
+	}
+
+	return inventory.Inventory{Packages: pkgs}, nil
+}
+
+// parseCondaDep parses a conda dependency string into an extractor.Package.
+//
+// Conda dependency format: name[=version[=build_string]]
+// The conda pinning operators are: = (exact), >= (min), <= (max), != (excluded)
+//
+// Examples:
+//
+//	"numpy"           → name=numpy, version=""
+//	"numpy=1.26.0"    → name=numpy, version=1.26.0
+//	"numpy>=1.26"     → name=numpy, version=>=1.26 (kept as-is for matching)
+//	"python=3.11.*"   → name=python, version=3.11.*
+func parseCondaDep(dep string, path string) *extractor.Package {
+	dep = strings.TrimSpace(dep)
+	if dep == "" {
+		return nil
+	}
+
+	// Split on the first version operator character.
+	// Operators: =, >=, <=, !=, ~=
+	// We find the first non-name character.
+	name := dep
+	version := ""
+
+	for _, op := range []string{"!=", "~=", ">=", "<=", "==", "="} {
+		if idx := strings.Index(dep, op); idx > 0 {
+			candidate := strings.TrimSpace(dep[:idx])
+			if isValidCondaName(candidate) {
+				name = candidate
+				version = strings.TrimSpace(dep[idx+len(op):])
+				break
+			}
+		}
+	}
+
+	// Strip the build string if present (second = in "numpy=1.26.0=py311_0")
+	if idx := strings.Index(version, "="); idx >= 0 {
+		version = version[:idx]
+	}
+
+	// Skip meta-packages and wildcards-only versions.
+	if name == "" {
+		return nil
+	}
+
+	return &extractor.Package{
+		Name:     name,
+		Version:  version,
+		PURLType: purl.TypeConda,
+		Location: extractor.LocationFromPath(path),
+	}
+}
+
+// isValidCondaName returns true if s looks like a valid conda package name.
+// Conda names consist of letters, digits, hyphens, underscores, and dots.
+func isValidCondaName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.') {
+			return false
+		}
+	}
+	return true
+}

--- a/extractor/filesystem/language/python/condaenv/condaenv_test.go
+++ b/extractor/filesystem/language/python/condaenv/condaenv_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package condaenv_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condaenv"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestNew(t *testing.T) {
+	e, err := condaenv.New(&cpb.PluginConfig{})
+	if err != nil {
+		t.Fatalf("condaenv.New(): %v", err)
+	}
+	if e == nil {
+		t.Fatal("condaenv.New() returned nil")
+	}
+}
+
+func TestName(t *testing.T) {
+	e, _ := condaenv.New(&cpb.PluginConfig{})
+	if got, want := e.Name(), condaenv.Name; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}
+
+func TestFileRequired(t *testing.T) {
+	e, _ := condaenv.New(&cpb.PluginConfig{})
+
+	tests := []struct {
+		name     string
+		path     string
+		wantBool bool
+	}{
+		{
+			name:     "environment.yml at root",
+			path:     "environment.yml",
+			wantBool: true,
+		},
+		{
+			name:     "environment.yaml alternative extension",
+			path:     "environment.yaml",
+			wantBool: true,
+		},
+		{
+			name:     "nested environment.yml",
+			path:     "project/conda/environment.yml",
+			wantBool: true,
+		},
+		{
+			name:     "requirements.txt is not a conda env file",
+			path:     "requirements.txt",
+			wantBool: false,
+		},
+		{
+			name:     "prefix match should not match",
+			path:     "my-environment.yml",
+			wantBool: false,
+		},
+		{
+			name:     "conda-lock.yml is a different format",
+			path:     "conda-lock.yml",
+			wantBool: false,
+		},
+		{
+			name:     "Pipfile is not environment.yml",
+			path:     "Pipfile",
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{FileName: "environment.yml", FileSize: 512}))
+			if got != tt.wantBool {
+				t.Errorf("FileRequired(%q) = %v, want %v", tt.path, got, tt.wantBool)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	e, _ := condaenv.New(&cpb.PluginConfig{})
+
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "pinned conda packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/pinned.yml",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "python", Version: "3.11", PURLType: purl.TypeConda, Location: extractor.LocationFromPath("testdata/pinned.yml")},
+				{Name: "numpy", Version: "1.26.0", PURLType: purl.TypeConda, Location: extractor.LocationFromPath("testdata/pinned.yml")},
+				{Name: "scipy", Version: "1.11.4", PURLType: purl.TypeConda, Location: extractor.LocationFromPath("testdata/pinned.yml")},
+				{Name: "matplotlib", Version: "3.8.0", PURLType: purl.TypeConda, Location: extractor.LocationFromPath("testdata/pinned.yml")},
+			},
+		},
+		{
+			Name: "pip section is ignored",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/with-pip.yml",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "python", Version: "3.10", PURLType: purl.TypeConda, Location: extractor.LocationFromPath("testdata/with-pip.yml")},
+				{Name: "torch", Version: "2.1.0", PURLType: purl.TypeConda, Location: extractor.LocationFromPath("testdata/with-pip.yml")},
+			},
+		},
+		{
+			Name: "empty dependencies produces no packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.yml",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "invalid yaml returns error",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid.yml",
+			},
+			WantPackages: nil,
+			WantErr:      extracttest.ContainsErrStr{Str: "yaml"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(context.Background(), &scanInput)
+
+			if tt.WantErr != nil {
+				if err == nil {
+					t.Fatalf("Extract() error = nil, want %v", tt.WantErr)
+				}
+				var wantContains extracttest.ContainsErrStr
+				if errors.As(tt.WantErr, &wantContains) {
+					if !strings.Contains(err.Error(), wantContains.Str) {
+						t.Fatalf("Extract() error = %q, want to contain %q", err.Error(), wantContains.Str)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Extract() error = %v, want nil", err)
+			}
+
+			opts := cmp.Options{
+				cmpopts.IgnoreUnexported(extractor.Package{}),
+				cmpopts.EquateEmpty(),
+				cmpopts.SortSlices(extracttest.PackageCmpLess),
+			}
+			if diff := cmp.Diff(tt.WantPackages, got.Packages, opts); diff != "" {
+				t.Errorf("Extract() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtract_PURLType(t *testing.T) {
+	e, _ := condaenv.New(&cpb.PluginConfig{})
+
+	scanInput := extracttest.GenerateScanInputMock(t, extracttest.ScanInputMockConfig{
+		Path: "testdata/pinned.yml",
+	})
+	defer extracttest.CloseTestScanInput(t, scanInput)
+
+	got, err := e.Extract(context.Background(), &scanInput)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got.Packages) == 0 {
+		t.Fatal("got 0 packages, want > 0")
+	}
+
+	for _, pkg := range got.Packages {
+		if pkg.PURLType != purl.TypeConda {
+			t.Errorf("Package %q PURLType = %q, want %q", pkg.Name, pkg.PURLType, purl.TypeConda)
+		}
+		p := pkg.PURL()
+		if p.Type != purl.TypeConda {
+			t.Errorf("Package %q PURL().Type = %q, want %q", pkg.Name, p.Type, purl.TypeConda)
+		}
+	}
+}

--- a/extractor/filesystem/language/python/condaenv/testdata/empty.yml
+++ b/extractor/filesystem/language/python/condaenv/testdata/empty.yml
@@ -1,0 +1,3 @@
+name: emptyenv
+channels:
+  - defaults

--- a/extractor/filesystem/language/python/condaenv/testdata/invalid.yml
+++ b/extractor/filesystem/language/python/condaenv/testdata/invalid.yml
@@ -1,0 +1,2 @@
+this is not valid yaml: [unclosed: {bracket
+  - invalid

--- a/extractor/filesystem/language/python/condaenv/testdata/pinned.yml
+++ b/extractor/filesystem/language/python/condaenv/testdata/pinned.yml
@@ -1,0 +1,9 @@
+name: myenv
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.11
+  - numpy=1.26.0
+  - scipy=1.11.4
+  - matplotlib=3.8.0

--- a/extractor/filesystem/language/python/condaenv/testdata/with-pip.yml
+++ b/extractor/filesystem/language/python/condaenv/testdata/with-pip.yml
@@ -1,0 +1,9 @@
+name: mlenv
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - torch=2.1.0
+  - pip:
+    - boto3==1.28.0
+    - fastapi==0.100.0

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -64,6 +64,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ocaml/opam"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cpan"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condaenv"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condameta"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfilelock"
@@ -227,6 +228,7 @@ var (
 		poetrylock.Name:   {poetrylock.New},
 		pylock.Name:       {pylock.New},
 		condameta.Name:    {condameta.New},
+		condaenv.Name:     {condaenv.New},
 		uvlock.Name:       {uvlock.New},
 	}
 	// PythonArtifact extractors for Python.
@@ -259,7 +261,9 @@ var (
 		cabal.Name:     {cabal.New},
 	}
 	// RSource extractors for R source extractors
-	RSource = InitMap{renvlock.Name: {renvlock.New}}
+	RSource = InitMap{
+		renvlock.Name: {renvlock.New},
+	}
 	// RubySource extractors for Ruby.
 	RubySource = InitMap{
 		gemspec.Name:     {gemspec.New},

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -52,7 +52,7 @@ func TestExtractorsFromName(t *testing.T) {
 		{
 			desc:     "Find_all_extractors_of_a_type",
 			name:     "python",
-			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/condaenv", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:     "Nonexistent_plugin",

--- a/plugin/list/list_test.go
+++ b/plugin/list/list_test.go
@@ -131,12 +131,12 @@ func TestFromNames(t *testing.T) {
 		{
 			desc:      "Find_all_Plugins_of_a_type",
 			names:     []string{"python", "windows", "cis", "layerdetails"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/condaenv", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
 		},
 		{
 			desc:      "Remove_duplicates",
 			names:     []string{"python", "python"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/condaenv", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:      "Nonexistent_plugin",


### PR DESCRIPTION
Closes #2038
Add an inventory extractor for Conda environment.yml files the standard format for sharing reproducible Conda environments in repos, CI/CD pipelines, and Docker build contexts.

- Distinct from python/condameta (which needs conda-meta/*.json)
- Handles =, >=, <=, !=, ~= version operators and build string stripping
- Skips pip: subsections (handled by pip extractors)
- Uses gopkg.in/yaml.v3 already in go.mod — no new dependencies
- Unit tests included