### PR TITLE
Filter invalid ExFAT entries during EmbeddedFS Scanning

### DIFF
--- a/extractor/filesystem/embeddedfs/common/common.go
+++ b/extractor/filesystem/embeddedfs/common/common.go
@@ -308,6 +308,14 @@ func ExtractAllRecursiveNtfs(fs *parser.NTFSContext, srcPath, destPath string) e
 	return nil
 }
 
+// isInvalidEntry checks for ".", "..", "$"-prefixed, and "/"-containing entries in ExFAT.
+func isInvalidEntry(entry string) bool {
+	if entry == "" || entry == "." || entry == ".." || strings.HasPrefix(entry, "$") || strings.Contains(entry, "/") {
+		return true
+	}
+	return false
+}
+
 // ExtractAllRecursiveExFAT extracts all files from an exFAT filesystem to a temporary directory recursively.
 func ExtractAllRecursiveExFAT(section *io.SectionReader, dst string) error {
 	er := exfat.NewExfatReader(section)
@@ -329,6 +337,10 @@ func ExtractAllRecursiveExFAT(section *io.SectionReader, dst string) error {
 		node := nodes[relPath]
 		resPath := strings.ReplaceAll(relPath, "\\", string(os.PathSeparator))
 		outPath := filepath.Join(dst, resPath)
+
+		if isInvalidEntry(resPath) {
+			continue
+		}
 
 		sde := node.StreamDirectoryEntry()
 		if node.IsDirectory() {


### PR DESCRIPTION
Originally introduced in https://github.com/google/osv-scalibr/pull/1904. Since https://github.com/google/osv-scalibr/pull/1904 will no longer be merged in favor of https://github.com/google/osv-scalibr/pull/2088 and it will take some time for https://github.com/google/osv-scalibr/pull/2088 to be merged, I decoupled this change from https://github.com/google/osv-scalibr/pull/1904 to urgently fix the associated Arbitrary File Write vulnerability