### PR TITLE
vulnmatch: use Debian source package names for OSV matching

### DIFF
--- a/enricher/vulnmatch/osvdev/osvdev.go
+++ b/enricher/vulnmatch/osvdev/osvdev.go
@@ -229,11 +229,12 @@ func (e *Enricher) makeVulnerabilitiesRequest(ctx context.Context, vulnIDs []str
 }
 
 func pkgToQuery(pkg *extractor.Package) *osvapipb.Query {
-	if pkg.Name != "" && !pkg.Ecosystem().IsEmpty() && pkg.Version != "" {
+	name := pkg.OSVPackageName()
+	if name != "" && !pkg.Ecosystem().IsEmpty() && pkg.Version != "" {
 		// TODO(#1222): Ecosystems could return ecosystems
 		return &osvapipb.Query{
 			Package: &osvpb.Package{
-				Name:      pkg.Name,
+				Name:      name,
 				Ecosystem: pkg.Ecosystem().String(),
 			},
 			Param: &osvapipb.Query_Version{

--- a/enricher/vulnmatch/osvdev/osvdev_test.go
+++ b/enricher/vulnmatch/osvdev/osvdev_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/osv-scalibr/enricher/vulnmatch/osvdev"
 	"github.com/google/osv-scalibr/enricher/vulnmatch/osvdev/fakeclient"
 	"github.com/google/osv-scalibr/extractor"
+	dpkgmeta "github.com/google/osv-scalibr/extractor/filesystem/os/dpkg/metadata"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/inventory/vex"
 	"github.com/google/osv-scalibr/purl"
@@ -532,5 +533,51 @@ func TestEnrich(t *testing.T) {
 				t.Errorf("Enrich(%v): unexpected diff (-want +got): %v", tt.packages, diff)
 			}
 		})
+	}
+}
+
+func TestEnrich_UsesDebianSourceNameForOSVQueries(t *testing.T) {
+	pkg := &extractor.Package{
+		Name:     "util-linux-extra",
+		Version:  "2.38.1-5+b1",
+		PURLType: purl.TypeDebian,
+		Metadata: &dpkgmeta.Metadata{
+			PackageName: "util-linux-extra",
+			SourceName:  "util-linux",
+			OSID:        "Debian",
+			OSVersionID: "12",
+		},
+	}
+
+	vuln := &osvpb.Vulnerability{
+		Id: "GHSA-test-debian-source-name",
+		Affected: []*osvpb.Affected{
+			{
+				Package: &osvpb.Package{
+					Ecosystem: "Debian:12",
+					Name:      "util-linux",
+				},
+				Versions: []string{"2.38.1-5+b1"},
+			},
+		},
+	}
+
+	client := fakeclient.New(map[string][]*osvpb.Vulnerability{
+		"util-linux:2.38.1-5+b1:": {vuln},
+	})
+
+	e := osvdev.NewWithClient(client, 0)
+	inv := &inventory.Inventory{Packages: []*extractor.Package{pkg}}
+
+	if err := e.Enrich(t.Context(), &enricher.ScanInput{}, inv); err != nil {
+		t.Fatalf("Enrich() error: %v", err)
+	}
+
+	if len(inv.PackageVulns) != 1 {
+		t.Fatalf("expected 1 vulnerability match, got %d", len(inv.PackageVulns))
+	}
+
+	if inv.PackageVulns[0].Vulnerability.GetId() != vuln.GetId() {
+		t.Fatalf("expected vulnerability %q, got %q", vuln.GetId(), inv.PackageVulns[0].Vulnerability.GetId())
 	}
 }

--- a/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go
+++ b/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go
@@ -134,6 +134,7 @@ func hasGitRangeForRepo(affected *osvpb.Affected, repo string) bool {
 
 // IsAffected returns true if the Vulnerability applies to the package version of the Package
 func IsAffected(v *osvpb.Vulnerability, pkg *extractor.Package) bool {
+	osvName := pkg.OSVPackageName()
 	for _, affected := range v.GetAffected() {
 		// assume we're dealing with a git-source package whose name is the git repository, and that the version is the tag
 		// the underlying commit has been resolved to (somehow), meaning we can check if it's in the versions listed by the advisory
@@ -148,7 +149,7 @@ func IsAffected(v *osvpb.Vulnerability, pkg *extractor.Package) bool {
 			continue
 		}
 		if osvecosystem.MustParse(affected.GetPackage().GetEcosystem()).Equal(pkg.Ecosystem()) &&
-			affected.GetPackage().GetName() == pkg.Name {
+			affected.GetPackage().GetName() == osvName {
 			if len(affected.GetRanges()) == 0 && len(affected.GetVersions()) == 0 {
 				continue
 			}

--- a/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability_test.go
+++ b/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability_test.go
@@ -653,3 +653,31 @@ func TestOSV_EcosystemsWithSuffix(t *testing.T) {
 		t.Errorf("Expected OSV to affect package version %s but it did not", "0.0.0")
 	}
 }
+
+func TestOSV_DebianSourceNameMismatchFalseNegative(t *testing.T) {
+	vuln := buildOSVWithAffected(
+		&osvpb.Affected{
+			Package: &osvpb.Package{
+				Ecosystem: "Debian:12",
+				Name:      "util-linux",
+			},
+			Versions: []string{"2.38.1-5+b1"},
+		},
+	)
+
+	pkg := &extractor.Package{
+		Name:     "util-linux-extra",
+		Version:  "2.38.1-5+b1",
+		PURLType: purl.TypeDebian,
+		Metadata: &metadata.Metadata{
+			PackageName: "util-linux-extra",
+			SourceName:  "util-linux",
+			OSID:        "Debian",
+			OSVersionID: "12",
+		},
+	}
+
+	if !vulns.IsAffected(vuln, pkg) {
+		t.Fatalf("expected Debian advisory keyed by source package name %q to affect binary package %q when SourceName metadata matches", "util-linux", "util-linux-extra")
+	}
+}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -17,6 +17,7 @@ package extractor
 
 import (
 	"github.com/google/osv-scalibr/binary/proto/metadata"
+	dpkgmeta "github.com/google/osv-scalibr/extractor/filesystem/os/dpkg/metadata"
 	"github.com/google/osv-scalibr/inventory/location"
 	"github.com/google/osv-scalibr/inventory/osvecosystem"
 	"github.com/google/osv-scalibr/inventory/vex"
@@ -110,6 +111,20 @@ func LocationFromPathAndLine(path string, line int) PackageLocation {
 			},
 		},
 	}
+}
+
+// OSVPackageName returns the package name that should be used for exact OSV matching.
+// Some ecosystems preserve multiple package name forms in metadata; when that happens,
+// the canonical advisory identity should be preferred over the human-readable Name field.
+func (p *Package) OSVPackageName() string {
+	switch m := p.Metadata.(type) {
+	case *dpkgmeta.Metadata:
+		if m.SourceName != "" {
+			return m.SourceName
+		}
+	}
+
+	return p.Name
 }
 
 // PURL returns the Package URL of this package.

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -117,11 +117,8 @@ func LocationFromPathAndLine(path string, line int) PackageLocation {
 // Some ecosystems preserve multiple package name forms in metadata; when that happens,
 // the canonical advisory identity should be preferred over the human-readable Name field.
 func (p *Package) OSVPackageName() string {
-	switch m := p.Metadata.(type) {
-	case *dpkgmeta.Metadata:
-		if m.SourceName != "" {
-			return m.SourceName
-		}
+	if m, ok := p.Metadata.(*dpkgmeta.Metadata); ok && m.SourceName != "" {
+		return m.SourceName
 	}
 
 	return p.Name


### PR DESCRIPTION
Fixes GHSA-8wp9-j8qc-xc53. This change teaches OSV matching to use the Debian source package name when it is available in extracted metadata instead of relying only on the human-readable binary package name. Tests run: go test ./enricher/vulnmatch/osvlocal/internal/vulns -run TestOSV_DebianSourceNameMismatchFalseNegative and go test ./enricher/vulnmatch/osvdev -run TestEnrich_UsesDebianSourceNameForOSVQueries.