### PR TITLE
Validate datasource local registry cache paths

### DIFF
--- a/clients/datasource/local_registry_path.go
+++ b/clients/datasource/local_registry_path.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasource
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+func localRegistryPath(kind, root string, paths []string) (string, error) {
+	for _, elem := range paths {
+		if elem == "" || path.IsAbs(elem) || strings.Contains(elem, `\`) {
+			return "", fmt.Errorf("invalid %s local registry cache path %q", kind, paths)
+		}
+		for _, part := range strings.Split(elem, "/") {
+			if part == "" || part == "." || part == ".." {
+				return "", fmt.Errorf("invalid %s local registry cache path %q", kind, paths)
+			}
+		}
+	}
+
+	rel := filepath.FromSlash(path.Join(paths...))
+	if !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("invalid %s local registry cache path %q", kind, paths)
+	}
+
+	filePath := filepath.Join(root, rel)
+	relToRoot, err := filepath.Rel(root, filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to check %s local registry cache path %s: %w", kind, filePath, err)
+	}
+	if !filepath.IsLocal(relToRoot) {
+		return "", fmt.Errorf("invalid %s local registry cache path %q", kind, paths)
+	}
+
+	return filePath, nil
+}

--- a/clients/datasource/local_registry_path.go
+++ b/clients/datasource/local_registry_path.go
@@ -26,7 +26,7 @@ func localRegistryPath(kind, root string, paths []string) (string, error) {
 		if elem == "" || path.IsAbs(elem) || strings.Contains(elem, `\`) {
 			return "", fmt.Errorf("invalid %s local registry cache path %q", kind, paths)
 		}
-		for _, part := range strings.Split(elem, "/") {
+		for part := range strings.SplitSeq(elem, "/") {
 			if part == "" || part == "." || part == ".." {
 				return "", fmt.Errorf("invalid %s local registry cache path %q", kind, paths)
 			}

--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -308,7 +308,11 @@ func (m *MavenRegistryAPIClient) getArtifactMetadata(ctx context.Context, regist
 func (m *MavenRegistryAPIClient) get(ctx context.Context, auth *HTTPAuthentication, registry MavenRegistry, paths []string, dst any) error {
 	filePath := ""
 	if m.localRegistry != "" {
-		filePath = filepath.Join(append([]string{m.localRegistry}, paths...)...)
+		var err error
+		filePath, err = localRegistryPath("Maven", m.localRegistry, paths)
+		if err != nil {
+			return err
+		}
 		file, err := os.Open(filePath)
 		if err == nil {
 			defer file.Close()

--- a/clients/datasource/maven_registry_test.go
+++ b/clients/datasource/maven_registry_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"deps.dev/util/maven"
@@ -275,5 +276,89 @@ func TestMavenLocalRegistry(t *testing.T) {
 	}
 	if !bytes.Equal(content, resp) {
 		t.Errorf("unexpected file content: got %s, want %s", string(content), string(resp))
+	}
+}
+
+func TestMavenLocalRegistryRejectsTraversal(t *testing.T) {
+	tempDir := t.TempDir()
+	srv := clienttest.NewMockHTTPServer(t)
+	client, _ := datasource.NewMavenRegistryAPIClient(t.Context(), datasource.MavenRegistry{URL: srv.URL, ReleasesEnabled: true}, tempDir, false)
+
+	for _, tc := range []struct {
+		name       string
+		groupID    string
+		artifactID string
+		version    string
+	}{
+		{
+			name:       "groupID",
+			groupID:    "../escape/outside/pwned",
+			artifactID: "x.y.z",
+			version:    "1.0.0",
+		},
+		{
+			name:       "artifactID",
+			groupID:    "org.example",
+			artifactID: "../../../../escape/outside/pwned",
+			version:    "1.0.0",
+		},
+		{
+			name:       "version",
+			groupID:    "org.example",
+			artifactID: "x.y.z",
+			version:    "../../../../escape/outside/pwned",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.GetProject(t.Context(), tc.groupID, tc.artifactID, tc.version)
+			if err == nil {
+				t.Fatal("GetProject() succeeded with traversal input, want error")
+			}
+			if !strings.Contains(err.Error(), "invalid Maven local registry cache path") {
+				t.Fatalf("GetProject() error = %v, want invalid local cache path error", err)
+			}
+		})
+	}
+
+	escaped := filepath.Join(tempDir, "escape", "outside", "pwned-1.0.0.pom")
+	if _, err := os.Stat(escaped); err == nil {
+		t.Fatalf("escaped cache file exists: %s", escaped)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("failed to stat escaped cache file %s: %v", escaped, err)
+	}
+}
+
+func TestMavenLocalRegistryRejectsTraversalSnapshotValue(t *testing.T) {
+	tempDir := t.TempDir()
+	srv := clienttest.NewMockHTTPServer(t)
+	client, _ := datasource.NewMavenRegistryAPIClient(t.Context(), datasource.MavenRegistry{URL: srv.URL, SnapshotsEnabled: true}, tempDir, false)
+	srv.SetResponse(t, "org/example/x.y.z/1.0.0-SNAPSHOT/maven-metadata.xml", []byte(`
+	<metadata>
+	  <groupId>org.example</groupId>
+	  <artifactId>x.y.z</artifactId>
+	  <versioning>
+	    <snapshotVersions>
+	      <snapshotVersion>
+	        <extension>pom</extension>
+	        <value>../../../../escape/outside/pwned</value>
+	      </snapshotVersion>
+	    </snapshotVersions>
+	  </versioning>
+	</metadata>
+	`))
+
+	_, err := client.GetProject(t.Context(), "org.example", "x.y.z", "1.0.0-SNAPSHOT")
+	if err == nil {
+		t.Fatal("GetProject() succeeded with traversal snapshot value, want error")
+	}
+	if !strings.Contains(err.Error(), "invalid Maven local registry cache path") {
+		t.Fatalf("GetProject() error = %v, want invalid local cache path error", err)
+	}
+
+	escaped := filepath.Join(tempDir, "escape", "outside", "pwned")
+	if _, err := os.Stat(escaped); err == nil {
+		t.Fatalf("escaped cache file exists: %s", escaped)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("failed to stat escaped cache file %s: %v", escaped, err)
 	}
 }

--- a/clients/datasource/pypi_registry.go
+++ b/clients/datasource/pypi_registry.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -97,14 +96,27 @@ func urlToPath(rawURL string) string {
 		log.Warnf("Error parsing URL %s: %s", rawURL, err)
 		return ""
 	}
-	return path.Join(parsedURL.Hostname(), parsedURL.Path)
+	host := parsedURL.Hostname()
+	if host == "" {
+		log.Warnf("Error parsing URL %s: missing hostname", rawURL)
+		return ""
+	}
+	urlPath := strings.Trim(parsedURL.Path, "/")
+	if urlPath == "" {
+		return host
+	}
+	return host + "/" + urlPath
 }
 
 func (p *PyPIRegistryAPIClient) get(ctx context.Context, url string, queryIndex bool) ([]byte, error) {
 	file := ""
 	urlPath := urlToPath(url)
 	if urlPath != "" && p.localRegistry != "" {
-		file = filepath.Join(p.localRegistry, urlPath)
+		var err error
+		file, err = localRegistryPath("PyPI", p.localRegistry, []string{urlPath})
+		if err != nil {
+			return nil, err
+		}
 		if content, err := os.ReadFile(file); err == nil {
 			// We can still fetch the file from upstream if error is not nil.
 			return content, nil

--- a/clients/datasource/pypi_registry_test.go
+++ b/clients/datasource/pypi_registry_test.go
@@ -15,6 +15,8 @@
 package datasource_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -211,4 +213,32 @@ func TestPyPILocalRegistry(t *testing.T) {
 	if string(content) != jsonResp {
 		t.Errorf("unexpected file content: got %s, want %s", string(content), jsonResp)
 	}
+}
+
+func TestPyPILocalRegistryRejectsTraversalURLPath(t *testing.T) {
+	tempDir := t.TempDir()
+	payload := []byte("WAVE10_PYPI_CACHE_TRAVERSAL_PAYLOAD")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(srv.Close)
+	client := datasource.NewPyPIRegistryAPIClient(srv.URL, tempDir)
+
+	_, err := client.GetFile(t.Context(), srv.URL+"/../../escape/outside/pwned.whl")
+	if err == nil {
+		t.Fatal("GetFile() succeeded with traversal URL path, want error")
+	}
+
+	cacheRoot := filepath.Join(tempDir, "pypi")
+	escaped := filepath.Join(tempDir, "escape", "outside", "pwned.whl")
+	if _, err := os.Stat(filepath.Join(cacheRoot, "escape", "outside", "pwned.whl")); err == nil {
+		t.Fatal("test setup error: file stayed under PyPI cache root")
+	}
+	if _, err := os.Stat(escaped); err == nil {
+		t.Fatalf("escaped cache file exists: %s", escaped)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("failed to stat escaped cache file %s: %v", escaped, err)
+	}
+	t.Logf("cache root: %s", cacheRoot)
 }


### PR DESCRIPTION
# Validate datasource local registry cache paths before read/write

## Summary

This change validates local registry cache path components before using them for
datasource cache reads or writes.

Maven coordinates, Maven snapshot metadata, and PyPI file URLs are used to build
cache paths under the configured `local_registry` root. Those values can contain
traversal-like path segments or slash-bearing values. The previous
implementation passed derived path elements to `filepath.Join`, which could
allow cache-root escape or unintended cache-key normalization.

The patch adds a shared local cache path builder that rejects:

- empty or absolute path components;
- backslashes;
- empty slash segments;
- `.` and `..` slash segments;
- any final path that is not local to the configured cache root.

## Tests

```bash
GOTOOLCHAIN=go1.24.6 go test ./clients/datasource -count=1 -v
GOTOOLCHAIN=go1.24.6 go test ./enricher/transitivedependency/pomxml -count=1 -v
GOTOOLCHAIN=go1.24.6 go test ./enricher/transitivedependency/requirements -count=1 -v
```

## Security Note

This hardens the Maven and PyPI datasource local registry caches against
traversal and cache-key confusion from attacker-controlled Maven coordinates,
Maven snapshot metadata, or PyPI file URLs. It does not change network registry
URL construction except by refusing to use invalid values for local cache
read/write when a local registry cache is configured.
