### PR TITLE
annotator/osduplicate: avoid suppressing manifest-only dependency groups

### DIFF
--- a/annotator/osduplicate/dpkg/dpkg_test.go
+++ b/annotator/osduplicate/dpkg/dpkg_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/osv-scalibr/annotator/osduplicate/dpkg"
 	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/extractor"
+	osv "github.com/google/osv-scalibr/extractor/filesystem/osv"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/inventory/vex"
@@ -161,6 +162,43 @@ Package: dpkg-pkg-name
 						Justification:   vex.ComponentNotPresent,
 						MatchesAllVulns: true,
 					}},
+				},
+			},
+		},
+		{
+			desc: "manifest_path_claimed_by_dpkg_does_not_suppress_manifest_packages",
+			txt: `
+-- var/lib/dpkg/info/dpkg-pkg-name.list --
+/app/package-lock.json
+-- var/lib/apt/lists/ports.ubuntu.com_ubuntu_dists_noble-updates_main_binary-arm64_Packages --
+Package: dpkg-pkg-name
+`,
+			packages: []*extractor.Package{
+				{
+					Name:     "left-pad",
+					Version:  "1.3.0",
+					Metadata: &osv.DepGroupMetadata{},
+					Location: extractor.LocationFromPath("app/package-lock.json"),
+				},
+				{
+					Name:     "lodash",
+					Version:  "4.17.20",
+					Metadata: &osv.DepGroupMetadata{},
+					Location: extractor.LocationFromPath("app/package-lock.json"),
+				},
+			},
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "left-pad",
+					Version:  "1.3.0",
+					Metadata: &osv.DepGroupMetadata{},
+					Location: extractor.LocationFromPath("app/package-lock.json"),
+				},
+				{
+					Name:     "lodash",
+					Version:  "4.17.20",
+					Metadata: &osv.DepGroupMetadata{},
+					Location: extractor.LocationFromPath("app/package-lock.json"),
 				},
 			},
 		},

--- a/annotator/osduplicate/osduplicate.go
+++ b/annotator/osduplicate/osduplicate.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
+	osv "github.com/google/osv-scalibr/extractor/filesystem/osv"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/inventory"
 )
@@ -44,19 +45,26 @@ pkgLoop:
 				continue pkgLoop
 			}
 		}
-		loc := pkg.Location.Descriptor.File.Path
-
-		// If ScanConfig.StoreAbsolutePath is on, this will be an absolute path.
-		// Convert to relative in these cases.
-		// Root starts and ends in a slash while relative paths don't, so this will only
-		// take effect for absolute paths.
-		loc = strings.TrimPrefix(loc, rootPrefix)
-
-		if prev, ok := locationToPKGs[loc]; ok {
-			locationToPKGs[loc] = append(prev, pkg)
-		} else {
-			locationToPKGs[loc] = []*extractor.Package{pkg}
+		for _, loc := range duplicateLocations(pkg, rootPrefix) {
+			if prev, ok := locationToPKGs[loc]; ok {
+				locationToPKGs[loc] = append(prev, pkg)
+			} else {
+				locationToPKGs[loc] = []*extractor.Package{pkg}
+			}
 		}
 	}
 	return locationToPKGs
+}
+
+func duplicateLocations(pkg *extractor.Package, rootPrefix string) []string {
+	if _, ok := pkg.Metadata.(osv.DepGroups); ok && len(pkg.Location.Related) == 0 {
+		// Packages extracted from lockfiles/manifests frequently only point at the
+		// dependency descriptor path. That is not strong enough evidence to claim the
+		// package is already provided by an OS package.
+		return nil
+	}
+
+	loc := pkg.Location.Descriptor.File.Path
+	loc = strings.TrimPrefix(loc, rootPrefix)
+	return []string{loc}
 }

--- a/annotator/osduplicate/osduplicate_test.go
+++ b/annotator/osduplicate/osduplicate_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/osv-scalibr/annotator/osduplicate"
 	"github.com/google/osv-scalibr/extractor"
+	osv "github.com/google/osv-scalibr/extractor/filesystem/osv"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/inventory/location"
@@ -86,6 +87,19 @@ func TestBuildLocationToPKGsMap(t *testing.T) {
 					},
 				}},
 			},
+		},
+		{
+			desc: "skip_descriptor_only_depgroup_packages",
+			inventory: &inventory.Inventory{
+				Packages: []*extractor.Package{
+					{
+						Name:     "package",
+						Metadata: &osv.DepGroupMetadata{},
+						Location: extractor.LocationFromPath("package-lock.json"),
+					},
+				},
+			},
+			want: map[string][]*extractor.Package{},
 		},
 		{
 			desc: "ignore_os_packages",


### PR DESCRIPTION
Fixes GHSA-hf2r-2x9v-rrj4. This change prevents osduplicate from treating descriptor-only dependency-group packages (for example manifest-only lockfile entries) as evidence that an OS package already provides the dependency. Tests run: go test ./annotator/osduplicate -run TestBuildLocationToPKGsMap and go test ./annotator/osduplicate/dpkg -run TestAnnotate/manifest_path_claimed_by_dpkg_does_not_suppress_manifest_packages.