### PR TITLE
Do not fail Linux distro EndOfLife if not a linux distro

### DIFF
--- a/detector/endoflife/linuxdistro/linuxdistro.go
+++ b/detector/endoflife/linuxdistro/linuxdistro.go
@@ -17,6 +17,7 @@ package linuxdistro
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/osv-scalibr/detector"
@@ -89,10 +90,10 @@ var eolDetector = map[string]func(map[string]string, scalibrfs.FS) bool{
 func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, px *packageindex.PackageIndex) (inventory.Finding, error) {
 	osRelease, err := osrelease.GetOSRelease(scanRoot.FS)
 	if err != nil {
+		if errors.Is(err, osrelease.ErrNotADistro) {
+			return inventory.Finding{}, nil
+		}
 		return inventory.Finding{}, err
-	}
-	if osRelease == nil {
-		return inventory.Finding{}, nil
 	}
 	distro, ok := osRelease["ID"]
 	if !ok {

--- a/detector/endoflife/linuxdistro/linuxdistro.go
+++ b/detector/endoflife/linuxdistro/linuxdistro.go
@@ -91,6 +91,9 @@ func (d Detector) Scan(ctx context.Context, scanRoot *scalibrfs.ScanRoot, px *pa
 	if err != nil {
 		return inventory.Finding{}, err
 	}
+	if osRelease == nil {
+		return inventory.Finding{}, nil
+	}
 	distro, ok := osRelease["ID"]
 	if !ok {
 		return inventory.Finding{}, err

--- a/detector/endoflife/linuxdistro/linuxdistro_test.go
+++ b/detector/endoflife/linuxdistro/linuxdistro_test.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,8 +36,17 @@ func (f fakeFS) Open(name string) (fs.File, error) {
 func (fakeFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	return nil, errors.New("not implemented")
 }
-func (fakeFS) Stat(name string) (fs.FileInfo, error) {
-	return nil, errors.New("not implemented")
+func (f fakeFS) Stat(name string) (fs.FileInfo, error) {
+	for path := range f {
+		if path == name {
+			return os.Stat(f[path])
+		}
+		rel, err := filepath.Rel(name, path)
+		if err == nil && !strings.HasPrefix(rel, "..") {
+			return os.Stat("testdata")
+		}
+	}
+	return nil, os.ErrNotExist
 }
 
 func TestEOLLinuxDistro(t *testing.T) {
@@ -110,6 +121,13 @@ func TestEOLLinuxDistro(t *testing.T) {
 			fsys: fakeFS{
 				"etc/os-release": "testdata/ubuntu_22.04_os_release",
 				"/etc/apt/sources.list.d/ubuntu-esm-infra.sources": "testdata/ubuntu-esm-infra.sources",
+			},
+		},
+		{
+			name: "not-an-os",
+			now:  "2026-01-01",
+			fsys: fakeFS{
+				"go.mod": "testdata/not-used",
 			},
 		},
 	}

--- a/extractor/filesystem/os/osrelease/osrelease.go
+++ b/extractor/filesystem/os/osrelease/osrelease.go
@@ -28,6 +28,11 @@ import (
 func GetOSRelease(fs scalibrfs.FS) (map[string]string, error) {
 	paths := []string{"etc/os-release", "usr/lib/os-release"}
 
+	if _, err := fs.Stat("etc"); os.IsNotExist(err) {
+		// Probably not a linux filesystem
+		return nil, nil
+	}
+
 	for _, p := range paths {
 		f, err := fs.Open(p)
 		if err != nil {

--- a/extractor/filesystem/os/osrelease/osrelease.go
+++ b/extractor/filesystem/os/osrelease/osrelease.go
@@ -17,6 +17,7 @@ package osrelease
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -24,13 +25,17 @@ import (
 	scalibrfs "github.com/google/osv-scalibr/fs"
 )
 
+// ErrNotADistro is returned when GetOSRelease is passed a filesystem which isn't
+// a Linux ditribution.
+var ErrNotADistro error = errors.New("does not have expected distro os-release file")
+
 // GetOSRelease tries different os-release locations and parses the first found.
 func GetOSRelease(fs scalibrfs.FS) (map[string]string, error) {
 	paths := []string{"etc/os-release", "usr/lib/os-release"}
 
 	if _, err := fs.Stat("etc"); os.IsNotExist(err) {
 		// Probably not a linux filesystem
-		return nil, nil
+		return nil, ErrNotADistro
 	}
 
 	for _, p := range paths {

--- a/extractor/filesystem/os/osrelease/osrelease_test.go
+++ b/extractor/filesystem/os/osrelease/osrelease_test.go
@@ -127,8 +127,8 @@ func TestNotAnOS(t *testing.T) {
 	d := t.TempDir()
 
 	got, err := osrelease.GetOSRelease(scalibrfs.DirFS(d))
-	if err != nil {
-		t.Fatalf("Got error on empty FS: %v", err)
+	if !errors.Is(err, osrelease.ErrNotADistro) {
+		t.Fatalf("Got unexpected error on empty FS: %v", err)
 	}
 	if got != nil {
 		t.Fatalf("Got OS data on empty FS: %+v", got)

--- a/extractor/filesystem/os/osrelease/osrelease_test.go
+++ b/extractor/filesystem/os/osrelease/osrelease_test.go
@@ -122,3 +122,15 @@ func TestGetOSRelease(t *testing.T) {
 		})
 	}
 }
+
+func TestNotAnOS(t *testing.T) {
+	d := t.TempDir()
+
+	got, err := osrelease.GetOSRelease(scalibrfs.DirFS(d))
+	if err != nil {
+		t.Fatalf("Got error on empty FS: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Got OS data on empty FS: %+v", got)
+	}
+}


### PR DESCRIPTION
Trying to use Scalibr to scan a source code repository, I noticed that the `endoflife/linuxdistro` check was failing because the source code repo wasn't a Linux distro at all.  Most other detectors seem to fail silently if they are not relevant, but this one fails with "file does not exist" when the FS is not a distro.

