### PR TITLE
Add JavaScript reachability enricher backed by Jelly

### DIFF
--- a/enricher/enricher.go
+++ b/enricher/enricher.go
@@ -41,6 +41,7 @@ var (
 		// Reachability enrichers need to run after vulnmatch enrichers (in certain configurations).
 		"reachability/go/source",
 		"reachability/rust",
+		"reachability/javascript",
 		// Base image attribution enricher need to run after base image enricher.
 		"baseimage",
 		"ffa/baseimageattr",

--- a/enricher/enricher.go
+++ b/enricher/enricher.go
@@ -47,6 +47,7 @@ var (
 		// Reachability enrichers need to run after vulnmatch enrichers (in certain configurations).
 		"reachability/go/source",
 		"reachability/rust",
+		"reachability/javascript",
 		// Base image attribution enricher need to run after base image enricher.
 		"baseimage",
 		"ffa/baseimageattr",

--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/osv-scalibr/enricher/packagedeprecation"
 	govcsource "github.com/google/osv-scalibr/enricher/reachability/go/source"
 	"github.com/google/osv-scalibr/enricher/reachability/java"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript"
 	"github.com/google/osv-scalibr/enricher/reachability/rust"
 	"github.com/google/osv-scalibr/enricher/secrets/convert"
 	"github.com/google/osv-scalibr/enricher/secrets/hashicorp"
@@ -202,6 +203,7 @@ var (
 		java.Name:       {java.New},
 		govcsource.Name: {govcsource.New},
 		rust.Name:       {rust.New},
+		javascript.Name: {javascript.New},
 	}
 
 	// TransitiveDependency enrichers.

--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/osv-scalibr/enricher/packagedeprecation"
 	govcsource "github.com/google/osv-scalibr/enricher/reachability/go/source"
 	"github.com/google/osv-scalibr/enricher/reachability/java"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript"
 	"github.com/google/osv-scalibr/enricher/reachability/rust"
 	"github.com/google/osv-scalibr/enricher/secrets/convert"
 	"github.com/google/osv-scalibr/enricher/secrets/hashicorp"
@@ -214,6 +215,7 @@ var (
 		java.Name:       {java.New},
 		govcsource.Name: {protoCfg(govcsource.New)},
 		rust.Name:       {protoCfg(rust.New)},
+		javascript.Name: {protoCfg(javascript.New)},
 	}
 
 	// TransitiveDependency enrichers.

--- a/enricher/reachability/javascript/corpus/corpus.go
+++ b/enricher/reachability/javascript/corpus/corpus.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package corpus loads the per-CVE vulnerability metadata corpus built by
+// the reachability project and exposes it as a lookup indexed by OSV ID.
+package corpus
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	osvpb "github.com/ossf/osv-schema/bindings/go/osvschema"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// Location is the Jelly-extension `loc` field (sentinel-loc technique).
+// Not part of the upstream OSV schema.
+type Location struct {
+	Filename string    `json:"filename"`
+	Start    *Position `json:"start,omitempty"`
+	End      *Position `json:"end,omitempty"`
+}
+
+// Position is line/column inside a source file.
+type Position struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+// Entry is one corpus record: an OSV vulnerability augmented with the
+// reachability-project's Jelly-pattern fields (loc + patterns).
+//
+// OSV is the parsed proto; entries returned by Lookup share storage and
+// must be treated as read-only. Mutating fields here will affect every
+// other holder of the same id's entries.
+type Entry struct {
+	OSV      *osvpb.Vulnerability
+	Loc      *Location
+	Patterns []string
+}
+
+// rawEntry mirrors the on-disk JSON shape; OSV is held as raw JSON so we
+// can hand it to protojson, which handles proto-specific quirks like
+// enum-string parsing for Range.Type ("SEMVER" → Range_SEMVER).
+type rawEntry struct {
+	OSV      json.RawMessage `json:"osv"`
+	Loc      *Location       `json:"loc,omitempty"`
+	Patterns []string        `json:"patterns,omitempty"`
+}
+
+// MarshalJSON serializes Entry back to the on-disk shape, using protojson
+// for the OSV portion so Range.Type round-trips as a string ("SEMVER")
+// rather than the proto integer. Jelly's --vulnerabilities consumer
+// expects the string form.
+func (e Entry) MarshalJSON() ([]byte, error) {
+	osvJSON, err := protojson.Marshal(e.OSV)
+	if err != nil {
+		return nil, fmt.Errorf("marshal osv: %w", err)
+	}
+	return json.Marshal(rawEntry{OSV: osvJSON, Loc: e.Loc, Patterns: e.Patterns})
+}
+
+// Corpus is the loaded metadata, indexed by OSV id.
+type Corpus struct {
+	byID map[string][]Entry
+}
+
+// Load reads and parses a corpus.json file produced by the reachability
+// project's build step.
+func Load(path string) (*Corpus, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read corpus: %w", err)
+	}
+
+	var raws []rawEntry
+	if err := json.Unmarshal(data, &raws); err != nil {
+		return nil, fmt.Errorf("parse corpus: %w", err)
+	}
+
+	c := &Corpus{byID: make(map[string][]Entry, len(raws))}
+	for i, r := range raws {
+		v := &osvpb.Vulnerability{}
+		if err := protojson.Unmarshal(r.OSV, v); err != nil {
+			return nil, fmt.Errorf("corpus entry %d: parse osv: %w", i, err)
+		}
+		defaultRangeType(v)
+		id := v.GetId()
+		if id == "" {
+			return nil, fmt.Errorf("corpus entry %d: missing osv.id", i)
+		}
+		if len(r.Patterns) == 0 && r.Loc == nil {
+			return nil, fmt.Errorf("corpus entry %d (%s): must have patterns[] or loc", i, id)
+		}
+		c.byID[id] = append(c.byID[id], Entry{OSV: v, Loc: r.Loc, Patterns: r.Patterns})
+	}
+	return c, nil
+}
+
+// defaultRangeType fills Range.Type = SEMVER on any range the corpus author
+// left implicit. Without this the proto enum defaults to UNSPECIFIED and
+// protojson.Marshal silently omits "type" when we hand the entry back to
+// Jelly's --vulnerabilities consumer, which expects the string form.
+// SEMVER is the only sensible default for npm — the only ecosystem this
+// enricher targets.
+func defaultRangeType(v *osvpb.Vulnerability) {
+	for _, a := range v.GetAffected() {
+		for _, r := range a.GetRanges() {
+			if r != nil && r.GetType() == osvpb.Range_UNSPECIFIED {
+				r.Type = osvpb.Range_SEMVER
+			}
+		}
+	}
+}
+
+// Lookup returns the entries for the given OSV id, or (nil, false) if none.
+func (c *Corpus) Lookup(osvID string) ([]Entry, bool) {
+	es, ok := c.byID[osvID]
+	return es, ok && len(es) > 0
+}
+
+// Size returns the total number of entries across all ids.
+func (c *Corpus) Size() int {
+	n := 0
+	for _, es := range c.byID {
+		n += len(es)
+	}
+	return n
+}

--- a/enricher/reachability/javascript/corpus/corpus_test.go
+++ b/enricher/reachability/javascript/corpus/corpus_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package corpus_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/corpus"
+)
+
+const twoEntryCorpus = `[
+  {
+    "osv": {
+      "id": "GHSA-fv66-9v8q-g76r",
+      "affected": [
+        {
+          "package": { "ecosystem": "npm", "name": "react-server-dom-webpack" },
+          "ranges": [{"events":[{"introduced":"19.0.0"},{"fixed":"19.0.1"}]}]
+        }
+      ]
+    },
+    "loc": { "filename": "__jelly_sentinel_suppress_module_wide_sink__" },
+    "patterns": ["call <react-server-dom-webpack/**>.{decodeReply}"]
+  },
+  {
+    "osv": {
+      "id": "GHSA-j5w5-568x-rq53",
+      "affected": [
+        { "package": { "ecosystem": "npm", "name": "fake" } }
+      ]
+    },
+    "patterns": ["call <fake>.sink"]
+  }
+]`
+
+func writeTempCorpus(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "corpus.json")
+	if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+func TestLoad_HappyPath(t *testing.T) {
+	path := writeTempCorpus(t, twoEntryCorpus)
+
+	c, err := corpus.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	entries, ok := c.Lookup("GHSA-fv66-9v8q-g76r")
+	if !ok {
+		t.Fatalf("lookup for existing id returned ok=false")
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if len(entries[0].Patterns) != 1 {
+		t.Fatalf("want 1 pattern, got %d", len(entries[0].Patterns))
+	}
+	if got := entries[0].OSV.GetId(); got != "GHSA-fv66-9v8q-g76r" {
+		t.Errorf("OSV.GetId() = %q, want GHSA-fv66-9v8q-g76r", got)
+	}
+
+	_, ok = c.Lookup("GHSA-does-not-exist")
+	if ok {
+		t.Errorf("lookup for missing id returned ok=true")
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := corpus.Load(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err == nil {
+		t.Fatal("Load: want error for missing file, got nil")
+	}
+}
+
+func TestLoad_MalformedJSON(t *testing.T) {
+	path := writeTempCorpus(t, `{not json`)
+	_, err := corpus.Load(path)
+	if err == nil {
+		t.Fatal("Load: want error for malformed JSON, got nil")
+	}
+}
+
+func TestLoad_RejectsEntryWithoutPatternsOrLoc(t *testing.T) {
+	path := writeTempCorpus(t, `[{"osv":{"id":"GHSA-x"}}]`)
+	_, err := corpus.Load(path)
+	if err == nil {
+		t.Fatal("Load: want error for entry with no patterns and no loc")
+	}
+}
+
+func TestLoad_AllowsLocOnly(t *testing.T) {
+	path := writeTempCorpus(t, `[{"osv":{"id":"GHSA-x"},"loc":{"filename":"a.js","start":{"line":1,"column":1},"end":{"line":1,"column":2}}}]`)
+	c, err := corpus.Load(path)
+	if err != nil {
+		t.Fatalf("loc-only entry should be valid: %v", err)
+	}
+	if _, ok := c.Lookup("GHSA-x"); !ok {
+		t.Fatal("loc-only entry was dropped")
+	}
+}
+
+func TestLoad_AllowsPatternsOnly(t *testing.T) {
+	path := writeTempCorpus(t, `[{"osv":{"id":"GHSA-x"},"patterns":["call <x>.y"]}]`)
+	c, err := corpus.Load(path)
+	if err != nil {
+		t.Fatalf("patterns-only entry should be valid: %v", err)
+	}
+	if _, ok := c.Lookup("GHSA-x"); !ok {
+		t.Fatal("patterns-only entry was dropped")
+	}
+}

--- a/enricher/reachability/javascript/depgraph/depgraph.go
+++ b/enricher/reachability/javascript/depgraph/depgraph.go
@@ -1,0 +1,401 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package depgraph builds a resolved dependency graph by walking the
+// node_modules tree on disk. It is used by the enricher to compute
+// per-vulnerability path-package scopes for the VulnPathOnly heuristic.
+//
+// Supported layouts:
+//   - npm v3+ / yarn classic: flat <node_modules>/<pkg> with nested
+//     <node_modules>/<pkg>/node_modules/<dep> when version conflicts force it.
+//
+// Not handled (returns a less precise graph; callers should fall through to
+// IgnoreDeps):
+//   - pnpm with its .pnpm flat store + symlink farm.
+//   - yarn Plug'n'Play (no node_modules tree).
+package depgraph
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// PackageNode is one resolved package in the on-disk tree.
+type PackageNode struct {
+	Name    string
+	Version string
+	// Dir is the absolute path to the package directory.
+	Dir string
+	// Dependencies are the resolved deps of this package, in deterministic
+	// order. Each entry is a key into Graph.Nodes (name@version).
+	Dependencies []string
+}
+
+// Graph is the resolved layout indexed by name@version. Multiple installed
+// versions of the same package are distinct nodes.
+type Graph struct {
+	// Nodes maps "name@version" → PackageNode.
+	Nodes map[string]*PackageNode
+	// Roots are direct deps of the project root: keys into Nodes.
+	Roots []string
+}
+
+// Key returns the canonical Graph.Nodes key for a (name, version) pair.
+func Key(name, version string) string { return name + "@" + version }
+
+// Build walks <projectRoot>/node_modules, reads each package.json, and
+// returns the resolved graph. Returns (nil, nil) if no node_modules tree
+// exists at projectRoot — the caller should treat that as "no graph
+// available" and skip VulnPathOnly.
+func Build(projectRoot string) (*Graph, error) {
+	// Normalize projectRoot: a trailing slash or other non-canonical form
+	// breaks the literal-equality compares used downstream (fallback Roots
+	// discovery, etc.) when WalkDir returns the cleaned form.
+	projectRoot = filepath.Clean(projectRoot)
+	rootNM := filepath.Join(projectRoot, "node_modules")
+	if _, err := os.Stat(rootNM); errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	g := &Graph{Nodes: map[string]*PackageNode{}}
+
+	// Phase A: discover every (name, version, dir) triple under any
+	// node_modules in the tree. Each entry is a candidate node; resolution
+	// from one node's package.json `dependencies` to a concrete (name@version)
+	// neighbor happens in Phase B with full visibility.
+	type discovered struct {
+		name, version, dir string
+		jsonDeps           map[string]string
+	}
+	var all []discovered
+	var rootJSON struct {
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+	if b, err := os.ReadFile(filepath.Join(projectRoot, "package.json")); err == nil {
+		_ = json.Unmarshal(b, &rootJSON)
+	}
+
+	err := filepath.WalkDir(rootNM, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// Skip unreadable entries rather than abort the whole graph;
+			// best-effort is better than nothing for a heuristic input.
+			return nil //nolint:nilerr // intentional: skip + continue walk
+		}
+		if d.IsDir() || d.Name() != "package.json" {
+			return nil
+		}
+		// Skip nested package.json files that aren't at the canonical
+		// <…/node_modules/<pkg>/package.json> position (e.g. test fixtures
+		// shipped inside a package's own src/ tree).
+		dir := filepath.Dir(path)
+		parent := filepath.Dir(dir)
+		grandparent := filepath.Base(parent)
+		if grandparent != "node_modules" {
+			// Scoped packages: <…/node_modules/@scope/pkg/package.json>
+			ggparent := filepath.Base(filepath.Dir(parent))
+			if !strings.HasPrefix(filepath.Base(parent), "@") || ggparent != "node_modules" {
+				return nil
+			}
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil //nolint:nilerr // intentional: skip unreadable file
+		}
+		var pj struct {
+			Name         string            `json:"name"`
+			Version      string            `json:"version"`
+			Dependencies map[string]string `json:"dependencies"`
+		}
+		if err := json.Unmarshal(b, &pj); err != nil {
+			return nil //nolint:nilerr // intentional: skip malformed package.json
+		}
+		if pj.Name == "" || pj.Version == "" {
+			return nil
+		}
+		all = append(all, discovered{
+			name: pj.Name, version: pj.Version, dir: dir, jsonDeps: pj.Dependencies,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Phase B: build the Nodes map and resolve each package's
+	// `dependencies` entries to a concrete neighbor by walking up parent
+	// node_modules dirs — that's npm's actual resolution algorithm.
+	for _, d := range all {
+		k := Key(d.name, d.version)
+		if _, exists := g.Nodes[k]; exists {
+			continue
+		}
+		g.Nodes[k] = &PackageNode{Name: d.name, Version: d.version, Dir: d.dir}
+	}
+	for _, d := range all {
+		k := Key(d.name, d.version)
+		node := g.Nodes[k]
+		seen := map[string]bool{}
+		for depName := range d.jsonDeps {
+			resolved := resolveDepFrom(d.dir, depName, rootNM)
+			if resolved == "" {
+				continue
+			}
+			if seen[resolved] {
+				continue
+			}
+			seen[resolved] = true
+			node.Dependencies = append(node.Dependencies, resolved)
+		}
+	}
+
+	// Roots: direct deps declared in <root>/package.json (dependencies +
+	// devDependencies — both are reachable from the project's entry points
+	// at scan time, and reachability scope must include either).
+	rootSeen := map[string]bool{}
+	addRoot := func(name string) {
+		resolved := resolveDepFrom(projectRoot, name, rootNM)
+		if resolved == "" || rootSeen[resolved] {
+			return
+		}
+		rootSeen[resolved] = true
+		g.Roots = append(g.Roots, resolved)
+	}
+	for n := range rootJSON.Dependencies {
+		addRoot(n)
+	}
+	for n := range rootJSON.DevDependencies {
+		addRoot(n)
+	}
+	// Fallback if no package.json: treat every top-level node_modules entry
+	// as a root, so VulnPathOnly still has something to walk from.
+	if len(g.Roots) == 0 {
+		for _, d := range all {
+			// Plain top-level: <projectRoot>/node_modules/<pkg>
+			if filepath.Dir(filepath.Dir(d.dir)) == projectRoot && filepath.Base(filepath.Dir(d.dir)) == "node_modules" {
+				k := Key(d.name, d.version)
+				if !rootSeen[k] {
+					rootSeen[k] = true
+					g.Roots = append(g.Roots, k)
+				}
+			}
+			// Scoped top-level: <projectRoot>/node_modules/@scope/<pkg>
+			// d.dir       = <projectRoot>/node_modules/@scope/<pkg>
+			// Dir(d.dir)  = <projectRoot>/node_modules/@scope
+			// Dir^2(d.dir)= <projectRoot>/node_modules
+			// Dir^3(d.dir)= <projectRoot>
+			if strings.HasPrefix(filepath.Base(filepath.Dir(d.dir)), "@") &&
+				filepath.Base(filepath.Dir(filepath.Dir(d.dir))) == "node_modules" &&
+				filepath.Dir(filepath.Dir(filepath.Dir(d.dir))) == projectRoot {
+				k := Key(d.name, d.version)
+				if !rootSeen[k] {
+					rootSeen[k] = true
+					g.Roots = append(g.Roots, k)
+				}
+			}
+		}
+	}
+	sort.Strings(g.Roots) // deterministic across runs
+
+	return g, nil
+}
+
+// resolveDepFrom mimics Node's lookup: start at fromDir, check its own
+// node_modules/<depName>/package.json, then walk up toward rootNM. Returns
+// the Graph key of the resolved package or "" if not found.
+func resolveDepFrom(fromDir, depName, rootNM string) string {
+	dir := fromDir
+	root := filepath.Dir(rootNM)
+	for {
+		candidate := filepath.Join(dir, "node_modules", depName, "package.json")
+		if b, err := os.ReadFile(candidate); err == nil {
+			var pj struct {
+				Name    string `json:"name"`
+				Version string `json:"version"`
+			}
+			if err := json.Unmarshal(b, &pj); err == nil && pj.Version != "" {
+				name := pj.Name
+				if name == "" {
+					name = depName
+				}
+				return Key(name, pj.Version)
+			}
+		}
+		if dir == root || dir == "/" || dir == "." {
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// IsReachable reports whether any node with the given package name is
+// reachable from at least one project root via the Dependencies edges.
+// Name-only — for the version-precise check use IsReachableKey, which
+// callers should prefer when they have a (name, version) pair (a
+// multi-version graph may have foo@1 reachable and foo@2 orphan).
+func (g *Graph) IsReachable(name string) bool {
+	if g == nil {
+		return false
+	}
+	reachable := bfsReachable(g, g.Roots)
+	for k, n := range g.Nodes {
+		if n.Name == name && reachable[k] {
+			return true
+		}
+	}
+	return false
+}
+
+// IsReachableKey reports whether the specific (name, version) node is
+// reachable from at least one project root. Use this when the vuln
+// targets a specific installed version — IsReachable's name-only check
+// would say "reachable" if any other version of the same name has a
+// root path, even when the requested version is orphaned.
+func (g *Graph) IsReachableKey(name, version string) bool {
+	if g == nil {
+		return false
+	}
+	k := Key(name, version)
+	if _, ok := g.Nodes[k]; !ok {
+		return false
+	}
+	reachable := bfsReachable(g, g.Roots)
+	return reachable[k]
+}
+
+// PathsToLeaf is the name-only variant of PathsToLeafKey, retained for
+// callers that genuinely want the union across all installed versions of
+// the same name. New callers should prefer PathsToLeafKey when a
+// (name, version) pair is available.
+func (g *Graph) PathsToLeaf(leafName string) []string {
+	return g.pathsTo(func(n *PackageNode) bool { return n.Name == leafName })
+}
+
+// PathsToLeafKey returns the package-name set on any root→(name@version)
+// path, EXCLUDING the leaf itself. Use this version-precise form to
+// avoid unioning ancestors from a sibling version of the same name (a
+// multi-version graph would otherwise widen VulnPathOnly's include-set
+// to packages routing to the wrong installed copy).
+func (g *Graph) PathsToLeafKey(leafName, leafVersion string) []string {
+	want := Key(leafName, leafVersion)
+	return g.pathsTo(func(n *PackageNode) bool {
+		return Key(n.Name, n.Version) == want
+	})
+}
+
+func (g *Graph) pathsTo(match func(*PackageNode) bool) []string {
+	if g == nil || len(g.Nodes) == 0 {
+		return nil
+	}
+	// Find every node matching the predicate.
+	var leaves []string
+	for k, n := range g.Nodes {
+		if match(n) {
+			leaves = append(leaves, k)
+		}
+	}
+	if len(leaves) == 0 {
+		return nil
+	}
+	leafSet := map[string]bool{}
+	for _, k := range leaves {
+		leafSet[k] = true
+	}
+
+	// A node is "on a path" iff it's reachable from a root AND can reach a
+	// leaf. Compute both directions and intersect.
+	reachableFromRoot := bfsReachable(g, g.Roots)
+	parentMap := buildReverseAdj(g)
+	canReachLeaf := map[string]bool{}
+	queue := append([]string(nil), leaves...)
+	for _, k := range leaves {
+		canReachLeaf[k] = true
+	}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, parent := range parentMap[cur] {
+			if canReachLeaf[parent] {
+				continue
+			}
+			canReachLeaf[parent] = true
+			queue = append(queue, parent)
+		}
+	}
+
+	nameSet := map[string]bool{}
+	for k := range g.Nodes {
+		if !reachableFromRoot[k] || !canReachLeaf[k] {
+			continue
+		}
+		if leafSet[k] {
+			continue
+		}
+		nameSet[g.Nodes[k].Name] = true
+	}
+	out := make([]string, 0, len(nameSet))
+	for n := range nameSet {
+		out = append(out, n)
+	}
+	sort.Strings(out) // deterministic argv for jelly --include-packages
+	return out
+}
+
+// bfsReachable returns the set of keys reachable from any seed by following
+// Dependencies edges.
+func bfsReachable(g *Graph, seeds []string) map[string]bool {
+	out := map[string]bool{}
+	queue := append([]string(nil), seeds...)
+	for _, s := range seeds {
+		out[s] = true
+	}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		node, ok := g.Nodes[cur]
+		if !ok {
+			continue
+		}
+		for _, d := range node.Dependencies {
+			if out[d] {
+				continue
+			}
+			out[d] = true
+			queue = append(queue, d)
+		}
+	}
+	return out
+}
+
+// buildReverseAdj returns child → parents.
+func buildReverseAdj(g *Graph) map[string][]string {
+	rev := map[string][]string{}
+	for k, n := range g.Nodes {
+		for _, d := range n.Dependencies {
+			rev[d] = append(rev[d], k)
+		}
+	}
+	return rev
+}

--- a/enricher/reachability/javascript/depgraph/depgraph_test.go
+++ b/enricher/reachability/javascript/depgraph/depgraph_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package depgraph_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/depgraph"
+)
+
+// writePkg materializes a minimal package.json at the given path. Caller
+// owns mkdir for the parent dir.
+func writePkg(t *testing.T, path, name, version string, deps map[string]string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	b.WriteString(`{"name":"`)
+	b.WriteString(name)
+	b.WriteString(`","version":"`)
+	b.WriteString(version)
+	b.WriteString(`"`)
+	if len(deps) > 0 {
+		b.WriteString(`,"dependencies":{`)
+		first := true
+		for k, v := range deps {
+			if !first {
+				b.WriteByte(',')
+			}
+			first = false
+			b.WriteString(`"`)
+			b.WriteString(k)
+			b.WriteString(`":"`)
+			b.WriteString(v)
+			b.WriteString(`"`)
+		}
+		b.WriteByte('}')
+	}
+	b.WriteByte('}')
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuild_FlatLayout(t *testing.T) {
+	root := t.TempDir()
+	writePkg(t, filepath.Join(root, "package.json"), "rootapp", "1.0.0", map[string]string{
+		"a": "^1.0.0", "b": "^1.0.0",
+	})
+	writePkg(t, filepath.Join(root, "node_modules", "a", "package.json"), "a", "1.0.0", map[string]string{"c": "^1.0.0"})
+	writePkg(t, filepath.Join(root, "node_modules", "b", "package.json"), "b", "1.0.0", nil)
+	writePkg(t, filepath.Join(root, "node_modules", "c", "package.json"), "c", "1.0.0", nil)
+
+	g, err := depgraph.Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if g == nil {
+		t.Fatal("Build returned nil graph")
+	}
+	if len(g.Nodes) != 3 {
+		t.Errorf("want 3 nodes, got %d: %v", len(g.Nodes), g.Nodes)
+	}
+	if len(g.Roots) != 2 {
+		t.Errorf("want 2 roots, got %d: %v", len(g.Roots), g.Roots)
+	}
+	if !slices.Contains(g.Roots, "a@1.0.0") || !slices.Contains(g.Roots, "b@1.0.0") {
+		t.Errorf("expected a@1.0.0 and b@1.0.0 in roots, got %v", g.Roots)
+	}
+	a := g.Nodes["a@1.0.0"]
+	if !slices.Contains(a.Dependencies, "c@1.0.0") {
+		t.Errorf("a should depend on c@1.0.0, got %v", a.Dependencies)
+	}
+}
+
+func TestBuild_NestedMultiVersion(t *testing.T) {
+	// Two versions of "semver" — one hoisted at the top, one nested
+	// because parent forces a different version.
+	root := t.TempDir()
+	writePkg(t, filepath.Join(root, "package.json"), "rootapp", "1.0.0", map[string]string{
+		"pkg-a": "^1.0.0", "pkg-b": "^1.0.0",
+	})
+	writePkg(t, filepath.Join(root, "node_modules", "pkg-a", "package.json"), "pkg-a", "1.0.0", map[string]string{"semver": "^7.0.0"})
+	writePkg(t, filepath.Join(root, "node_modules", "pkg-b", "package.json"), "pkg-b", "1.0.0", map[string]string{"semver": "^6.0.0"})
+	writePkg(t, filepath.Join(root, "node_modules", "semver", "package.json"), "semver", "7.5.0", nil)
+	writePkg(t, filepath.Join(root, "node_modules", "pkg-b", "node_modules", "semver", "package.json"), "semver", "6.3.0", nil)
+
+	g, err := depgraph.Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if _, ok := g.Nodes["semver@7.5.0"]; !ok {
+		t.Errorf("missing semver@7.5.0; have %v", keys(g))
+	}
+	if _, ok := g.Nodes["semver@6.3.0"]; !ok {
+		t.Errorf("missing semver@6.3.0; have %v", keys(g))
+	}
+	// pkg-a/semver should resolve to 7.5.0 (hoisted), pkg-b/semver to 6.3.0
+	// (nested) — that's npm's actual resolution.
+	if got := g.Nodes["pkg-a@1.0.0"].Dependencies; !slices.Contains(got, "semver@7.5.0") {
+		t.Errorf("pkg-a → expected semver@7.5.0, got %v", got)
+	}
+	if got := g.Nodes["pkg-b@1.0.0"].Dependencies; !slices.Contains(got, "semver@6.3.0") {
+		t.Errorf("pkg-b → expected semver@6.3.0, got %v", got)
+	}
+}
+
+func TestBuild_ScopedPackage(t *testing.T) {
+	root := t.TempDir()
+	writePkg(t, filepath.Join(root, "package.json"), "rootapp", "1.0.0", map[string]string{
+		"@scope/pkg": "^1.0.0",
+	})
+	writePkg(t, filepath.Join(root, "node_modules", "@scope", "pkg", "package.json"), "@scope/pkg", "1.0.0", nil)
+
+	g, err := depgraph.Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if _, ok := g.Nodes["@scope/pkg@1.0.0"]; !ok {
+		t.Errorf("scoped package missing; have %v", keys(g))
+	}
+}
+
+func TestBuild_NoNodeModulesReturnsNilNil(t *testing.T) {
+	root := t.TempDir()
+	g, err := depgraph.Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if g != nil {
+		t.Errorf("want nil graph when node_modules absent, got %v", g)
+	}
+}
+
+func TestPathsToLeaf_ExcludesLeafAndUnreachable(t *testing.T) {
+	root := t.TempDir()
+	writePkg(t, filepath.Join(root, "package.json"), "rootapp", "1.0.0", map[string]string{
+		"reachable-root": "^1.0.0", "unrelated": "^1.0.0",
+	})
+	writePkg(t, filepath.Join(root, "node_modules", "reachable-root", "package.json"), "reachable-root", "1.0.0", map[string]string{
+		"middle": "^1.0.0",
+	})
+	writePkg(t, filepath.Join(root, "node_modules", "middle", "package.json"), "middle", "1.0.0", map[string]string{
+		"vulnpkg": "^1.0.0",
+	})
+	writePkg(t, filepath.Join(root, "node_modules", "vulnpkg", "package.json"), "vulnpkg", "1.0.0", nil)
+	writePkg(t, filepath.Join(root, "node_modules", "unrelated", "package.json"), "unrelated", "1.0.0", nil)
+
+	g, err := depgraph.Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	got := g.PathsToLeaf("vulnpkg")
+	want := map[string]bool{"reachable-root": true, "middle": true}
+	if len(got) != len(want) {
+		t.Fatalf("PathsToLeaf len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected package on path: %q", p)
+		}
+	}
+	if slices.Contains(got, "vulnpkg") {
+		t.Error("leaf must be excluded from PathsToLeaf result")
+	}
+	if slices.Contains(got, "unrelated") {
+		t.Error("unrelated package must not appear in path result")
+	}
+}
+
+func TestIsReachableKey_DistinguishesVersions(t *testing.T) {
+	// Multi-version setup: foo@1.0.0 reachable from root via direct dep,
+	// foo@2.0.0 nested under bar but bar is unreachable (no root path).
+	// Name-only IsReachable would say "reachable" for both; IsReachableKey
+	// must distinguish so a vuln on the orphan version isn't analyzed
+	// against the reachable copy's code.
+	root := t.TempDir()
+	writePkg(t, filepath.Join(root, "package.json"), "app", "1.0.0", map[string]string{
+		"foo": "^1.0.0", // direct dep at top
+	})
+	writePkg(t, filepath.Join(root, "node_modules", "foo", "package.json"), "foo", "1.0.0", nil)
+	// bar exists in the tree but root doesn't depend on it → orphan.
+	writePkg(t, filepath.Join(root, "node_modules", "bar", "package.json"), "bar", "1.0.0", map[string]string{
+		"foo": "^2.0.0",
+	})
+	writePkg(t, filepath.Join(root, "node_modules", "bar", "node_modules", "foo", "package.json"), "foo", "2.0.0", nil)
+
+	g, err := depgraph.Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !g.IsReachable("foo") {
+		t.Errorf("name-only IsReachable(foo) should be true (1.0.0 is reachable)")
+	}
+	if !g.IsReachableKey("foo", "1.0.0") {
+		t.Errorf("IsReachableKey(foo, 1.0.0) should be true")
+	}
+	if g.IsReachableKey("foo", "2.0.0") {
+		t.Errorf("IsReachableKey(foo, 2.0.0) should be false — bar is an orphan, foo@2 is unreachable via bar")
+	}
+}
+
+func TestPathsToLeaf_AbsentLeafReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	writePkg(t, filepath.Join(root, "package.json"), "r", "1.0.0", map[string]string{"a": "^1.0.0"})
+	writePkg(t, filepath.Join(root, "node_modules", "a", "package.json"), "a", "1.0.0", nil)
+	g, err := depgraph.Build(root)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := g.PathsToLeaf("not-installed"); len(got) != 0 {
+		t.Errorf("PathsToLeaf on absent leaf = %v, want []", got)
+	}
+}
+
+func keys(g *depgraph.Graph) []string {
+	out := make([]string, 0, len(g.Nodes))
+	for k := range g.Nodes {
+		out = append(out, k)
+	}
+	return out
+}

--- a/enricher/reachability/javascript/entrypoints/entrypoints.go
+++ b/enricher/reachability/javascript/entrypoints/entrypoints.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package entrypoints infers Jelly entry-point file/directory paths from a
+// project's package.json and tsconfig.json. Returning an empty slice means
+// "no inference possible — fall back to whole-project".
+package entrypoints
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Infer reads package.json and tsconfig.json at projectRoot and returns a
+// deterministic list of entry-point paths suitable for Jelly's positional
+// arguments. Paths are absolute and guaranteed to reside within
+// projectRoot — `../`-bearing entries that resolve outside are silently
+// dropped to prevent a malicious or corrupt package.json from steering
+// jelly into reading e.g. /etc/* or sibling-project files. Returns nil
+// when no signal is found, in which case the caller should pass nil so
+// Jelly defaults to [projectRoot].
+func Infer(projectRoot string) []string {
+	absRoot, err := filepath.Abs(projectRoot)
+	if err != nil {
+		absRoot = projectRoot
+	}
+	absRoot = filepath.Clean(absRoot)
+	// Resolve symlinks on the root so a symlinked project dir is compared
+	// against its real target. Falls back to absRoot if EvalSymlinks fails
+	// (e.g. the dir doesn't exist yet — every entry then also fails the
+	// stat below).
+	realRoot := absRoot
+	if r, err := filepath.EvalSymlinks(absRoot); err == nil {
+		realRoot = r
+	}
+	rootPrefix := realRoot + string(filepath.Separator)
+	seen := map[string]bool{}
+	var out []string
+	add := func(rel string) {
+		if rel == "" {
+			return
+		}
+		abs := filepath.Clean(filepath.Join(absRoot, filepath.FromSlash(rel)))
+		// Lexical pre-check — cheap reject for obvious `../escapes`.
+		if abs != absRoot && !strings.HasPrefix(abs, absRoot+string(filepath.Separator)) {
+			return
+		}
+		// Resolve symlinks before final containment so an in-tree
+		// symlink pointing outside (e.g. /proj/cache -> /etc) is caught.
+		// When the path doesn't exist yet (a common case for pre-build
+		// projects whose `main` references not-yet-generated dist/) the
+		// lexical pre-check already proved containment — accept the
+		// declared path. Jelly will fail-loudly on missing files but
+		// can't escape the project root.
+		realAbs, err := filepath.EvalSymlinks(abs)
+		switch {
+		case err == nil:
+			if realAbs != realRoot && !strings.HasPrefix(realAbs, rootPrefix) {
+				return
+			}
+		case errors.Is(err, fs.ErrNotExist):
+			realAbs = abs // fall back to lexical containment (already passed)
+		default:
+			return
+		}
+		// Dedup on the resolved real path so two symlinks pointing at
+		// the same target don't both emit (jelly walks each entry).
+		if seen[realAbs] {
+			return
+		}
+		seen[realAbs] = true
+		out = append(out, abs)
+	}
+
+	for _, p := range fromPackageJSON(projectRoot) {
+		add(p)
+	}
+	for _, p := range fromTSConfig(projectRoot) {
+		add(p)
+	}
+	sort.Strings(out) // deterministic for tests and snapshot comparisons
+	return out
+}
+
+// fromPackageJSON pulls entry-point hints from a project's package.json:
+// the `bin` field (single string or name→path map), and the `main`
+// /`exports` fields (library public surface).
+func fromPackageJSON(projectRoot string) []string {
+	raw, err := os.ReadFile(filepath.Join(projectRoot, "package.json"))
+	if err != nil {
+		return nil
+	}
+	var pj struct {
+		Bin     json.RawMessage `json:"bin"`
+		Main    string          `json:"main"`
+		Module  string          `json:"module"`
+		Exports json.RawMessage `json:"exports"`
+	}
+	if err := json.Unmarshal(raw, &pj); err != nil {
+		return nil
+	}
+	var paths []string
+
+	// `bin` is either a string or { name: path }.
+	if len(pj.Bin) > 0 {
+		var s string
+		if json.Unmarshal(pj.Bin, &s) == nil && s != "" {
+			paths = append(paths, s)
+		} else {
+			var m map[string]string
+			if json.Unmarshal(pj.Bin, &m) == nil {
+				for _, v := range m {
+					if v != "" {
+						paths = append(paths, v)
+					}
+				}
+			}
+		}
+	}
+
+	if pj.Main != "" {
+		paths = append(paths, pj.Main)
+	}
+	if pj.Module != "" {
+		paths = append(paths, pj.Module)
+	}
+
+	// `exports` is recursively-nested string|map. Walk it and collect every
+	// string leaf — those are the package's published entry points.
+	for _, p := range walkExports(pj.Exports) {
+		if p != "" && !strings.HasPrefix(p, "#") {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+// walkExports returns every string leaf inside a package.json "exports"
+// value, which may be a string, an array of strings, or a map of strings to
+// further exports values (recursive).
+func walkExports(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		if s == "" {
+			return nil
+		}
+		return []string{s}
+	}
+	var arr []json.RawMessage
+	if json.Unmarshal(raw, &arr) == nil {
+		var out []string
+		for _, e := range arr {
+			out = append(out, walkExports(e)...)
+		}
+		return out
+	}
+	var m map[string]json.RawMessage
+	if json.Unmarshal(raw, &m) == nil {
+		var out []string
+		for _, v := range m {
+			out = append(out, walkExports(v)...)
+		}
+		return out
+	}
+	return nil
+}
+
+// fromTSConfig pulls entry-point hints from tsconfig.json's `files` and
+// `include` arrays. `include` entries are passed through as-is — Jelly
+// accepts both file paths and directories, and glob-resolving here would
+// duplicate Jelly's own walk.
+func fromTSConfig(projectRoot string) []string {
+	raw, err := os.ReadFile(filepath.Join(projectRoot, "tsconfig.json"))
+	if err != nil {
+		return nil
+	}
+	// tsconfig allows comments and trailing commas. Strip line comments
+	// only — full JSON5 parsing is overkill for a best-effort hint.
+	raw = stripLineComments(raw)
+	var tc struct {
+		Files   []string `json:"files"`
+		Include []string `json:"include"`
+	}
+	if err := json.Unmarshal(raw, &tc); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(tc.Files)+len(tc.Include))
+	out = append(out, tc.Files...)
+	// Drop glob-suffixed include entries like "src/**/*" — pass the prefix
+	// directory instead so Jelly's own entry-point walker handles it.
+	for _, inc := range tc.Include {
+		if i := strings.IndexAny(inc, "*?"); i >= 0 {
+			inc = strings.TrimRight(inc[:i], "/")
+		}
+		if inc != "" {
+			out = append(out, inc)
+		}
+	}
+	return out
+}
+
+// stripLineComments removes // line comments from a tsconfig.json byte slice.
+// It's deliberately string-blind (no awareness of strings containing "//"),
+// because tsconfig string values almost never contain // and the worst
+// outcome of a false trim is that the file fails to parse and we return nil.
+func stripLineComments(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	i := 0
+	for i < len(b) {
+		if i+1 < len(b) && b[i] == '/' && b[i+1] == '/' {
+			for i < len(b) && b[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		out = append(out, b[i])
+		i++
+	}
+	return out
+}

--- a/enricher/reachability/javascript/entrypoints/entrypoints_test.go
+++ b/enricher/reachability/javascript/entrypoints/entrypoints_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entrypoints_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/entrypoints"
+)
+
+func writeFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInfer_NoConfigsReturnsNil(t *testing.T) {
+	root := t.TempDir()
+	if got := entrypoints.Infer(root); got != nil {
+		t.Errorf("want nil with no package.json/tsconfig.json, got %v", got)
+	}
+}
+
+func TestInfer_PackageJSONMain(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "package.json", `{"main":"lib/index.js"}`)
+	writeFile(t, root, "lib/index.js", "")
+	got := entrypoints.Infer(root)
+	want := filepath.Join(root, "lib/index.js")
+	if !slices.Contains(got, want) {
+		t.Errorf("Infer = %v, want to contain %q", got, want)
+	}
+}
+
+func TestInfer_PackageJSONBinAsString(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "package.json", `{"bin":"bin/cli.js"}`)
+	writeFile(t, root, "bin/cli.js", "")
+	got := entrypoints.Infer(root)
+	want := filepath.Join(root, "bin/cli.js")
+	if !slices.Contains(got, want) {
+		t.Errorf("Infer = %v, want to contain %q", got, want)
+	}
+}
+
+func TestInfer_PackageJSONBinAsMap(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "package.json", `{"bin":{"foo":"bin/foo.js","bar":"bin/bar.js"}}`)
+	writeFile(t, root, "bin/foo.js", "")
+	writeFile(t, root, "bin/bar.js", "")
+	got := entrypoints.Infer(root)
+	for _, want := range []string{filepath.Join(root, "bin/foo.js"), filepath.Join(root, "bin/bar.js")} {
+		if !slices.Contains(got, want) {
+			t.Errorf("Infer missing %q in %v", want, got)
+		}
+	}
+}
+
+func TestInfer_PackageJSONExportsNested(t *testing.T) {
+	// Conditional exports: { ".": { "import": "./a.mjs", "require": "./a.cjs" } }
+	root := t.TempDir()
+	writeFile(t, root, "package.json",
+		`{"exports":{".":{"import":"./a.mjs","require":"./a.cjs"},"./util":"./util.js"}}`)
+	for _, f := range []string{"a.mjs", "a.cjs", "util.js"} {
+		writeFile(t, root, f, "")
+	}
+	got := entrypoints.Infer(root)
+	for _, want := range []string{filepath.Join(root, "a.mjs"), filepath.Join(root, "a.cjs"), filepath.Join(root, "util.js")} {
+		if !slices.Contains(got, want) {
+			t.Errorf("Infer missing %q in %v", want, got)
+		}
+	}
+}
+
+func TestInfer_AcceptsDeclaredButNotYetExisting(t *testing.T) {
+	// `main` points to a path that doesn't exist on disk yet. Common in
+	// pre-build / freshly-cloned projects: package.json declares
+	// `dist/index.js` but `npm run build` hasn't generated it.
+	// The lexical-containment pre-check already proves the declared
+	// path is under projectRoot, so it's safe to hand to jelly —
+	// jelly's own file open will surface the missing-file error
+	// without escaping the project root. Dropping the entry would
+	// silently widen jelly to a whole-project scan.
+	root := t.TempDir()
+	writeFile(t, root, "package.json", `{"main":"dist/index.js"}`)
+	got := entrypoints.Infer(root)
+	want := filepath.Join(root, "dist/index.js")
+	if !slices.Contains(got, want) {
+		t.Errorf("Infer should accept declared-but-not-yet-existing in-tree paths; got %v, want to contain %q", got, want)
+	}
+}
+
+func TestInfer_RejectsMissingPathThatEscapes(t *testing.T) {
+	// Even when the path doesn't exist, escape attempts via ../ must
+	// still be rejected by the lexical pre-check.
+	root := t.TempDir()
+	writeFile(t, root, "package.json", `{"main":"../../etc/hostname"}`)
+	got := entrypoints.Infer(root)
+	for _, p := range got {
+		if !strings.HasPrefix(p, root+string(filepath.Separator)) && p != root {
+			t.Errorf("escape via missing path: %q is outside project root %q", p, root)
+		}
+	}
+}
+
+func TestInfer_TSConfigFilesAndIncludeStripsGlobs(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "tsconfig.json", `{
+	  // line comments are tolerated
+	  "files": ["src/main.ts"],
+	  "include": ["src/**/*", "tests/setup.ts"]
+	}`)
+	writeFile(t, root, "src/main.ts", "")
+	writeFile(t, root, "src/extra.ts", "")
+	writeFile(t, root, "tests/setup.ts", "")
+	got := entrypoints.Infer(root)
+	// Glob "src/**/*" should be reduced to its prefix "src".
+	for _, want := range []string{
+		filepath.Join(root, "src/main.ts"),
+		filepath.Join(root, "src"),
+		filepath.Join(root, "tests/setup.ts"),
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("Infer missing %q in %v", want, got)
+		}
+	}
+}
+
+func TestInfer_RejectsPathsEscapingProjectRoot(t *testing.T) {
+	// Defense: a malicious or corrupt package.json can declare main as
+	// "../../etc/hostname". filepath.Join cleans this to /etc/hostname,
+	// which os.Stat may succeed on. The containment check must drop it
+	// before jelly sees it as an entry point.
+	root := t.TempDir()
+	// Use a real file outside root that absolutely exists on Linux: the
+	// project's own go.mod via a relative escape. Picking a path we
+	// EXPECT to be outside root is fine for the test.
+	writeFile(t, root, "package.json", `{"main":"../../etc/hostname"}`)
+	got := entrypoints.Infer(root)
+	for _, p := range got {
+		if !strings.HasPrefix(p, root+string(filepath.Separator)) && p != root {
+			t.Errorf("entry point %q escapes project root %q", p, root)
+		}
+	}
+}
+
+func TestInfer_Deduplicates(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "package.json", `{"main":"lib/index.js","module":"lib/index.js"}`)
+	writeFile(t, root, "lib/index.js", "")
+	got := entrypoints.Infer(root)
+	count := 0
+	want := filepath.Join(root, "lib/index.js")
+	for _, p := range got {
+		if p == want {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 occurrence of %q, got %d in %v", want, count, got)
+	}
+}

--- a/enricher/reachability/javascript/integration_test.go
+++ b/enricher/reachability/javascript/integration_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+// +build integration
+
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/inventory/vex"
+	osvpb "github.com/ossf/osv-schema/bindings/go/osvschema"
+)
+
+func corpusPath(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(wd, "testdata", "corpus.json")
+}
+
+func fixturePath(t *testing.T, cve, sub string) string {
+	t.Helper()
+	wd, _ := os.Getwd()
+	return filepath.Join(wd, "testdata", cve, sub)
+}
+
+func runEnricher(t *testing.T, root string, vulns []*inventory.PackageVuln) []*inventory.PackageVuln {
+	t.Helper()
+	e := javascript.NewWithConfig(javascript.Config{
+		MetadataFile:   corpusPath(t),
+		SubprojectRoot: root,
+	})
+	inv := &inventory.Inventory{PackageVulns: vulns}
+	if err := e.Enrich(context.Background(), nil, inv); err != nil {
+		t.Fatalf("Enrich: %v", err)
+	}
+	return inv.PackageVulns
+}
+
+func TestIntegration_GHSAfv66_Positive(t *testing.T) {
+	root := fixturePath(t, "GHSA-fv66-9v8q-g76r", "positive")
+	if _, err := os.Stat(filepath.Join(root, "node_modules")); err != nil {
+		t.Skipf("node_modules missing in %s; run `pnpm install` first", root)
+	}
+	vulns := []*inventory.PackageVuln{{
+		Vulnerability: &osvpb.Vulnerability{Id: "GHSA-fv66-9v8q-g76r"},
+		Package:       &extractor.Package{Name: "react-server-dom-webpack", Version: "19.2.0"},
+	}}
+	out := runEnricher(t, root, vulns)
+	if len(out[0].ExploitabilitySignals) != 0 {
+		t.Errorf("positive: want 0 signals (reachable), got %d", len(out[0].ExploitabilitySignals))
+	}
+}
+
+func TestIntegration_GHSAfv66_Negative(t *testing.T) {
+	root := fixturePath(t, "GHSA-fv66-9v8q-g76r", "negative")
+	if _, err := os.Stat(filepath.Join(root, "node_modules")); err != nil {
+		t.Skipf("node_modules missing in %s; run `pnpm install` first", root)
+	}
+	vulns := []*inventory.PackageVuln{{
+		Vulnerability: &osvpb.Vulnerability{Id: "GHSA-fv66-9v8q-g76r"},
+		Package:       &extractor.Package{Name: "react-server-dom-webpack", Version: "19.2.0"},
+	}}
+	out := runEnricher(t, root, vulns)
+	sigs := out[0].ExploitabilitySignals
+	if len(sigs) != 1 {
+		t.Fatalf("negative: want 1 signal (unreachable), got %d", len(sigs))
+	}
+	if sigs[0].Justification != vex.VulnerableCodeNotInExecutePath {
+		t.Errorf("justification = %v, want VulnerableCodeNotInExecutePath", sigs[0].Justification)
+	}
+}
+
+func TestIntegration_GHSAj5w5_Positive(t *testing.T) {
+	root := fixturePath(t, "GHSA-j5w5-568x-rq53", "positive")
+	if _, err := os.Stat(filepath.Join(root, "node_modules")); err != nil {
+		t.Skipf("node_modules missing in %s; run `pnpm install` first", root)
+	}
+	vulns := []*inventory.PackageVuln{{
+		Vulnerability: &osvpb.Vulnerability{Id: "GHSA-j5w5-568x-rq53"},
+		Package:       &extractor.Package{Name: "@evomap/evolver"},
+	}}
+	out := runEnricher(t, root, vulns)
+	if len(out[0].ExploitabilitySignals) != 0 {
+		t.Errorf("positive: want 0 signals, got %d", len(out[0].ExploitabilitySignals))
+	}
+}
+
+func TestIntegration_GHSAj5w5_Negative(t *testing.T) {
+	root := fixturePath(t, "GHSA-j5w5-568x-rq53", "negative")
+	if _, err := os.Stat(filepath.Join(root, "node_modules")); err != nil {
+		t.Skipf("node_modules missing in %s; run `pnpm install` first", root)
+	}
+	vulns := []*inventory.PackageVuln{{
+		Vulnerability: &osvpb.Vulnerability{Id: "GHSA-j5w5-568x-rq53"},
+		Package:       &extractor.Package{Name: "@evomap/evolver"},
+	}}
+	out := runEnricher(t, root, vulns)
+	sigs := out[0].ExploitabilitySignals
+	if len(sigs) != 1 {
+		t.Fatalf("negative: want 1 signal, got %d", len(sigs))
+	}
+	if sigs[0].Justification != vex.VulnerableCodeNotInExecutePath {
+		t.Errorf("wrong justification: %v", sigs[0].Justification)
+	}
+}
+

--- a/enricher/reachability/javascript/internal/types.go
+++ b/enricher/reachability/javascript/internal/types.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package internal holds types shared across the javascript enricher's
+// sub-packages without creating import cycles.
+package internal
+
+// FailedPackage identifies an (npm-name, version) pair that the
+// materializer couldn't fetch / install OR that the post-materialize
+// dep-graph walk couldn't locate on disk. Lives in internal/ to avoid
+// dragging the materialize and scan packages into each other's import
+// graphs just to share this struct.
+//
+// **Contract**: Version MUST be set when the failure pertains to a
+// specific version. An empty Version is the explicit "all installed
+// versions of this name are absent / unanalyzable" signal — every vuln
+// matching the name is then Skipped regardless of its own version. Use
+// the empty form ONLY when the entire package is missing from the
+// resolved tree; otherwise pass a concrete Version so peers at other
+// installed versions are not accidentally suppressed.
+type FailedPackage struct {
+	Name    string
+	Version string
+}
+
+// VulnRef is a trimmed reference to a vulnerability as it travels through
+// scan/ + corpus/. It bundles the OSV id, the access-path patterns from
+// corpus, and a back-pointer to the PackageVuln for final signal emission.
+type VulnRef struct {
+	OSVID              string
+	PackageName        string
+	PackageVersion     string
+	AccessPathPatterns []string
+	// Any additional fields (e.g. VulnChainDetails equivalent) that later
+	// tasks need should be added here, not re-threaded through signatures.
+}
+
+// Result is produced by scan.Scan per VulnRef. Ref points back to the
+// originating request so callers can attribute the verdict 1:1 instead of
+// keying on OSVID (which can repeat when one CVE affects multiple
+// installed packages).
+type Result struct {
+	Ref        *VulnRef
+	OSVID      string
+	Reachable  bool // true = matched, false = confirmed unreachable
+	Skipped    bool // true = we didn't actually analyze; emit no signal
+	SkipReason string
+}

--- a/enricher/reachability/javascript/javascript.go
+++ b/enricher/reachability/javascript/javascript.go
@@ -1,0 +1,364 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package javascript provides an Enricher that uses the Jelly static
+// analyzer to determine whether npm-ecosystem vulnerabilities are reachable
+// from the project being scanned.
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/enricher"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/corpus"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/depgraph"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/entrypoints"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/internal"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/jelly"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/materialize"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/scan"
+	"github.com/google/osv-scalibr/enricher/vulnmatch/osvdev"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/packagelockjson"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/pnpmlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/yarnlock"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/inventory/vex"
+	"github.com/google/osv-scalibr/log"
+	"github.com/google/osv-scalibr/plugin"
+)
+
+// Name is the unique name of this enricher.
+const Name = "reachability/javascript"
+
+// defaultMaxFileSize bounds the size of any individual source file Jelly
+// will analyze. 512 KiB is large enough for any legitimate hand-written
+// module, small enough to skip minified vendor bundles that would otherwise
+// dominate analysis time and memory.
+const defaultMaxFileSize int64 = 524288
+
+// Config bundles the enricher's runtime options.
+type Config struct {
+	MetadataFile   string // path to corpus.json produced by reachability project
+	SubprojectRoot string // default "." (CWD); tests override
+}
+
+// Enricher is the JavaScript/npm reachability enricher.
+type Enricher struct {
+	cfg         Config
+	jellyClient jelly.Client // nil means use realClient
+}
+
+// NewWithConfig constructs an Enricher with explicit config (for tests and
+// future wiring from PluginConfig).
+func NewWithConfig(cfg Config) *Enricher {
+	return &Enricher{cfg: cfg}
+}
+
+// NewWithConfigAndClient is the test-seam constructor that injects a
+// custom Jelly client.
+func NewWithConfigAndClient(cfg Config, client jelly.Client) *Enricher {
+	return &Enricher{cfg: cfg, jellyClient: client}
+}
+
+// Name returns the enricher name.
+func (Enricher) Name() string { return Name }
+
+// Version returns the enricher version.
+func (Enricher) Version() int { return 0 }
+
+// Requirements returns the plugin capabilities.
+func (Enricher) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{
+		Network:            plugin.NetworkOnline,
+		DirectFS:           true,
+		RunningSystem:      true,
+		AllowUnsafePlugins: true,
+	}
+}
+
+// RequiredPlugins returns the plugins this enricher depends on. The vulnmatch
+// enricher is required so inv.PackageVulns is populated before we run.
+func (Enricher) RequiredPlugins() []string {
+	return []string{packagelockjson.Name, pnpmlock.Name, yarnlock.Name, osvdev.Name}
+}
+
+// New constructs a new Enricher. cfg is currently unused; metadata-file path
+// is read from the SCALIBR_JELLY_METADATA_FILE environment variable until
+// PluginConfig proto wiring is added.
+func New(cfg *cpb.PluginConfig) (enricher.Enricher, error) {
+	return NewWithConfig(Config{
+		MetadataFile: os.Getenv("SCALIBR_JELLY_METADATA_FILE"),
+	}), nil
+}
+
+// Enrich runs the reachability pipeline.
+//
+// Skips with nil only when prerequisites legitimately aren't met (no
+// configured metadata file, jelly toolchain absent, no in-scope vulns).
+// Configuration mistakes (corpus parse failure) and runtime failures
+// (materialize, scan) propagate as errors so operators see a non-SUCCEEDED
+// plugin status rather than silent no-op.
+func (e *Enricher) Enrich(ctx context.Context, input *enricher.ScanInput, inv *inventory.Inventory) error {
+	if e.cfg.MetadataFile == "" {
+		log.Debug("reachability/javascript: SCALIBR_JELLY_METADATA_FILE not set, skipping")
+		return nil
+	}
+	client := e.jellyClient
+	if client == nil {
+		client = jelly.NewRealClient()
+	}
+	if !client.Available(ctx) {
+		log.Info("reachability/javascript: jelly toolchain not available, skipping")
+		return nil
+	}
+
+	corp, err := corpus.Load(e.cfg.MetadataFile)
+	if err != nil {
+		return fmt.Errorf("corpus load: %w", err)
+	}
+
+	// Select in-scope vulns.
+	var in []*internal.VulnRef
+	var backrefs []*inventory.PackageVuln
+	for _, pv := range inv.PackageVulns {
+		if pv.Package == nil || pv.Vulnerability == nil {
+			continue
+		}
+		entries, ok := corp.Lookup(pv.Vulnerability.Id)
+		if !ok {
+			continue
+		}
+		var patterns []string
+		for _, ent := range entries {
+			patterns = append(patterns, ent.Patterns...)
+		}
+		in = append(in, &internal.VulnRef{
+			OSVID:              pv.Vulnerability.Id,
+			PackageName:        pv.Package.Name,
+			PackageVersion:     pv.Package.Version,
+			AccessPathPatterns: patterns,
+		})
+		backrefs = append(backrefs, pv)
+	}
+	if len(in) == 0 {
+		return nil
+	}
+
+	root := e.cfg.SubprojectRoot
+	if root == "" && input != nil && input.ScanRoot != nil {
+		root = input.ScanRoot.Path
+	}
+	if root == "" {
+		root = "."
+	}
+
+	// Phase 0: materialize (uses pre-existing node_modules if present).
+	layout, err := materialize.Materialize(ctx, materialize.Spec{
+		SubprojectRoot: root,
+	})
+	if err != nil {
+		return fmt.Errorf("materialize: %w", err)
+	}
+	defer func() {
+		if err := layout.Cleanup(); err != nil {
+			log.Warnf("reachability/javascript: layout cleanup: %v", err)
+		}
+	}()
+
+	// Phase 1+2: scan. Try VulnPathOnly first (narrow scope by walking
+	// node_modules for each vuln's path packages); on graph build failure
+	// or empty graph, that heuristic emits an empty include set which
+	// degrades to "scan only the leaf" — IgnoreDeps as the chained fallback
+	// is what actually rescues those cases.
+	heuristics, missingFromGraph := buildHeuristics(root, in)
+	failed := append([]internal.FailedPackage(nil), layout.FailedPackages...)
+	failed = append(failed, missingFromGraph...)
+	orch := &scan.Orchestrator{
+		Client:         client,
+		Corpus:         corp,
+		BaseDir:        root,
+		Heuristics:     heuristics,
+		Timeouts:       scan.DefaultTimeouts(),
+		FailedPackages: failed,
+		MaxFileSize:    defaultMaxFileSize,
+		EntryPoints:    entrypoints.Infer(root),
+		ExcludeEntries: stagingExcludes(layout),
+	}
+	results, err := orch.Scan(ctx, in)
+	if err != nil {
+		return fmt.Errorf("scan: %w", err)
+	}
+
+	// Map results back to PackageVulns by VulnRef pointer identity. Keying
+	// by OSVID would collapse two PackageVulns sharing the same CVE id
+	// (e.g. the same CVE present in two installed packages) into a single
+	// verdict, misattributing one package's reachability to the other.
+	byRef := make(map[*internal.VulnRef]*internal.Result, len(results))
+	for _, r := range results {
+		if r != nil && r.Ref != nil {
+			byRef[r.Ref] = r
+		}
+	}
+	for i, pv := range backrefs {
+		r, ok := byRef[in[i]]
+		if !ok || r == nil {
+			continue
+		}
+		if r.Skipped {
+			log.Debugf("reachability/javascript: %s skipped: %s", r.OSVID, r.SkipReason)
+			continue
+		}
+		if !r.Reachable && !hasOurSignal(pv.ExploitabilitySignals) {
+			pv.ExploitabilitySignals = append(pv.ExploitabilitySignals, &vex.FindingExploitabilitySignal{
+				Plugin:        Name,
+				Justification: vex.VulnerableCodeNotInExecutePath,
+			})
+		}
+	}
+	return nil
+}
+
+// stagingExcludes returns the jelly --exclude-entries arguments needed to
+// keep the materializer's hardlink-staging tree (and any stale one from a
+// previous SIGKILLed run) out of the analysis surface.
+//
+// When Layout.StagingPath is non-empty it's used to derive a project-
+// relative form (basename + `/<base>/**`) so any future change to the
+// staging directory name in materialize is honored automatically.
+// Otherwise the static `node_modules/.jelly` default is emitted to
+// guard against stale staging trees left behind by previous runs.
+//
+// Returns RELATIVE paths under the project root rather than absolute
+// ones: jelly's glob library treats `[`, `]`, `*`, `?`, `{`, `}` as
+// metacharacters, so a project path containing those (CI workspace
+// dirs are a frequent culprit, e.g. /tmp/build[123]/) would silently
+// defeat an absolute-path exclude.
+func stagingExcludes(l *materialize.Layout) []string {
+	rel := "node_modules/.jelly"
+	if l != nil && l.StagingPath != "" {
+		// StagingPath is <root>/node_modules/<basename>. Derive the
+		// project-relative form so the exclude matches even if the
+		// staging dir name changes in the future.
+		base := filepath.Base(l.StagingPath)
+		if base != "" && base != "." && base != "/" {
+			rel = "node_modules/" + base
+		}
+	}
+	return []string{rel, rel + "/**"}
+}
+
+// nameInGraph reports whether ANY node with the given package name is
+// present in the graph (regardless of root-reachability). Used by the
+// empty-version FailedPackage gate so we don't issue a nameOnly
+// wholesale-skip when a copy of the package IS on disk — even if that
+// copy is orphaned, peers at other concrete versions may still be
+// analyzable.
+func nameInGraph(g *depgraph.Graph, name string) bool {
+	if g == nil {
+		return false
+	}
+	for _, n := range g.Nodes {
+		if n.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// hasOurSignal reports whether this enricher has already attached a signal
+// to a PackageVuln. Guards Enrich against duplicating signals when the
+// enricher is invoked twice on the same Inventory (test harness, retry).
+func hasOurSignal(sigs []*vex.FindingExploitabilitySignal) bool {
+	for _, s := range sigs {
+		if s != nil && s.Plugin == Name {
+			return true
+		}
+	}
+	return false
+}
+
+// buildHeuristics returns the scan heuristic chain AND the list of vuln
+// leaf packages that are absent (or orphaned) in the on-disk dep graph.
+// The latter feeds Orchestrator.FailedPackages so vulns whose code is
+// either missing OR not reachable from any project root get Skipped
+// instead of silently marked unreachable.
+//
+// Empty-version vulns are NOT added to the missing list — partition's
+// version-blind name-only path would then suppress every other vuln of
+// the same name (including ones with concrete on-disk versions). We
+// can't classify them confidently, so let them flow through the
+// heuristic chain.
+//
+// VulnPathOnly is first when at least one vuln has a usable path; the
+// last entry is always IgnoreDeps as the safe fallback (jelly treats
+// dependencies as opaque). When depgraph.Build returns nil (no
+// node_modules), we can't trust missing-leaf detection and return no
+// FailedPackages.
+func buildHeuristics(root string, vulns []*internal.VulnRef) ([]scan.Heuristic, []internal.FailedPackage) {
+	graph, err := depgraph.Build(root)
+	if err != nil || graph == nil {
+		if err != nil {
+			log.Debugf("reachability/javascript: depgraph.Build failed: %v", err)
+		}
+		return []scan.Heuristic{scan.IgnoreDeps{}}, nil
+	}
+	// Per-VulnRef path map (keyed by pointer, not OSVID) so that two
+	// VulnRefs sharing one CVE id but living in different installed
+	// packages don't collide and overwrite each other's path list.
+	vulnPaths := make(map[*internal.VulnRef][]string, len(vulns))
+	var missing []internal.FailedPackage
+	haveUsablePath := false
+	for _, v := range vulns {
+		if v.PackageVersion == "" {
+			// Empty version is ambiguous — we can't classify a specific
+			// installed copy. Only mark missing if NO version of this
+			// name is installed at all. We MUST NOT key this on
+			// IsReachable (orphan-but-installed packages are not
+			// reachable from a root yet are present on disk — the
+			// nameOnly skip would then suppress vulns at concrete
+			// versions of the SAME name that ARE reachable).
+			if !nameInGraph(graph, v.PackageName) {
+				missing = append(missing, internal.FailedPackage{Name: v.PackageName})
+			}
+			continue
+		}
+		// Version-precise checks: avoid the multi-version trap where
+		// foo@1 is reachable and foo@2 is orphaned. IsReachableKey and
+		// PathsToLeafKey both pin to the exact installed copy this vuln
+		// targets.
+		if !graph.IsReachableKey(v.PackageName, v.PackageVersion) {
+			missing = append(missing, internal.FailedPackage{
+				Name:    v.PackageName,
+				Version: v.PackageVersion,
+			})
+			continue
+		}
+		paths := graph.PathsToLeafKey(v.PackageName, v.PackageVersion)
+		if len(paths) > 0 {
+			vulnPaths[v] = paths
+		}
+		haveUsablePath = true
+	}
+	if !haveUsablePath {
+		return []scan.Heuristic{scan.IgnoreDeps{}}, missing
+	}
+	return []scan.Heuristic{
+		scan.VulnPathOnly{VulnPathPackages: vulnPaths},
+		scan.IgnoreDeps{},
+	}, missing
+}

--- a/enricher/reachability/javascript/javascript_test.go
+++ b/enricher/reachability/javascript/javascript_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/jelly"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/inventory/vex"
+	osvpb "github.com/ossf/osv-schema/bindings/go/osvschema"
+)
+
+func TestEnrich_NoOpWhenJellyUnavailable(t *testing.T) {
+	// With an empty config, MetadataFile is unset → we skip cleanly.
+	e := javascript.NewWithConfig(javascript.Config{
+		MetadataFile: "", // unset: skip
+	})
+	inv := &inventory.Inventory{
+		PackageVulns: []*inventory.PackageVuln{
+			{
+				Vulnerability: &osvpb.Vulnerability{Id: "GHSA-x"},
+				Package:       &extractor.Package{Name: "lodash"},
+			},
+		},
+	}
+	if err := e.Enrich(context.Background(), nil, inv); err != nil {
+		t.Fatalf("Enrich: %v", err)
+	}
+	if len(inv.PackageVulns[0].ExploitabilitySignals) != 0 {
+		t.Errorf("expected no signals on skip, got %d", len(inv.PackageVulns[0].ExploitabilitySignals))
+	}
+}
+
+func TestEnrich_EmitsSignalOnUnreachable(t *testing.T) {
+	corpusPath := writeCorpus(t, `[
+	  {"osv":{"id":"GHSA-unreach","affected":[{"package":{"ecosystem":"npm","name":"lodash"}}]},"patterns":["call <lodash>.template"]}
+	]`)
+	proj := t.TempDir()
+	// Install a stub lodash package in node_modules so depgraph.Build sees
+	// it as on-disk; otherwise the enricher would (correctly) skip the
+	// vuln as "package not installed" and emit no signal.
+	installStubPkg(t, proj, "lodash", "4.17.21")
+	mockJelly := &jelly.MockClient{
+		AvailableResult: true,
+		ImportResult: jelly.ImportResult{
+			ReachablePackages: []jelly.ReachablePackage{{Name: "lodash"}},
+		},
+		FullScanResults: []jelly.ScanResult{
+			{Matches: map[string][]string{"GHSA-unreach": {}}}, // analyzed, no matches
+		},
+	}
+	e := javascript.NewWithConfigAndClient(javascript.Config{
+		MetadataFile:   corpusPath,
+		SubprojectRoot: proj,
+	}, mockJelly)
+
+	inv := &inventory.Inventory{
+		PackageVulns: []*inventory.PackageVuln{{
+			Vulnerability: &osvpb.Vulnerability{Id: "GHSA-unreach"},
+			Package:       &extractor.Package{Name: "lodash", Version: "4.17.21"},
+		}},
+	}
+	if err := e.Enrich(context.Background(), nil, inv); err != nil {
+		t.Fatalf("Enrich: %v", err)
+	}
+	sigs := inv.PackageVulns[0].ExploitabilitySignals
+	if len(sigs) != 1 {
+		t.Fatalf("want 1 signal, got %d", len(sigs))
+	}
+	if sigs[0].Justification != vex.VulnerableCodeNotInExecutePath {
+		t.Errorf("justification = %v, want VulnerableCodeNotInExecutePath", sigs[0].Justification)
+	}
+}
+
+func TestEnrich_NoSignalOnReachable(t *testing.T) {
+	corpusPath := writeCorpus(t, `[
+	  {"osv":{"id":"GHSA-reach","affected":[{"package":{"ecosystem":"npm","name":"lodash"}}]},"patterns":["call <lodash>.template"]}
+	]`)
+	proj := t.TempDir()
+	installStubPkg(t, proj, "lodash", "4.17.21")
+	mockJelly := &jelly.MockClient{
+		AvailableResult: true,
+		ImportResult: jelly.ImportResult{
+			ReachablePackages: []jelly.ReachablePackage{{Name: "lodash"}},
+		},
+		FullScanResults: []jelly.ScanResult{
+			{Matches: map[string][]string{"GHSA-reach": {"app.js:1:1:1:2"}}},
+		},
+	}
+	e := javascript.NewWithConfigAndClient(javascript.Config{
+		MetadataFile:   corpusPath,
+		SubprojectRoot: proj,
+	}, mockJelly)
+	inv := &inventory.Inventory{
+		PackageVulns: []*inventory.PackageVuln{{
+			Vulnerability: &osvpb.Vulnerability{Id: "GHSA-reach"},
+			Package:       &extractor.Package{Name: "lodash", Version: "4.17.21"},
+		}},
+	}
+	if err := e.Enrich(context.Background(), nil, inv); err != nil {
+		t.Fatalf("Enrich: %v", err)
+	}
+	if len(inv.PackageVulns[0].ExploitabilitySignals) != 0 {
+		t.Errorf("reachable vuln should emit no signal; got %d", len(inv.PackageVulns[0].ExploitabilitySignals))
+	}
+}
+
+func writeCorpus(t *testing.T, contents string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "corpus.json")
+	if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// installStubPkg writes a minimal valid package.json under
+// <proj>/node_modules/<name>/ so depgraph.Build records it as on-disk,
+// AND writes a root <proj>/package.json that declares the package as a
+// direct dependency so PathsToLeaf actually finds the leaf via a root.
+// Without the root declaration the leaf is "orphan in graph" — present
+// but unreachable from any root — and the enricher correctly skips it.
+func installStubPkg(t *testing.T, proj, name, version string) {
+	t.Helper()
+	dir := filepath.Join(proj, "node_modules", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pj := `{"name":"` + name + `","version":"` + version + `"}`
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pj), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Root package.json declaring this package as a dep, so depgraph
+	// treats it as reachable from a root rather than an orphan.
+	rootPJ := `{"name":"testapp","version":"0.0.0","dependencies":{"` + name + `":"^` + version + `"}}`
+	_ = os.WriteFile(filepath.Join(proj, "package.json"), []byte(rootPJ), 0o600)
+}

--- a/enricher/reachability/javascript/jelly/classify_internal_test.go
+++ b/enricher/reachability/javascript/jelly/classify_internal_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package jelly
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestClassify_ParentCanceled(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	run, runCancel := context.WithCancel(parent)
+	defer runCancel()
+	gotCause, gotErr := classify(parent, run, nil)
+	if gotCause != terminationCanceled {
+		t.Errorf("cause = %v, want terminationCanceled", gotCause)
+	}
+	if !errors.Is(gotErr, context.Canceled) {
+		t.Errorf("err = %v, want errors.Is(context.Canceled)", gotErr)
+	}
+}
+
+func TestClassify_ParentDeadlineExceeded(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	parent, cancel := context.WithDeadline(context.Background(), past)
+	defer cancel()
+	<-parent.Done() // ensure parent.Err() is non-nil
+	run, runCancel := context.WithCancel(parent)
+	defer runCancel()
+	gotCause, gotErr := classify(parent, run, errors.New("signal: killed"))
+	if gotCause != terminationCanceled {
+		t.Errorf("cause = %v, want terminationCanceled (parent deadline counts as cancellation upstream)", gotCause)
+	}
+	if !errors.Is(gotErr, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want errors.Is(context.DeadlineExceeded) (parent deadline propagated verbatim)", gotErr)
+	}
+}
+
+func TestClassify_LocalDeadlineExceeded(t *testing.T) {
+	parent := context.Background()
+	past := time.Now().Add(-time.Hour)
+	run, cancel := context.WithDeadline(context.Background(), past)
+	defer cancel()
+	<-run.Done()
+	waitErr := errors.New("signal: killed")
+	gotCause, gotErr := classify(parent, run, waitErr)
+	if gotCause != terminationTimedOut {
+		t.Errorf("cause = %v, want terminationTimedOut", gotCause)
+	}
+	// Local timeout returns waitErr unwrapped so callers can distinguish
+	// via cause; errors.Is(context.DeadlineExceeded) is intentionally
+	// false here (parent ctx never expired).
+	if errors.Is(gotErr, context.DeadlineExceeded) {
+		t.Errorf("local-timeout waitErr must NOT satisfy errors.Is(DeadlineExceeded); got %v", gotErr)
+	}
+	if !errors.Is(gotErr, waitErr) {
+		t.Errorf("err = %v, want the raw waitErr passed in", gotErr)
+	}
+}
+
+func TestClassify_DefensiveShouldntHappenBranchReturnsNonNilErr(t *testing.T) {
+	// Synthetic case: runCtx.Done has fired but neither parent.Err() nor
+	// run.Err() is non-nil. Cannot be reached via stdlib context today,
+	// but the defensive branch must guarantee a non-nil error so the
+	// caller's "cause==terminationCanceled => non-nil err" invariant
+	// holds (a nil err would let the caller return ScanResult{}, nil and
+	// silently mark every vuln as Skipped/no-data).
+	parent := context.Background()
+	run := context.Background()
+	gotCause, gotErr := classify(parent, run, nil)
+	if gotCause != terminationCanceled {
+		t.Errorf("cause = %v, want terminationCanceled", gotCause)
+	}
+	if gotErr == nil {
+		t.Error("defensive branch must return non-nil err so cancellation can't slip through as silent success")
+	}
+}

--- a/enricher/reachability/javascript/jelly/client.go
+++ b/enricher/reachability/javascript/jelly/client.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package jelly provides a subprocess wrapper around the Jelly static
+// analyzer's CLI. The Client interface is mockable so scan/ can be tested
+// without actually spawning jelly.
+package jelly
+
+import (
+	"context"
+	"time"
+)
+
+// Client is the mockable interface to Jelly.
+type Client interface {
+	// Available returns true if the jelly and node binaries are on PATH
+	// and node is version >= 22.0.0.
+	Available(ctx context.Context) bool
+
+	// RunImportOnly runs `jelly --modules-only ...` for Phase 1 pre-pass.
+	RunImportOnly(ctx context.Context, args ImportOnlyArgs) (ImportResult, error)
+
+	// RunFullScan runs the expensive full-scan Phase 2 command.
+	RunFullScan(ctx context.Context, args FullScanArgs) (ScanResult, error)
+}
+
+// ImportOnlyArgs is the input to RunImportOnly.
+type ImportOnlyArgs struct {
+	BaseDir          string
+	EntryPoints      []string // positional; defaults to [BaseDir] if empty
+	IncludePackages  []string // empty means --ignore-dependencies
+	ExcludeEntries   []string
+	ReachableFileOut string // path to --reachable-file
+	Timeout          time.Duration
+	MaxFileSize      int64 // bytes; 0 = jelly default (no cap)
+}
+
+// ImportResult is parsed from --reachable-file.
+type ImportResult struct {
+	ReachablePackages []ReachablePackage
+}
+
+// ReachablePackage is one entry in the --reachable-file output's "packages" array.
+// Exact schema is pinned at runtime; for now we only need Name.
+type ReachablePackage struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+// FullScanArgs is the input to RunFullScan.
+type FullScanArgs struct {
+	BaseDir             string
+	EntryPoints         []string // positional
+	VulnerabilitiesFile string   // path to --vulnerabilities <file>
+	IncludePackages     []string // empty means --ignore-dependencies
+	ExcludeEntries      []string
+	MatchesFile         string        // path to --matches-file
+	DiagnosticsFile     string        // path to --diagnostics-json
+	Timeout             time.Duration // for jelly's internal -i flag
+	MaxIndirections     int
+	Approx              bool
+	MaxFileSize         int64 // bytes; 0 = jelly default (no cap)
+}
+
+// ScanResult is parsed from --matches-file + --diagnostics-json.
+type ScanResult struct {
+	// Matches is a map of OSV id → source location strings
+	// ("file:startLine:startCol:endLine:endCol"). An empty entry for a
+	// submitted vuln id means Jelly analyzed it and found no matches.
+	Matches map[string][]string
+
+	Diagnostics     Diagnostics
+	TimedOut        bool
+	TerminatedEarly bool
+	LowConfidence   bool
+
+	// TerminationError carries the underlying subprocess error when
+	// TerminatedEarly is true (e.g. missing jelly binary, an *exec.ExitError
+	// describing the signal that killed it, or the Windows "unsupported"
+	// sentinel). nil otherwise. Operators see it in the orchestrator's
+	// "all heuristics exhausted; last error" diagnostic.
+	TerminationError error
+}
+
+// Diagnostics is a subset of Jelly's --diagnostics-json output.
+// Fields are optional; only AnalyzerRounds drives LowConfidence today.
+type Diagnostics struct {
+	AnalyzerRounds int  `json:"analyzerRounds,omitempty"`
+	Aborted        bool `json:"aborted,omitempty"`
+	Timeout        bool `json:"timeout,omitempty"`
+	LowMemory      bool `json:"lowmemory,omitempty"`
+	RangeError     bool `json:"rangeError,omitempty"`
+}

--- a/enricher/reachability/javascript/jelly/flags.go
+++ b/enricher/reachability/javascript/jelly/flags.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jelly
+
+import (
+	"strconv"
+	"time"
+)
+
+// flags accumulates argv tokens for a jelly subprocess invocation. Each
+// method names exactly one jelly CLI flag and chains so the build site
+// reads top-to-bottom in the order jelly will see the arguments.
+//
+// To add a new jelly flag: add one method here, no other call sites need
+// to know what the flag spelling is.
+type flags struct {
+	args []string
+}
+
+func newFlags() *flags { return &flags{} }
+
+// BaseDir adds `-b PATH` (jelly's analysis base directory).
+func (f *flags) BaseDir(path string) *flags {
+	f.args = append(f.args, "-b", path)
+	return f
+}
+
+// Timeout adds `-i SECONDS` (jelly's internal time limit). Sub-second
+// durations are rounded UP to 1s — jelly interprets `-i 0` as "no timeout"
+// and runJelly's wall-clock guard collapses to a 0-duration context that
+// would fire immediately. Negative durations are also floored at 1s.
+func (f *flags) Timeout(t time.Duration) *flags {
+	secs := int(t.Seconds())
+	if t > 0 && secs < 1 {
+		secs = 1
+	}
+	if secs < 1 {
+		secs = 1
+	}
+	f.args = append(f.args, "-i", strconv.Itoa(secs))
+	return f
+}
+
+// Vulnerabilities adds `-v PATH` (file containing vulnerability patterns).
+func (f *flags) Vulnerabilities(path string) *flags {
+	f.args = append(f.args, "-v", path)
+	return f
+}
+
+// ModulesOnly adds `--modules-only` (Phase 1 import-reachability mode).
+func (f *flags) ModulesOnly() *flags {
+	f.args = append(f.args, "--modules-only")
+	return f
+}
+
+// VulnerabilitiesFull adds `--vulnerabilities-full` (use the full
+// pattern-matching mode instead of the lightweight default).
+func (f *flags) VulnerabilitiesFull() *flags {
+	f.args = append(f.args, "--vulnerabilities-full")
+	return f
+}
+
+// ReachableFile adds `--reachable-file PATH` (Phase 1 output JSON).
+func (f *flags) ReachableFile(path string) *flags {
+	f.args = append(f.args, "--reachable-file", path)
+	return f
+}
+
+// MatchesFile adds `--matches-file PATH` (Phase 2 matches output JSON).
+func (f *flags) MatchesFile(path string) *flags {
+	f.args = append(f.args, "--matches-file", path)
+	return f
+}
+
+// DiagnosticsJSON adds `--diagnostics-json PATH` (run diagnostics output).
+func (f *flags) DiagnosticsJSON(path string) *flags {
+	f.args = append(f.args, "--diagnostics-json", path)
+	return f
+}
+
+// IgnoreUnresolved adds `--ignore-unresolved` (don't fail on missing
+// modules; treat them as opaque). Always safe to include for our use
+// case.
+func (f *flags) IgnoreUnresolved() *flags {
+	f.args = append(f.args, "--ignore-unresolved")
+	return f
+}
+
+// Scope translates an include-set into either
+// `--include-packages PKG...` or `--ignore-dependencies`. The two flags
+// are mutually exclusive in jelly's CLI; an empty include-set means
+// "deps are opaque".
+func (f *flags) Scope(includePackages []string) *flags {
+	if len(includePackages) == 0 {
+		f.args = append(f.args, "--ignore-dependencies")
+		return f
+	}
+	f.args = append(f.args, "--include-packages")
+	f.args = append(f.args, includePackages...)
+	return f
+}
+
+// ExcludeEntries adds `--exclude-entries GLOB...` when entries is
+// non-empty; otherwise the flag is omitted entirely.
+func (f *flags) ExcludeEntries(entries []string) *flags {
+	if len(entries) == 0 {
+		return f
+	}
+	f.args = append(f.args, "--exclude-entries")
+	f.args = append(f.args, entries...)
+	return f
+}
+
+// MaxIndirections adds `--max-indirections N` when n > 0; jelly's
+// internal default applies when omitted.
+func (f *flags) MaxIndirections(n int) *flags {
+	if n > 0 {
+		f.args = append(f.args, "--max-indirections", strconv.Itoa(n))
+	}
+	return f
+}
+
+// Approx adds `--approx` (cheap-approximation mode) only when on is true.
+func (f *flags) Approx(on bool) *flags {
+	if on {
+		f.args = append(f.args, "--approx")
+	}
+	return f
+}
+
+// MaxFileSize adds `--max-file-size BYTES` when n > 0; jelly skips any source
+// file larger than the given size. Defends against minified vendor bundles
+// that would otherwise dominate analysis time and memory.
+func (f *flags) MaxFileSize(n int64) *flags {
+	if n > 0 {
+		f.args = append(f.args, "--max-file-size", strconv.FormatInt(n, 10))
+	}
+	return f
+}
+
+// EntryPointsOrDefault appends the trailing positional entry-point paths.
+// When entries is empty, defaults to [defaultEntry] so jelly always has
+// at least one entry argument.
+func (f *flags) EntryPointsOrDefault(defaultEntry string, entries []string) *flags {
+	if len(entries) == 0 {
+		entries = []string{defaultEntry}
+	}
+	f.args = append(f.args, entries...)
+	return f
+}
+
+// Build returns the accumulated argv tokens.
+func (f *flags) Build() []string { return f.args }

--- a/enricher/reachability/javascript/jelly/mock.go
+++ b/enricher/reachability/javascript/jelly/mock.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jelly
+
+import (
+	"context"
+)
+
+// MockClient is a test double for the Client interface. It is intentionally
+// exported (not in a _test.go file) so the scan/ sub-package's external test
+// files can construct one. Production code MUST NOT instantiate MockClient —
+// callers should always go through NewRealClient.
+type MockClient struct {
+	AvailableResult bool
+
+	ImportResult ImportResult
+	ImportErr    error
+	ImportCalls  []ImportOnlyArgs
+
+	FullScanResults []ScanResult // popped off the front per call
+	FullScanErrs    []error
+	FullScanCalls   []FullScanArgs
+}
+
+// Available returns the prebuilt result.
+func (m *MockClient) Available(ctx context.Context) bool { return m.AvailableResult }
+
+// RunImportOnly records args and returns the canned result.
+func (m *MockClient) RunImportOnly(ctx context.Context, a ImportOnlyArgs) (ImportResult, error) {
+	m.ImportCalls = append(m.ImportCalls, a)
+	return m.ImportResult, m.ImportErr
+}
+
+// RunFullScan pops the next canned result/err off the slice.
+func (m *MockClient) RunFullScan(ctx context.Context, a FullScanArgs) (ScanResult, error) {
+	m.FullScanCalls = append(m.FullScanCalls, a)
+	var res ScanResult
+	var err error
+	if len(m.FullScanResults) > 0 {
+		res = m.FullScanResults[0]
+		m.FullScanResults = m.FullScanResults[1:]
+	}
+	if len(m.FullScanErrs) > 0 {
+		err = m.FullScanErrs[0]
+		m.FullScanErrs = m.FullScanErrs[1:]
+	}
+	return res, err
+}
+
+// Compile-time check that MockClient satisfies Client.
+var _ Client = (*MockClient)(nil)

--- a/enricher/reachability/javascript/jelly/real.go
+++ b/enricher/reachability/javascript/jelly/real.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jelly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// defaultNodeOptions raises Node's heap limits for jelly subprocesses. The
+// `jelly` binary is a `#!/usr/bin/env node` script, so Node honors
+// NODE_OPTIONS from the environment. Without the larger old-space cap real
+// projects OOM on long fixpoint runs; the semi-space tweak reduces GC churn
+// during heavy AST traversal.
+const defaultNodeOptions = "--max-old-space-size=8192 --max-semi-space-size=128"
+
+// realClient is the production implementation of Client.
+type realClient struct {
+	// jellyLookupPath lets tests override exec.LookPath("jelly").
+	// Empty means "use exec.LookPath".
+	jellyLookupPath string
+	// nodeOptions overrides defaultNodeOptions in tests. Empty = use default.
+	nodeOptions string
+}
+
+// NewRealClient returns a Client that shells out to the jelly binary on PATH.
+func NewRealClient() Client { return &realClient{} }
+
+// parseNodeMajor extracts the major-version integer from `node --version`
+// output of the form "v22.11.0\n". A leading "v0" (e.g. very old Node)
+// is rejected — the minimum supported real-world version is far above 0
+// and accepting it would falsely succeed Available() if minNodeMajor were
+// ever lowered.
+func parseNodeMajor(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "v") {
+		return 0, false
+	}
+	s = s[1:]
+	major, _, ok2 := strings.Cut(s, ".")
+	if !ok2 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(major)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// RunImportOnly runs the Phase 1 import-only pass.
+func (c *realClient) RunImportOnly(ctx context.Context, a ImportOnlyArgs) (ImportResult, error) {
+	args := newFlags().
+		BaseDir(a.BaseDir).
+		Timeout(a.Timeout).
+		ModulesOnly().
+		Scope(a.IncludePackages).
+		ExcludeEntries(a.ExcludeEntries).
+		ReachableFile(a.ReachableFileOut).
+		MaxFileSize(a.MaxFileSize).
+		IgnoreUnresolved().
+		EntryPointsOrDefault(a.BaseDir, a.EntryPoints).
+		Build()
+	cause, runErr := c.runJelly(ctx, args, a.Timeout)
+	if cause == terminationCanceled {
+		// Parent ctx canceled / deadlined. runErr satisfies
+		// errors.Is(err, context.Canceled / DeadlineExceeded), so
+		// RunPhase1's errors.Is check propagates this upward.
+		return ImportResult{}, runErr
+	}
+	// terminationTimedOut (our local wall-clock guard fired) and
+	// terminationNormal+err (subprocess error with parent ctx alive) are
+	// both ADVISORY failures: try to read the partial reachable-file —
+	// anything jelly emitted before being killed is positive-evidence
+	// (those packages ARE reachable) — and return it with the runErr.
+	// runErr in the timeout case is the raw waitErr (e.g. *exec.ExitError
+	// "signal: killed") and does NOT satisfy errors.Is(DeadlineExceeded),
+	// so RunPhase1 won't conflate it with parent cancellation.
+	doc := parseReachableFile(a.ReachableFileOut)
+	if runErr != nil {
+		return ImportResult{ReachablePackages: doc.Packages}, runErr
+	}
+	if doc.parseErr != nil {
+		return ImportResult{}, doc.parseErr
+	}
+	return ImportResult{ReachablePackages: doc.Packages}, nil
+}
+
+// reachableFileDoc is the parsed form of jelly's --reachable-file output.
+// parseErr captures a read/parse failure so callers can choose to either
+// propagate it (clean success branch) or ignore it (salvage-partial branch).
+type reachableFileDoc struct {
+	Packages []ReachablePackage `json:"packages"`
+	parseErr error
+}
+
+func parseReachableFile(path string) reachableFileDoc {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return reachableFileDoc{parseErr: fmt.Errorf("read reachable-file: %w", err)}
+	}
+	var doc reachableFileDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return reachableFileDoc{parseErr: fmt.Errorf("parse reachable-file: %w", err)}
+	}
+	return doc
+}
+
+// RunFullScan runs the Phase 2 expensive scan. When the subprocess errors
+// but produced partial output, the result is returned with TerminatedEarly
+// set so the caller doesn't treat empty matches as authoritative.
+// Parent-ctx cancellation is propagated as ctx.Canceled rather than being
+// re-classified as a terminated-early diagnostic.
+func (c *realClient) RunFullScan(ctx context.Context, a FullScanArgs) (ScanResult, error) {
+	args := newFlags().
+		BaseDir(a.BaseDir).
+		Timeout(a.Timeout).
+		Vulnerabilities(a.VulnerabilitiesFile).
+		VulnerabilitiesFull().
+		Scope(a.IncludePackages).
+		ExcludeEntries(a.ExcludeEntries).
+		MatchesFile(a.MatchesFile).
+		DiagnosticsJSON(a.DiagnosticsFile).
+		MaxIndirections(a.MaxIndirections).
+		Approx(a.Approx).
+		MaxFileSize(a.MaxFileSize).
+		IgnoreUnresolved().
+		EntryPointsOrDefault(a.BaseDir, a.EntryPoints).
+		Build()
+	cause, runErr := c.runJelly(ctx, args, a.Timeout)
+	if cause == terminationCanceled {
+		return ScanResult{}, runErr
+	}
+	result, readErr := readScanResult(a.MatchesFile, a.DiagnosticsFile, cause == terminationTimedOut)
+
+	if runErr != nil {
+		if readErr != nil {
+			return ScanResult{}, fmt.Errorf("jelly failed (%w) and reading outputs failed (%w)", runErr, readErr)
+		}
+		// Subprocess errored but wrote some output. Two regimes:
+		//   1. Matches non-empty AND analyzerRounds >= 2: the scan
+		//      completed enough fixpoint rounds to be trustworthy — a
+		//      non-zero exit is likely a teardown issue (unhandled
+		//      promise, deinit failure) OR a kill that arrived after
+		//      the main analysis was done. Keep the result and clear
+		//      the early-termination flags that readScanResult set
+		//      pessimistically from the kill signal; record runErr in
+		//      TerminationError so operators can see what happened.
+		//   2. Otherwise: mark TerminatedEarly so the scan layer
+		//      advances heuristics rather than emitting "unreachable"
+		//      on empty/partial matches.
+		result.TerminationError = runErr
+		if len(result.Matches) > 0 && result.Diagnostics.AnalyzerRounds >= 2 {
+			result.TimedOut = false
+			result.TerminatedEarly = false
+			result.LowConfidence = false
+		} else {
+			result.TerminatedEarly = true
+		}
+		return result, nil
+	}
+	if readErr != nil {
+		return ScanResult{}, readErr
+	}
+	return result, nil
+}
+
+// terminationCause classifies how runJelly's subprocess ended, so the
+// caller can decide whether to bucket-split, advance heuristics, or
+// propagate cancellation upstream.
+//
+// Zero value is terminationUnknown — chosen deliberately so a future
+// code path that returns the unset value (e.g. `var cause terminationCause`
+// then early-return without explicit assignment) fails loudly at the
+// classify site rather than silently being treated as "clean exit".
+type terminationCause int
+
+const (
+	terminationUnknown  terminationCause = iota // unset; never returned by runJelly
+	terminationNormal                           // subprocess exited on its own
+	terminationTimedOut                         // our wall-clock deadline fired
+	terminationCanceled                         // parent ctx canceled
+)
+
+// withNodeOptions returns env with the analyzer's NODE_OPTIONS appended
+// AFTER any operator-supplied NODE_OPTIONS. Node parses NODE_OPTIONS
+// left-to-right with last-wins semantics for repeated flags, so placing
+// the defaults at the end makes them effectively win for the keys we care
+// about (e.g. --max-old-space-size) while still allowing operators to
+// inject orthogonal flags (e.g. --inspect) via the shell.
+func withNodeOptions(env []string, override string) []string {
+	opts := override
+	if opts == "" {
+		opts = defaultNodeOptions
+	}
+	out := make([]string, 0, len(env)+1)
+	merged := false
+	for _, kv := range env {
+		if existing, ok := strings.CutPrefix(kv, "NODE_OPTIONS="); ok {
+			combined := opts
+			if existing != "" {
+				combined = existing + " " + opts
+			}
+			out = append(out, "NODE_OPTIONS="+combined)
+			merged = true
+			continue
+		}
+		out = append(out, kv)
+	}
+	if !merged {
+		out = append(out, "NODE_OPTIONS="+opts)
+	}
+	return out
+}
+
+// readScanResult parses the matches-file and diagnostics-json.
+func readScanResult(matchesPath, diagPath string, subprocessTimedOut bool) (ScanResult, error) {
+	var res ScanResult
+	if raw, err := os.ReadFile(matchesPath); err == nil {
+		if err := json.Unmarshal(raw, &res.Matches); err != nil {
+			return ScanResult{}, fmt.Errorf("parse matches-file: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return ScanResult{}, fmt.Errorf("read matches-file: %w", err)
+	}
+	if raw, err := os.ReadFile(diagPath); err == nil {
+		if err := json.Unmarshal(raw, &res.Diagnostics); err != nil {
+			return ScanResult{}, fmt.Errorf("parse diagnostics-json: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return ScanResult{}, fmt.Errorf("read diagnostics-json: %w", err)
+	}
+	res.TimedOut = subprocessTimedOut || res.Diagnostics.Timeout
+	res.TerminatedEarly = res.TimedOut || res.Diagnostics.Aborted ||
+		res.Diagnostics.LowMemory || res.Diagnostics.RangeError
+	res.LowConfidence = res.Diagnostics.AnalyzerRounds < 2 && res.TerminatedEarly
+	return res, nil
+}

--- a/enricher/reachability/javascript/jelly/real_test.go
+++ b/enricher/reachability/javascript/jelly/real_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jelly
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+)
+
+// These snapshot tests guard against accidental flag-order or flag-spelling
+// regressions in the inlined builder chains in real.go::RunImportOnly and
+// real.go::RunFullScan. Mirror those chains exactly; if you add a flag at
+// the call site, add it here too in the same position.
+
+func TestImportOnlyFlags_Snapshot(t *testing.T) {
+	got := newFlags().
+		BaseDir("/proj").
+		Timeout(90*time.Second).
+		ModulesOnly().
+		Scope([]string{"lodash", "react"}).
+		ExcludeEntries([]string{"node_modules/.jelly/**"}).
+		ReachableFile("/tmp/reach.json").
+		MaxFileSize(524288).
+		IgnoreUnresolved().
+		EntryPointsOrDefault("/proj", nil).
+		Build()
+	want := []string{
+		"-b", "/proj",
+		"-i", "90",
+		"--modules-only",
+		"--include-packages", "lodash", "react",
+		"--exclude-entries", "node_modules/.jelly/**",
+		"--reachable-file", "/tmp/reach.json",
+		"--max-file-size", "524288",
+		"--ignore-unresolved",
+		"/proj",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("import-only flags mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestImportOnlyFlags_NoIncludeUsesIgnoreDeps(t *testing.T) {
+	got := newFlags().
+		BaseDir("/proj").
+		Timeout(30*time.Second).
+		ModulesOnly().
+		Scope(nil).
+		ReachableFile("/tmp/reach.json").
+		IgnoreUnresolved().
+		EntryPointsOrDefault("/proj", nil).
+		Build()
+	if !slices.Contains(got, "--ignore-dependencies") {
+		t.Errorf("expected --ignore-dependencies in %q", got)
+	}
+	if slices.Contains(got, "--include-packages") {
+		t.Errorf("unexpected --include-packages in %q", got)
+	}
+}
+
+func TestFullScanFlags_Snapshot(t *testing.T) {
+	got := newFlags().
+		BaseDir("/proj").
+		Timeout(300*time.Second).
+		Vulnerabilities("/tmp/v.json").
+		VulnerabilitiesFull().
+		Scope([]string{"lodash"}).
+		ExcludeEntries([]string{"test/**"}).
+		MatchesFile("/tmp/m.json").
+		DiagnosticsJSON("/tmp/d.json").
+		MaxIndirections(5).
+		Approx(true).
+		MaxFileSize(524288).
+		IgnoreUnresolved().
+		EntryPointsOrDefault("/proj", nil).
+		Build()
+	want := []string{
+		"-b", "/proj",
+		"-i", "300",
+		"-v", "/tmp/v.json",
+		"--vulnerabilities-full",
+		"--include-packages", "lodash",
+		"--exclude-entries", "test/**",
+		"--matches-file", "/tmp/m.json",
+		"--diagnostics-json", "/tmp/d.json",
+		"--max-indirections", "5",
+		"--approx",
+		"--max-file-size", "524288",
+		"--ignore-unresolved",
+		"/proj",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("full-scan flags mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestWithNodeOptions_DefaultsWhenAbsent(t *testing.T) {
+	got := withNodeOptions([]string{"FOO=bar"}, "")
+	if !slices.Contains(got, "NODE_OPTIONS="+defaultNodeOptions) {
+		t.Errorf("default NODE_OPTIONS missing from %q", got)
+	}
+}
+
+func TestWithNodeOptions_DefaultsWinUnderLastWins(t *testing.T) {
+	// Node parses NODE_OPTIONS left-to-right and last-wins for repeated
+	// flags. The analyzer's defaults MUST come after any operator value so
+	// e.g. an operator's --max-old-space-size=512 doesn't silently shrink
+	// jelly's heap below the OOM threshold the defaults exist to prevent.
+	in := []string{"NODE_OPTIONS=--max-old-space-size=512 --inspect", "FOO=bar"}
+	got := withNodeOptions(in, "")
+	want := "NODE_OPTIONS=--max-old-space-size=512 --inspect " + defaultNodeOptions
+	if !slices.Contains(got, want) {
+		t.Errorf("combined NODE_OPTIONS wrong order: got %q, want entry %q", got, want)
+	}
+}
+
+func ctxBackground(t *testing.T) context.Context {
+	t.Helper()
+	return context.Background()
+}
+
+func TestParseNodeVersion(t *testing.T) {
+	cases := []struct {
+		in    string
+		major int
+		ok    bool
+	}{
+		{"v22.11.0\n", 22, true},
+		{"v23.0.0", 23, true},
+		{"v21.7.3", 21, true},
+		{"v0.10.0", 0, false}, // major 0 rejected — not a real Node version
+		{"not a version", 0, false},
+		{"", 0, false},
+	}
+	for _, c := range cases {
+		gotMajor, gotOK := parseNodeMajor(c.in)
+		if gotMajor != c.major || gotOK != c.ok {
+			t.Errorf("parseNodeMajor(%q) = (%d, %v), want (%d, %v)",
+				c.in, gotMajor, gotOK, c.major, c.ok)
+		}
+	}
+}
+
+func TestRealClient_Available_HappyIfJellyAndNode22(t *testing.T) {
+	if _, err := exec.LookPath("jelly"); err != nil {
+		t.Skip("jelly not on PATH; positive case covered by integration tests")
+	}
+	c := &realClient{}
+	_ = c.Available(ctxBackground(t))
+	// No assertion: just checking it doesn't panic.
+}
+
+func TestRealClient_Available_FalseWhenJellyAbsent(t *testing.T) {
+	c := &realClient{jellyLookupPath: "/definitely/not/on/path/jelly"}
+	if got := c.Available(ctxBackground(t)); got {
+		t.Errorf("Available() = true when jelly binary absent")
+	}
+}
+
+func TestParseScanResult(t *testing.T) {
+	dir := t.TempDir()
+	matchesPath := filepath.Join(dir, "m.json")
+	diagPath := filepath.Join(dir, "d.json")
+
+	matchesJSON := `{"GHSA-x":["app.js:12:1:12:27"],"GHSA-y":[]}`
+	diagJSON := `{"analyzerRounds":4,"aborted":false,"timeout":false}`
+	if err := os.WriteFile(matchesPath, []byte(matchesJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(diagPath, []byte(diagJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readScanResult(matchesPath, diagPath, false)
+	if err != nil {
+		t.Fatalf("readScanResult: %v", err)
+	}
+	if len(got.Matches["GHSA-x"]) != 1 {
+		t.Errorf("GHSA-x matches: got %v", got.Matches["GHSA-x"])
+	}
+	if _, ok := got.Matches["GHSA-y"]; !ok {
+		t.Errorf("GHSA-y key missing; absent-but-key-present is the encoding for 'analyzed, no matches'")
+	}
+	if got.Diagnostics.AnalyzerRounds != 4 {
+		t.Errorf("AnalyzerRounds: got %d, want 4", got.Diagnostics.AnalyzerRounds)
+	}
+	if got.LowConfidence {
+		t.Errorf("LowConfidence should be false with 4 rounds")
+	}
+	if got.TimedOut {
+		t.Errorf("TimedOut should be false")
+	}
+}
+
+func TestParseScanResult_LowConfidence(t *testing.T) {
+	dir := t.TempDir()
+	mp := filepath.Join(dir, "m.json")
+	dp := filepath.Join(dir, "d.json")
+	_ = os.WriteFile(mp, []byte(`{}`), 0o600)
+	_ = os.WriteFile(dp, []byte(`{"analyzerRounds":1,"timeout":true}`), 0o600)
+
+	got, err := readScanResult(mp, dp, true /* subprocessTimedOut */)
+	if err != nil {
+		t.Fatalf("readScanResult: %v", err)
+	}
+	if !got.LowConfidence {
+		t.Error("LowConfidence should be true when analyzerRounds<2 and terminatedEarly")
+	}
+	if !got.TimedOut {
+		t.Error("TimedOut should be true")
+	}
+}
+
+func TestDiagnosticsJSONRoundtrip(t *testing.T) {
+	d := Diagnostics{AnalyzerRounds: 3, Aborted: true}
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back Diagnostics
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back != d {
+		t.Errorf("roundtrip mismatch: %v vs %v", back, d)
+	}
+}

--- a/enricher/reachability/javascript/jelly/real_unix.go
+++ b/enricher/reachability/javascript/jelly/real_unix.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package jelly
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+const minNodeMajor = 22
+
+// Available checks that jelly and node >= 22 are installed.
+func (c *realClient) Available(ctx context.Context) bool {
+	if !c.jellyBinaryAvailable(ctx) {
+		return false
+	}
+	out, err := exec.CommandContext(ctx, "node", "--version").Output()
+	if err != nil {
+		return false
+	}
+	major, ok := parseNodeMajor(string(out))
+	return ok && major >= minNodeMajor
+}
+
+func (c *realClient) jellyBinaryAvailable(_ context.Context) bool {
+	if c.jellyLookupPath != "" {
+		_, err := exec.LookPath(c.jellyLookupPath)
+		return err == nil
+	}
+	_, err := exec.LookPath("jelly")
+	return err == nil
+}
+
+// timeoutMultiplier wraps args.Timeout with 1.5× wall-clock to guard against
+// jelly's internal timer drifting under GC pressure on large inputs.
+const timeoutMultiplier = 3.0 / 2.0
+
+// runJelly spawns the jelly binary with the given flags, enforcing a
+// wall-clock timeout of 1.5× internalTimeout (SIGKILL on the process
+// group). Returns (cause, err).
+//
+// Kill-vs-reap race is avoided by serializing through a non-blocking
+// re-check of waitCh once runCtx fires: if Wait already returned, we
+// don't kill at all (the leader is reaped and the PID may be recycled).
+// Otherwise we SIGKILL the group, then drain waitCh.
+//
+// Cause classification is the SOLE signal for what kind of termination
+// happened — the returned error is the raw waitErr/ctx.Err(), NEVER
+// wrapped with a context sentinel that would let an inner wall-clock
+// timeout be confused for a parent-deadline cancellation. Callers
+// switch on cause, not errors.Is.
+func (c *realClient) runJelly(ctx context.Context, flags []string, internalTimeout time.Duration) (terminationCause, error) {
+	wall := time.Duration(float64(internalTimeout) * timeoutMultiplier)
+	runCtx, cancel := context.WithTimeout(ctx, wall)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, "jelly", flags...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // so we can signal the group
+	cmd.Env = withNodeOptions(os.Environ(), c.nodeOptions)
+	if err := cmd.Start(); err != nil {
+		return terminationNormal, err
+	}
+	pid := cmd.Process.Pid
+
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+
+	select {
+	case <-runCtx.Done():
+		// runCtx fired. The process may have exited on its own at the
+		// same instant. Re-check waitCh non-blocking first: if ready
+		// AND the wait succeeded, the process beat the deadline and we
+		// don't classify as a timeout.
+		select {
+		case err := <-waitCh:
+			if err == nil {
+				return terminationNormal, nil
+			}
+			return classify(ctx, runCtx, err)
+		default:
+			_ = syscall.Kill(-pid, syscall.SIGKILL)
+			err := <-waitCh
+			return classify(ctx, runCtx, err)
+		}
+	case err := <-waitCh:
+		return terminationNormal, err
+	}
+}
+
+// classify maps (parent ctx, runCtx, wait err) → (cause, error). Parent
+// cancellation (Canceled or DeadlineExceeded) returns the parent's err
+// verbatim — it already satisfies errors.Is(Canceled/DeadlineExceeded)
+// for downstream propagation. Our own wall-clock timeout returns the
+// raw waitErr WITHOUT wrapping; the cause enum is the signal.
+func classify(parent, run context.Context, waitErr error) (terminationCause, error) {
+	if parent.Err() != nil {
+		return terminationCanceled, parent.Err()
+	}
+	if errors.Is(run.Err(), context.DeadlineExceeded) {
+		// Our own wall-clock guard fired. Return waitErr unwrapped so
+		// callers can distinguish via cause: terminationTimedOut means
+		// LOCAL guard, terminationCanceled means parent issue.
+		return terminationTimedOut, waitErr
+	}
+	// Shouldn't happen — runCtx.Done fired but neither parent nor our
+	// own deadline tripped. Return a non-nil error so the caller's
+	// "cancellation = nil error path" assumption can't silently produce
+	// an empty result set.
+	if waitErr == nil {
+		waitErr = errors.New("jelly: subprocess terminated for unknown reason")
+	}
+	return terminationCanceled, waitErr
+}

--- a/enricher/reachability/javascript/jelly/real_windows.go
+++ b/enricher/reachability/javascript/jelly/real_windows.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package jelly
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Available always reports false on Windows so the enricher cleanly
+// skips. The Unix implementation requires process groups (Setpgid +
+// Kill(-pid)) for race-free timeout handling, neither of which has a
+// direct Windows equivalent we want to maintain.
+func (c *realClient) Available(_ context.Context) bool { return false }
+
+// errJellyUnsupportedOnWindows is what runJelly returns on Windows. The
+// rest of the enricher treats jelly toolchain unavailability as a clean
+// skip (Enricher.Available returns false → Enrich returns nil with no
+// signals), so this error surfaces only if a Windows caller bypasses the
+// Available gate.
+var errJellyUnsupportedOnWindows = errors.New("jelly subprocess is not supported on Windows (requires unix process groups)")
+
+// runJelly is a stub on Windows. The Unix implementation uses
+// syscall.SysProcAttr.Setpgid + syscall.Kill(-pid) for process-group
+// signaling, neither of which exists on Windows; rather than ship a
+// half-implementation we refuse cleanly. Available() already returns
+// false on Windows so this path is normally unreachable.
+func (c *realClient) runJelly(_ context.Context, _ []string, _ time.Duration) (terminationCause, error) {
+	// Reference fields that only the Unix runJelly reads, so the
+	// Windows build's "unused" linter doesn't fire on the shared
+	// realClient struct.
+	_ = c.nodeOptions
+	return terminationNormal, errJellyUnsupportedOnWindows
+}

--- a/enricher/reachability/javascript/materialize/hardlink.go
+++ b/enricher/reachability/javascript/materialize/hardlink.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package materialize
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// ExtractTarball decompresses and untars tarPath into destDir, stripping the
+// npm-style top-level "package/" directory component.
+func ExtractTarball(tarPath, destDir string) error {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir dest: %w", err)
+	}
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return fmt.Errorf("open tarball: %w", err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar read: %w", err)
+		}
+		// Strip first path component (npm tarballs have a "package/" prefix).
+		name := hdr.Name
+		if i := strings.IndexByte(name, '/'); i >= 0 {
+			name = name[i+1:]
+		}
+		if name == "" {
+			continue
+		}
+		// Defend against path traversal — reject only segments equal to
+		// "..", not any "..": legitimate filenames like "v1..2.js" or
+		// "version..bak" contain ".." as a substring and would otherwise
+		// be silently dropped, leaving the materialized package
+		// incomplete and hiding their files from jelly's analysis.
+		if hasParentSegment(name) {
+			continue
+		}
+		dst := filepath.Join(destDir, name)
+		// Post-join containment: defense in depth against tar-slip
+		// (CWE-22). hasParentSegment catches `..` segments before the
+		// join, but absolute paths, NUL bytes, or platform-specific
+		// escapes might still resolve outside destDir. Reject anything
+		// whose cleaned absolute form doesn't live under the cleaned
+		// destDir prefix.
+		cleanDest := filepath.Clean(destDir) + string(filepath.Separator)
+		if !strings.HasPrefix(filepath.Clean(dst)+string(filepath.Separator), cleanDest) {
+			continue
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(dst, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", dst, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				return fmt.Errorf("mkdir parent: %w", err)
+			}
+			out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+			if err != nil {
+				return fmt.Errorf("create %s: %w", dst, err)
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return fmt.Errorf("copy %s: %w", dst, err)
+			}
+			if err := out.Close(); err != nil {
+				return err
+			}
+		default:
+			// Ignore symlinks / special types; Jelly only needs regular files.
+		}
+	}
+	return nil
+}
+
+// HardlinkTree replicates the contents of src at dst using hardlinks.
+// Subdirectories named "node_modules" are skipped — placement decides
+// where each nested package lands separately, so we don't want to
+// re-link the staging tree's nested copies.
+func HardlinkTree(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(dst, 0o755)
+		}
+		if info.IsDir() && info.Name() == "node_modules" {
+			return filepath.SkipDir
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := os.Link(path, target); err != nil {
+			// Tolerate pre-existing identical hardlinks at the destination
+			// (cross-placement target collisions surface as EEXIST on the
+			// second link attempt). A target that already exists with the
+			// same inode is a no-op; if the inode differs, fall through and
+			// report the original Link error.
+			if errors.Is(err, fs.ErrExist) && sameInode(path, target) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	})
+}
+
+// hasParentSegment reports whether any "/"-separated segment of name is
+// exactly "..", which would let a tarball entry escape the destination
+// directory. Substring containment is too coarse and rejects real files.
+func hasParentSegment(name string) bool {
+	return slices.Contains(strings.Split(name, "/"), "..")
+}
+
+// sameInode reports whether a and b refer to the same on-disk file (same
+// device + inode). Used to make HardlinkTree idempotent under cross-
+// placement target overlap.
+func sameInode(a, b string) bool {
+	sa, ea := os.Stat(a)
+	sb, eb := os.Stat(b)
+	if ea != nil || eb != nil {
+		return false
+	}
+	return os.SameFile(sa, sb)
+}

--- a/enricher/reachability/javascript/materialize/materialize.go
+++ b/enricher/reachability/javascript/materialize/materialize.go
@@ -1,0 +1,328 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package materialize implements Phase 0 — npm dependency materialization.
+// It stages a resolved node_modules tree for Jelly to walk, either by
+// reusing a pre-existing one or by running `npm pack` against a subset of
+// the dependency graph and laying out the tarballs with npm's hoisting
+// rules.
+package materialize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/internal"
+)
+
+// nodeKey is the multi-version-safe identifier used internally by
+// Materialize. Two installed copies of the same package at different
+// versions are distinct nodes.
+func nodeKey(name, version string) string { return name + "@" + version }
+
+// Spec is the input to Materialize.
+type Spec struct {
+	SubprojectRoot string
+	// ResolvedGraph is the dep graph (from scalibr's inventory). Nil means
+	// "no materialization needed" — the caller already has node_modules or
+	// there are no deps to install. Materialize will still detect and use
+	// a pre-existing node_modules if present.
+	ResolvedGraph *DepGraph
+	// InstallSet is the subset of ResolvedGraph's packages the caller wants
+	// installed. Empty with a non-nil ResolvedGraph means "install all".
+	InstallSet []string
+}
+
+// DepGraph is the resolved dependency graph, typically built from scalibr's
+// inv.Packages inside the Enricher.
+type DepGraph struct {
+	// Nodes maps package-install-id → package metadata.
+	Nodes map[string]*DepNode
+	// DirectDeps is the list of node IDs that are direct deps of the root.
+	DirectDeps []string
+}
+
+// DepNode is one resolved package in the graph.
+type DepNode struct {
+	ID      string // arbitrary unique id in the graph
+	Name    string
+	Version string
+	// Dependencies are IDs of other nodes in Nodes.
+	Dependencies []string
+	// PackageJSONDeps are package.json `dependencies` (name → version spec)
+	// from the package, used for alias detection in placement. May be nil
+	// if unknown.
+	PackageJSONDeps map[string]string
+}
+
+// Layout is the result of Materialize.
+type Layout struct {
+	NodeModulesPath string
+	StagingPath     string // <root>/node_modules/.jelly; empty if CreatedByUs=false
+	// FailedPackages lists (name, version) pairs that npm pack failed to
+	// fetch. These are absent from the materialized tree; downstream scan
+	// results for vulns rooted in these packages should be treated as
+	// "skipped, unknown" — never as "unreachable".
+	FailedPackages []internal.FailedPackage
+	CreatedByUs    bool // if true, Cleanup will rm -rf NodeModulesPath
+}
+
+// Materialize stages a node_modules tree for Jelly by downloading,
+// extracting, and hardlinking the subset of the dep graph the caller
+// requested. On failure during steps 0.b-0.g, the partial NodeModulesPath
+// is removed so the next call doesn't trip the pre-existing gate at 0.a.
+func Materialize(ctx context.Context, spec Spec) (*Layout, error) {
+	nm := filepath.Join(spec.SubprojectRoot, "node_modules")
+
+	// Step 0.a: pre-existing gate.
+	if st, err := os.Stat(nm); err == nil && st.IsDir() {
+		return &Layout{NodeModulesPath: nm, CreatedByUs: false}, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("stat node_modules: %w", err)
+	}
+	if spec.ResolvedGraph == nil {
+		return &Layout{NodeModulesPath: nm, CreatedByUs: false}, nil
+	}
+
+	// 0.b: decide install set.
+	installNodes := selectInstallNodes(spec.ResolvedGraph, spec.InstallSet)
+	packSpecs := make([]PackSpec, 0, len(installNodes))
+	for _, n := range installNodes {
+		packSpecs = append(packSpecs, PackSpec{Name: n.Name, Version: n.Version})
+	}
+
+	tmpDir, err := os.MkdirTemp("", "scalibr-jelly-pack-")
+	if err != nil {
+		return nil, fmt.Errorf("tmpdir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Roll back the (initially empty) node_modules tree if any subsequent
+	// step fails — otherwise the next invocation hits the pre-existing
+	// gate above and silently skips the install.
+	success := false
+	defer func() {
+		if !success {
+			_ = os.RemoveAll(nm)
+		}
+	}()
+
+	// 0.c: download.
+	tarballs, failed, err := DownloadTarballs(ctx, tmpDir, packSpecs)
+	if err != nil {
+		return nil, fmt.Errorf("download: %w", err)
+	}
+
+	// 0.d: extract.
+	stagingDir := filepath.Join(nm, ".jelly")
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir staging: %w", err)
+	}
+	metas := make([]*PackageMeta, 0, len(tarballs))
+	for _, tb := range tarballs {
+		pkgStagingDir := filepath.Join(stagingDir,
+			fmt.Sprintf("%s@%s", strings.ReplaceAll(tb.Spec.Name, "/", "+"), tb.Spec.Version))
+		extractTo := filepath.Join(pkgStagingDir, "node_modules", tb.Spec.Name)
+		if err := ExtractTarball(tb.TarPath, extractTo); err != nil {
+			return nil, fmt.Errorf("extract %s: %w", tb.Spec.Name, err)
+		}
+		pkgDeps := readPackageJSONDeps(extractTo)
+		metas = append(metas, &PackageMeta{
+			Name:            tb.Spec.Name,
+			Version:         tb.Spec.Version,
+			Dir:             extractTo,
+			PackageJSONDeps: pkgDeps,
+		})
+	}
+
+	// 0.e: graph edges from spec.ResolvedGraph. Keys are name@version so
+	// multiple copies of one package at different versions stay distinct.
+	// Metas whose findNode returns nil are unplaceable (the graph is
+	// inconsistent) and are excluded from placement by clearing their
+	// Parents and gating Parents writes against the unplaceable set. The
+	// full metas slice (not a subset) is passed to ComputePlacements so
+	// the integer indices encoded in Parents stay valid.
+	keyToIdx := map[string]int{}
+	unplaceable := make(map[int]bool, len(metas))
+	for i, m := range metas {
+		key := nodeKey(m.Name, m.Version)
+		// Two metas with the same (name, version) collapse via
+		// keyToIdx's last-writer-wins: the earlier copy would silently
+		// get no edges and no Placement, while the later copy is
+		// placed normally. Mark the loser unplaceable so its Parents
+		// can't accumulate phantom edges, but do NOT append to failed:
+		// the WINNER serves all vulns at this (name, version) from
+		// node_modules, so emitting FailedPackage would over-skip
+		// vulns whose code IS on disk.
+		if prev, dup := keyToIdx[key]; dup {
+			unplaceable[prev] = true
+		}
+		keyToIdx[key] = i + 1 // offset: 0 = synthetic root
+	}
+	for i, m := range metas {
+		// Skip metas already marked unplaceable above to avoid emitting
+		// duplicate FailedPackage entries when findNode also returns
+		// nil for an already-flagged dup loser.
+		if unplaceable[i+1] {
+			continue
+		}
+		if findNode(spec.ResolvedGraph, m.Name, m.Version) == nil {
+			unplaceable[i+1] = true
+			failed = append(failed, internal.FailedPackage{Name: m.Name, Version: m.Version})
+		}
+	}
+	for _, m := range metas {
+		node := findNode(spec.ResolvedGraph, m.Name, m.Version)
+		if node == nil {
+			continue
+		}
+		for _, depID := range node.Dependencies {
+			depNode := spec.ResolvedGraph.Nodes[depID]
+			if depNode == nil {
+				continue
+			}
+			depIdx, ok := keyToIdx[nodeKey(depNode.Name, depNode.Version)]
+			if !ok {
+				continue
+			}
+			// Don't list an unplaceable meta as a parent — placeSCC
+			// would otherwise try to dereference it and emit a
+			// placement under its (non-installed) directory.
+			if unplaceable[depIdx] {
+				continue
+			}
+			// depNode lists m as a parent.
+			metas[depIdx-1].Parents = append(metas[depIdx-1].Parents, keyToIdx[nodeKey(m.Name, m.Version)])
+		}
+	}
+	// Direct deps get synthetic-root parent (unless the dep itself is
+	// unplaceable — same reason as above).
+	for _, id := range spec.ResolvedGraph.DirectDeps {
+		dn := spec.ResolvedGraph.Nodes[id]
+		if dn == nil {
+			continue
+		}
+		idx, ok := keyToIdx[nodeKey(dn.Name, dn.Version)]
+		if !ok || unplaceable[idx] {
+			continue
+		}
+		metas[idx-1].Parents = append(metas[idx-1].Parents, 0)
+	}
+
+	// 0.f: placements. Pass the FULL metas slice so the int indices in
+	// Parents (which are metas-space) remain valid. Unplaceable metas
+	// have no Parents (nothing gated them in) so placeSCC produces no
+	// placement for them.
+	placements := ComputePlacements(metas, nm)
+
+	// Detect placement losers: metas that placeSCC touched but whose
+	// every target was claimed first by another meta. ComputePlacements
+	// records them with empty TargetPaths so we can surface them as
+	// FailedPackage — otherwise the scan layer wouldn't skip vulns
+	// rooted in a package whose code is in staging but not in the
+	// hard-linked node_modules layout.
+	for _, p := range placements {
+		if len(p.TargetPaths) == 0 {
+			failed = append(failed, internal.FailedPackage{Name: p.Meta.Name, Version: p.Meta.Version})
+		}
+	}
+
+	// 0.g: hardlink.
+	for _, p := range placements {
+		for _, target := range p.TargetPaths {
+			if err := HardlinkTree(p.Meta.Dir, target); err != nil {
+				return nil, fmt.Errorf("hardlink %s → %s: %w", p.Meta.Dir, target, err)
+			}
+		}
+	}
+
+	success = true
+	return &Layout{
+		NodeModulesPath: nm,
+		StagingPath:     stagingDir,
+		FailedPackages:  failed,
+		CreatedByUs:     true,
+	}, nil
+}
+
+// selectInstallNodes picks the subset of graph nodes we'll install.
+// Empty installSet means "install everything". Output is sorted by
+// (name, version) so downstream graph construction (and any test that
+// observes the order) is deterministic.
+func selectInstallNodes(g *DepGraph, installSet []string) []*DepNode {
+	out := make([]*DepNode, 0, len(g.Nodes))
+	if len(installSet) == 0 {
+		for _, n := range g.Nodes {
+			out = append(out, n)
+		}
+	} else {
+		want := map[string]bool{}
+		for _, n := range installSet {
+			want[n] = true
+		}
+		for _, n := range g.Nodes {
+			if want[n.Name] {
+				out = append(out, n)
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Version < out[j].Version
+	})
+	return out
+}
+
+// findNode returns the DepGraph node for a given (name, version) pair, or
+// nil if no match. Multi-version safe.
+func findNode(g *DepGraph, name, version string) *DepNode {
+	for _, n := range g.Nodes {
+		if n.Name == name && n.Version == version {
+			return n
+		}
+	}
+	return nil
+}
+
+// readPackageJSONDeps reads dependencies from <dir>/package.json. Returns
+// nil if the file is missing or malformed (best-effort; placement fallback
+// handles missing deps).
+func readPackageJSONDeps(dir string) map[string]string {
+	b, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return nil
+	}
+	var pj struct {
+		Dependencies map[string]string `json:"dependencies"`
+	}
+	if err := json.Unmarshal(b, &pj); err != nil {
+		return nil
+	}
+	return pj.Dependencies
+}
+
+// Cleanup removes the materialized node_modules if we created it.
+func (l *Layout) Cleanup() error {
+	if l == nil || !l.CreatedByUs {
+		return nil
+	}
+	return os.RemoveAll(l.NodeModulesPath)
+}

--- a/enricher/reachability/javascript/materialize/materialize_test.go
+++ b/enricher/reachability/javascript/materialize/materialize_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package materialize_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/materialize"
+)
+
+func TestMaterialize_GateOnExistingNodeModules(t *testing.T) {
+	proj := t.TempDir()
+	existing := filepath.Join(proj, "node_modules")
+	if err := os.Mkdir(existing, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	layout, err := materialize.Materialize(context.Background(), materialize.Spec{
+		SubprojectRoot: proj,
+	})
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if layout.NodeModulesPath != existing {
+		t.Errorf("NodeModulesPath = %q, want %q", layout.NodeModulesPath, existing)
+	}
+	if layout.CreatedByUs {
+		t.Error("CreatedByUs must be false for pre-existing node_modules")
+	}
+}
+
+func TestMaterialize_NoGraphMeansNoOp(t *testing.T) {
+	proj := t.TempDir()
+	_, err := materialize.Materialize(context.Background(), materialize.Spec{
+		SubprojectRoot: proj,
+	})
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+}
+
+func TestComputePlacements_SingleRootPackage(t *testing.T) {
+	nm := filepath.Join("/proj", "node_modules")
+	metas := []*materialize.PackageMeta{
+		{Name: "lodash", Dir: "/stage/lodash@4", Parents: []int{0}},
+	}
+	placements := materialize.ComputePlacements(metas, nm)
+	if len(placements) != 1 {
+		t.Fatalf("want 1 placement, got %d", len(placements))
+	}
+	want := filepath.Join(nm, "lodash")
+	if len(placements[0].TargetPaths) != 1 || placements[0].TargetPaths[0] != want {
+		t.Errorf("want top-level placement %q, got %v", want, placements[0].TargetPaths)
+	}
+}
+
+func TestComputePlacements_HoistThroughTwoLevels(t *testing.T) {
+	// Both mid and leaf are root direct deps in this fixture (Parents=[0]).
+	// Both should land at top-level.
+	nm := filepath.Join("/proj", "node_modules")
+	metas := []*materialize.PackageMeta{
+		{Name: "mid", Dir: "/s/mid", Parents: []int{0}, PackageJSONDeps: map[string]string{"leaf": "1.0"}},
+		{Name: "leaf", Dir: "/s/leaf", Parents: []int{0}},
+	}
+	placements := materialize.ComputePlacements(metas, nm)
+	targetSet := map[string]bool{}
+	for _, p := range placements {
+		for _, tp := range p.TargetPaths {
+			targetSet[tp] = true
+		}
+	}
+	for _, name := range []string{"mid", "leaf"} {
+		if !targetSet[filepath.Join(nm, name)] {
+			t.Errorf("%s missing top-level; have %v", name, targetSet)
+		}
+	}
+}
+
+func TestComputePlacements_NestOnVersionConflict(t *testing.T) {
+	// Two mids depend on different versions of leaf → nest under each.
+	// Parents convention: positive N means metas[N-1].
+	nm := filepath.Join("/proj", "node_modules")
+	metas := []*materialize.PackageMeta{
+		{Name: "mid1", Dir: "/s/mid1", Parents: []int{0},
+			PackageJSONDeps: map[string]string{"leaf": "1.0"}},
+		{Name: "mid2", Dir: "/s/mid2", Parents: []int{0},
+			PackageJSONDeps: map[string]string{"leaf": "2.0"}},
+		{Name: "leaf", Version: "1.0", Dir: "/s/leaf1", Parents: []int{1}}, // mid1
+		{Name: "leaf", Version: "2.0", Dir: "/s/leaf2", Parents: []int{2}}, // mid2
+	}
+	placements := materialize.ComputePlacements(metas, nm)
+	var paths []string
+	for _, p := range placements {
+		paths = append(paths, p.TargetPaths...)
+	}
+	sort.Strings(paths)
+	want := []string{
+		filepath.Join(nm, "mid1"),
+		filepath.Join(nm, "mid1", "node_modules", "leaf"),
+		filepath.Join(nm, "mid2"),
+		filepath.Join(nm, "mid2", "node_modules", "leaf"),
+	}
+	for _, w := range want {
+		if !slices.Contains(paths, w) {
+			t.Errorf("missing expected path %q in %v", w, paths)
+		}
+	}
+}
+
+func TestTarjanSCC_HandlesCycles(t *testing.T) {
+	// a ↔ b cycle. Per the offset convention, Parents=[N] means metas[N-1].
+	// To encode "a's parent is b" → Parents=[2]; "b's parent is a" → Parents=[1].
+	metas := []*materialize.PackageMeta{
+		{Name: "a", Parents: []int{2}}, // parent = metas[1] = b
+		{Name: "b", Parents: []int{1}}, // parent = metas[0] = a
+	}
+	sccs := materialize.TarjanSCC(metas)
+	if len(sccs) != 1 {
+		t.Errorf("want 1 SCC, got %d (%v)", len(sccs), sccs)
+	}
+}
+
+func TestComputePlacements_NpmAlias(t *testing.T) {
+	// parent declares `"alias-name": "npm:real@1.0"`, real package has
+	// Name="real". Install location should be under "alias-name".
+	metas := []*materialize.PackageMeta{
+		{Name: "parent", Dir: "/s/parent", Parents: []int{0},
+			PackageJSONDeps: map[string]string{"alias-name": "npm:real@1.0"}},
+		{Name: "real", Version: "1.0", Dir: "/s/real", Parents: []int{1}},
+	}
+	placements := materialize.ComputePlacements(metas, "/proj/node_modules")
+	found := false
+	for _, p := range placements {
+		for _, tp := range p.TargetPaths {
+			if strings.Contains(tp, "alias-name") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected at least one placement under the alias name")
+	}
+}
+
+func makeFakeTarball(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name:     "package/" + name, // npm strip-components=1
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(tw, bytes.NewReader([]byte(content))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExtractTarball_StripsPackagePrefix(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "pkg.tgz")
+	makeFakeTarball(t, tarPath, map[string]string{
+		"index.js":    "module.exports = 1;",
+		"lib/util.js": "module.exports = 2;",
+	})
+	out := filepath.Join(dir, "extracted")
+	if err := materialize.ExtractTarball(tarPath, out); err != nil {
+		t.Fatalf("ExtractTarball: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(out, "index.js"))
+	if err != nil || string(b) != "module.exports = 1;" {
+		t.Errorf("index.js content wrong: %q err=%v", b, err)
+	}
+	b, err = os.ReadFile(filepath.Join(out, "lib", "util.js"))
+	if err != nil || string(b) != "module.exports = 2;" {
+		t.Errorf("lib/util.js content wrong: %q err=%v", b, err)
+	}
+}
+
+func TestHardlinkTree_PreservesContent(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "hl")
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub", "b.txt"), []byte("world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := materialize.HardlinkTree(src, dst); err != nil {
+		t.Fatalf("HardlinkTree: %v", err)
+	}
+	b1, _ := os.ReadFile(filepath.Join(dst, "a.txt"))
+	b2, _ := os.ReadFile(filepath.Join(dst, "sub", "b.txt"))
+	if string(b1) != "hello" || string(b2) != "world" {
+		t.Errorf("hard-linked content wrong: %q %q", b1, b2)
+	}
+}
+
+func TestHardlinkTree_SkipsNestedNodeModules(t *testing.T) {
+	src := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(src, "node_modules", "nested"), 0o755)
+	_ = os.WriteFile(filepath.Join(src, "node_modules", "nested", "x.js"), []byte("x"), 0o644)
+	_ = os.WriteFile(filepath.Join(src, "main.js"), []byte("m"), 0o644)
+
+	dst := filepath.Join(t.TempDir(), "hl")
+	if err := materialize.HardlinkTree(src, dst); err != nil {
+		t.Fatalf("HardlinkTree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "main.js")); err != nil {
+		t.Errorf("main.js missing from dst")
+	}
+	if _, err := os.Stat(filepath.Join(dst, "node_modules")); err == nil {
+		t.Errorf("nested node_modules should have been skipped")
+	}
+}

--- a/enricher/reachability/javascript/materialize/npmpack.go
+++ b/enricher/reachability/javascript/materialize/npmpack.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package materialize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/internal"
+)
+
+// PackSpec is one package to download.
+type PackSpec struct {
+	Name    string
+	Version string
+}
+
+// Tarball is one downloaded file.
+type Tarball struct {
+	Spec    PackSpec
+	TarPath string // <tmpDir>/<npm-pack-output-name>.tgz
+}
+
+// DownloadTarballs fetches the given specs via `npm pack --json` in parallel
+// chunks, tolerating per-package failures. Returns successful tarballs +
+// the (name, version) pairs that couldn't be fetched.
+func DownloadTarballs(ctx context.Context, tmpDir string, specs []PackSpec) ([]Tarball, []internal.FailedPackage, error) {
+	if len(specs) == 0 {
+		return nil, nil, nil
+	}
+	chunkSize := max(len(specs)/runtime.NumCPU(), 10)
+	var chunks [][]PackSpec
+	for i := 0; i < len(specs); i += chunkSize {
+		end := min(i+chunkSize, len(specs))
+		chunks = append(chunks, specs[i:end])
+	}
+
+	var (
+		mu       sync.Mutex
+		tarballs []Tarball
+		failed   []internal.FailedPackage
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(8)
+	for _, ch := range chunks {
+		g.Go(func() error {
+			got, bad := runOneChunk(gctx, tmpDir, ch)
+			mu.Lock()
+			tarballs = append(tarballs, got...)
+			failed = append(failed, bad...)
+			mu.Unlock()
+			// Surface cancellation so g.Wait returns it. Without this, a
+			// canceled scan returns (partial, partial, nil) and the caller
+			// keeps marching through Phase 1/2 as if download succeeded.
+			return gctx.Err()
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return tarballs, failed, err
+	}
+	return tarballs, failed, nil
+}
+
+// runOneChunk runs `npm pack --json` against a chunk. If the chunk
+// partially succeeds, returns the successful tarballs plus the failed
+// (name, version) pairs. If nothing succeeds and the chunk has more
+// than one entry, retries each individually so a single bad package
+// doesn't poison the whole chunk.
+func runOneChunk(ctx context.Context, tmpDir string, chunk []PackSpec) ([]Tarball, []internal.FailedPackage) {
+	tbs, bad := tryPack(ctx, tmpDir, chunk)
+	if len(tbs) > 0 || len(chunk) == 1 {
+		return tbs, bad
+	}
+	// Whole-chunk failure on >1 entry: retry per-package so we can pin
+	// blame on the actual culprit(s) rather than the whole chunk.
+	var singles []Tarball
+	var singleFails []internal.FailedPackage
+	for _, s := range chunk {
+		one, b := tryPack(ctx, tmpDir, []PackSpec{s})
+		singles = append(singles, one...)
+		singleFails = append(singleFails, b...)
+	}
+	return singles, singleFails
+}
+
+type npmPackEntry struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Filename string `json:"filename"`
+}
+
+// tryPack invokes `npm pack --json` for the given chunk and returns the
+// resolved tarballs plus the names of any chunk entries that didn't make
+// it into npm's stdout. Failure attribution is by stdout-presence (what
+// did succeed); stderr is not parsed because npm error messages aren't a
+// stable contract and the substrings overlap with non-fatal warnings.
+func tryPack(ctx context.Context, tmpDir string, chunk []PackSpec) ([]Tarball, []internal.FailedPackage) {
+	// "--" separates flags from positional args so a malformed Name
+	// starting with "-" can't be misinterpreted as an npm CLI flag.
+	args := []string{"pack", "--json", "--"}
+	for _, s := range chunk {
+		args = append(args, fmt.Sprintf("%s@%s", s.Name, s.Version))
+	}
+	cmd := exec.CommandContext(ctx, "npm", args...)
+	cmd.Dir = tmpDir
+	// Use CombinedOutput? No — stdout has the JSON, stderr has errors.
+	// Capture stdout even on non-zero exit; npm pack often writes a
+	// partial JSON array when some specs resolve and others don't.
+	stdout, err := cmd.Output()
+
+	// Parse whatever JSON came back. On error this may be empty or partial.
+	var entries []npmPackEntry
+	if len(stdout) > 0 {
+		_ = json.Unmarshal(stdout, &entries)
+	}
+
+	got := make(map[string]npmPackEntry, len(entries))
+	for _, e := range entries {
+		got[e.Name+"@"+e.Version] = e
+	}
+
+	tarballs := make([]Tarball, 0, len(entries))
+	var failed []internal.FailedPackage
+	for _, s := range chunk {
+		key := s.Name + "@" + s.Version
+		if e, ok := got[key]; ok {
+			tarballs = append(tarballs, Tarball{
+				Spec:    s,
+				TarPath: filepath.Join(tmpDir, e.Filename),
+			})
+		} else {
+			failed = append(failed, internal.FailedPackage{Name: s.Name, Version: s.Version})
+		}
+	}
+
+	// If we got nothing AND the command errored, return (nil, nil) so the
+	// caller falls back to per-package retries — that path may surface a
+	// recoverable failure for some entries.
+	if len(tarballs) == 0 && err != nil && len(chunk) > 1 {
+		return nil, nil
+	}
+	return tarballs, failed
+}

--- a/enricher/reachability/javascript/materialize/placement.go
+++ b/enricher/reachability/javascript/materialize/placement.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package materialize
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// PackageMeta is the internal package-graph node used for placement.
+//
+// Parents encodes the dep-graph edges: 0 = synthetic project root;
+// positive N = metas[N-1].
+type PackageMeta struct {
+	Name            string
+	Version         string
+	Dir             string            // extracted staging dir
+	PackageJSONDeps map[string]string // from <Dir>/package.json's dependencies
+	Parents         []int
+}
+
+// Placement is one {package, target-paths} pairing.
+type Placement struct {
+	Meta        *PackageMeta
+	TargetPaths []string
+}
+
+// ComputePlacements decides where each package should appear in the
+// node_modules tree, respecting npm hoisting rules. See JELLY.md §3 Phase 0.f.
+//
+// Cross-meta target-path collisions (e.g. two multi-version metas both
+// rooted at synthetic root via aliases, which would resolve to the same
+// `<nm>/<name>` slot) are detected at record time: the first claimant
+// wins; subsequent claims are silently dropped from THIS meta's
+// TargetPaths so HardlinkTree doesn't attempt a duplicate os.Link
+// that sameInode can't reconcile. The losing meta still appears in the
+// output with empty TargetPaths so callers can distinguish "wasn't
+// placed" (entry present, TargetPaths empty) from "didn't exist"
+// (entry absent).
+func ComputePlacements(metas []*PackageMeta, nodeModulesDir string) []Placement {
+	placements := map[*PackageMeta]map[string]bool{}
+	claimedTargets := map[string]bool{}
+	record := func(m *PackageMeta, dir string) {
+		// Always register the meta in placements (with an empty set if
+		// every target collides) so the returned slice contains an
+		// entry for every meta touched by placeSCC. materialize.go uses
+		// the empty-TargetPaths shape to surface placement-lost metas
+		// as FailedPackage.
+		s := placements[m]
+		if s == nil {
+			s = map[string]bool{}
+			placements[m] = s
+		}
+		if claimedTargets[dir] {
+			return // another meta already won this target path
+		}
+		claimedTargets[dir] = true
+		s[dir] = true
+	}
+	multiVersion := findMultiVersionNames(metas)
+
+	sccs := TarjanSCC(metas)
+	for _, scc := range sccs {
+		placeSCC(metas, scc, nodeModulesDir, multiVersion, record)
+	}
+
+	// Sort the per-meta target paths and the placements slice itself so
+	// HardlinkTree's call order is deterministic. Without this, the
+	// nondeterministic map iteration causes intermittent EEXIST flakes when
+	// two metas hash to the same target path on different runs.
+	out := make([]Placement, 0, len(placements))
+	for m, set := range placements {
+		paths := make([]string, 0, len(set))
+		for p := range set {
+			paths = append(paths, p)
+		}
+		sort.Strings(paths)
+		out = append(out, Placement{Meta: m, TargetPaths: paths})
+	}
+	// SliceStable so two metas with identical Name+Version (constructible
+	// when the same package appears under two distinct DepGraph IDs —
+	// hoisted transitive vs direct dep) retain a deterministic order
+	// across runs.
+	sort.SliceStable(out, func(i, j int) bool {
+		ki := out[i].Meta.Name + "@" + out[i].Meta.Version
+		kj := out[j].Meta.Name + "@" + out[j].Meta.Version
+		return ki < kj
+	})
+	return out
+}
+
+func placeSCC(metas []*PackageMeta, scc []int, nodeModulesDir string, multiVersion map[string]bool, record func(*PackageMeta, string)) {
+	// V1: each package in the SCC is placed at the top-level unless a parent
+	// depends on a different version, or this name has multiple installed
+	// versions across the graph (force-nest).
+	for _, idx := range scc {
+		m := metas[idx]
+		if multiVersion[m.Name] {
+			for _, parentIdx := range m.Parents {
+				if parentIdx == 0 {
+					record(m, filepath.Join(nodeModulesDir, m.Name))
+					continue
+				}
+				parent := metas[parentIdx-1]
+				parentDir := filepath.Join(nodeModulesDir, parent.Name)
+				record(m, filepath.Join(parentDir, "node_modules", resolvedInstallName(parent, m)))
+			}
+			continue
+		}
+		for _, parentIdx := range m.Parents {
+			if parentIdx == 0 {
+				record(m, filepath.Join(nodeModulesDir, m.Name))
+				continue
+			}
+			parent := metas[parentIdx-1]
+			if hasVersionConflict(parent, m) {
+				parentDir := filepath.Join(nodeModulesDir, parent.Name)
+				record(m, filepath.Join(parentDir, "node_modules", resolvedInstallName(parent, m)))
+			} else {
+				record(m, filepath.Join(nodeModulesDir, resolvedInstallName(parent, m)))
+			}
+		}
+	}
+}
+
+func hasVersionConflict(parent, child *PackageMeta) bool {
+	if parent.PackageJSONDeps == nil {
+		return false
+	}
+	spec, ok := parent.PackageJSONDeps[child.Name]
+	if !ok {
+		return false
+	}
+	if child.Version == "" {
+		return false
+	}
+	// Pragmatic v1: treat "spec doesn't contain installed version" as conflict.
+	// A real semver-range satisfier comes later.
+	return !strings.Contains(spec, child.Version)
+}
+
+func findMultiVersionNames(metas []*PackageMeta) map[string]bool {
+	seen := map[string]string{}
+	multi := map[string]bool{}
+	for _, m := range metas {
+		if existing, ok := seen[m.Name]; ok && existing != m.Version {
+			multi[m.Name] = true
+		} else {
+			seen[m.Name] = m.Version
+		}
+	}
+	return multi
+}
+
+// resolvedInstallName inspects the parent's package.json dependencies for
+// an `npm:real@ver` entry matching child; if found, returns the alias key.
+// Otherwise returns the child's real name. Multiple aliases pointing at the
+// same npm:real@ver tie-break by lexicographic order so the chosen
+// install-name is deterministic across runs.
+func resolvedInstallName(parent, child *PackageMeta) string {
+	if parent == nil || parent.PackageJSONDeps == nil {
+		return child.Name
+	}
+	var matches []string
+	for alias, spec := range parent.PackageJSONDeps {
+		if strings.HasPrefix(spec, "npm:"+child.Name+"@") {
+			matches = append(matches, alias)
+		}
+	}
+	if len(matches) == 0 {
+		return child.Name
+	}
+	sort.Strings(matches)
+	return matches[0]
+}
+
+// TarjanSCC runs Tarjan's strongly-connected-components algorithm on the
+// package-metadata graph (using Parents as edges).
+func TarjanSCC(metas []*PackageMeta) [][]int {
+	n := len(metas)
+	index := make([]int, n)
+	lowlink := make([]int, n)
+	onStack := make([]bool, n)
+	for i := range index {
+		index[i] = -1
+	}
+	var stack []int
+	var sccs [][]int
+	var idx int
+
+	var strong func(v int)
+	strong = func(v int) {
+		index[v] = idx
+		lowlink[v] = idx
+		idx++
+		stack = append(stack, v)
+		onStack[v] = true
+
+		for _, p := range metas[v].Parents {
+			if p == 0 {
+				continue // synthetic root
+			}
+			w := p - 1
+			if w < 0 || w >= n {
+				continue
+			}
+			if index[w] == -1 {
+				strong(w)
+				if lowlink[w] < lowlink[v] {
+					lowlink[v] = lowlink[w]
+				}
+			} else if onStack[w] && index[w] < lowlink[v] {
+				lowlink[v] = index[w]
+			}
+		}
+
+		if lowlink[v] == index[v] {
+			var scc []int
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onStack[w] = false
+				scc = append(scc, w)
+				if w == v {
+					break
+				}
+			}
+			sccs = append(sccs, scc)
+		}
+	}
+
+	for v := range n {
+		if index[v] == -1 {
+			strong(v)
+		}
+	}
+	return sccs
+}

--- a/enricher/reachability/javascript/scan/bucket.go
+++ b/enricher/reachability/javascript/scan/bucket.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scan
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/internal"
+)
+
+// ErrBucketTimeout is returned by RunOneBucket when the underlying jelly
+// invocation reported a timeout (either subprocess wall-clock or jelly's
+// internal timer). RunPhase2 splits the bucket on this error.
+var ErrBucketTimeout = errors.New("jelly bucket timed out")
+
+// ErrBucketTerminatedEarly is returned by RunOneBucket when jelly produced
+// some output but flagged the run as untrustworthy (Aborted, LowMemory,
+// RangeError, or non-zero subprocess exit). RunPhase2 advances the
+// heuristic on this — splitting wouldn't help if the analyzer itself is
+// failing.
+var ErrBucketTerminatedEarly = errors.New("jelly bucket terminated early")
+
+// Bucket is one unit of work for Phase 2 — a set of vulns to analyze
+// together under a given heuristic + timeout.
+type Bucket struct {
+	Heuristic  Heuristic
+	Vulns      []*internal.VulnRef
+	Timeout    time.Duration
+	SplitDepth int // for telemetry; increments each recursive split
+}
+
+// Split returns two sub-buckets covering the input vulns, each with the
+// given timeout. Partitions roughly in half.
+func (b Bucket) Split(newTimeout time.Duration) (Bucket, Bucket) {
+	mid := len(b.Vulns) / 2
+	left := Bucket{
+		Heuristic:  b.Heuristic,
+		Vulns:      b.Vulns[:mid],
+		Timeout:    newTimeout,
+		SplitDepth: b.SplitDepth + 1,
+	}
+	right := Bucket{
+		Heuristic:  b.Heuristic,
+		Vulns:      b.Vulns[mid:],
+		Timeout:    newTimeout,
+		SplitDepth: b.SplitDepth + 1,
+	}
+	return left, right
+}

--- a/enricher/reachability/javascript/scan/dedup_internal_test.go
+++ b/enricher/reachability/javascript/scan/dedup_internal_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scan
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/corpus"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/internal"
+)
+
+func TestWriteBucketVulns_NoDupesWhenSameOSVIDAppearsMultipleTimes(t *testing.T) {
+	// Regression: writeBucketVulns used to call corp.Lookup once per
+	// VulnRef, so when two refs shared an OSV id the same entries were
+	// appended twice and serialized as N duplicate records in vulns.json.
+	// Fix: each unique OSV id is looked up at most once.
+	corpJSON := `[
+	  {"osv":{"id":"GHSA-x"},"patterns":["call <a>.foo"]}
+	]`
+	corpDir := t.TempDir()
+	corpPath := corpDir + "/corpus.json"
+	if err := os.WriteFile(corpPath, []byte(corpJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := corpus.Load(corpPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := corpDir + "/vulns.json"
+	// Two distinct VulnRefs with the same OSVID — one CVE matched against
+	// two installed packages, the exact scenario the byRef refactor
+	// supports.
+	vulns := []*internal.VulnRef{
+		{OSVID: "GHSA-x", PackageName: "a", PackageVersion: "1.0.0"},
+		{OSVID: "GHSA-x", PackageName: "a", PackageVersion: "2.0.0"},
+	}
+	if err := writeBucketVulns(out, vulns, c); err != nil {
+		t.Fatalf("writeBucketVulns: %v", err)
+	}
+	body, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Decode as a generic []any and count entries — should be 1, not 2.
+	var entries []any
+	if err := json.Unmarshal(body, &entries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("want 1 entry in vulns.json, got %d (%s)", len(entries), body)
+	}
+}
+
+func TestDedupPatternsCbargWins(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "no cbarg: passthrough untouched",
+			in:   []string{"call <x>.a", "call <x>.b?"},
+			want: []string{"call <x>.a", "call <x>.b?"},
+		},
+		{
+			name: "cbarg present: ? patterns dropped",
+			in:   []string{"call <x>.a?", "call <x>.b(cbarg)"},
+			want: []string{"call <x>.b(cbarg)"},
+		},
+		{
+			name: "cbarg present: non-? patterns kept",
+			in:   []string{"call <x>.plain", "call <x>.a?", "call <x>.b(cbarg)"},
+			want: []string{"call <x>.plain", "call <x>.b(cbarg)"},
+		},
+		{
+			name: "all cbarg: nothing dropped",
+			in:   []string{"call <x>.a(cbarg)", "call <y>.b(cbarg)"},
+			want: []string{"call <x>.a(cbarg)", "call <y>.b(cbarg)"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Snapshot the input so we can detect accidental mutation of the
+			// caller's backing array — corpus shares Patterns slices across
+			// holders, so any in-place edit would corrupt other vulns.
+			snapshot := append([]string(nil), tc.in...)
+			got := dedupPatternsCbargWins(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+			if !reflect.DeepEqual(tc.in, snapshot) {
+				t.Errorf("input was mutated: now %q, was %q", tc.in, snapshot)
+			}
+		})
+	}
+}

--- a/enricher/reachability/javascript/scan/heuristic.go
+++ b/enricher/reachability/javascript/scan/heuristic.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scan
+
+import (
+	"sort"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/internal"
+)
+
+// Heuristic governs the scope of one Phase 2 scan attempt.
+type Heuristic interface {
+	Name() string
+	IncludePackages(vulns []*internal.VulnRef) []string
+	MaxIndirections() int
+	SplitInBuckets() bool
+}
+
+// VulnPathOnly is the default heuristic. Scope = packages on the transitive
+// path from root to each vulnerable leaf, leaf excluded. First-choice.
+type VulnPathOnly struct {
+	// VulnPathPackages maps each VulnRef pointer to the list of packages
+	// on its root→leaf path. Keying by pointer (rather than OSVID)
+	// preserves per-VulnRef paths when two VulnRefs share one CVE id —
+	// e.g. the same CVE affecting two installed packages, whose paths
+	// can differ.
+	VulnPathPackages map[*internal.VulnRef][]string
+}
+
+// Name returns the heuristic name.
+func (VulnPathOnly) Name() string { return "VULN_PATH_ONLY" }
+
+// IncludePackages returns the union of path packages across the input
+// vulns, excluding each vuln's OWN leaf only — not other vulns' leaves.
+// Jelly's import resolution can still load the excluded leaf at scan time,
+// and excluding other vulns' leaves from a shared transitive path (e.g.
+// vuln-in-A reached via … → B → A when vuln-in-B is also in the bucket)
+// would prevent jelly from traversing through B to reach A, producing a
+// false-unreachable.
+func (h VulnPathOnly) IncludePackages(vulns []*internal.VulnRef) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, v := range vulns {
+		ownLeaf := v.PackageName
+		for _, p := range h.VulnPathPackages[v] {
+			if p == ownLeaf || seen[p] {
+				continue
+			}
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out) // deterministic argv
+	return out
+}
+
+// MaxIndirections returns the pointer-analysis depth limit.
+func (VulnPathOnly) MaxIndirections() int { return 5 }
+
+// SplitInBuckets allows recursive bucket-split on timeout.
+func (VulnPathOnly) SplitInBuckets() bool { return true }
+
+// IgnoreDeps is the fallback heuristic. Scope = none (jelly treats deps
+// opaque). Used when VulnPathOnly scoping breaks reachability.
+type IgnoreDeps struct{}
+
+// Name returns the heuristic name.
+func (IgnoreDeps) Name() string { return "IGNORE_DEPS" }
+
+// IncludePackages returns a sentinel name that matches nothing, which
+// causes jelly to treat all dependencies as opaque packages. The sentinel
+// approach is preferred over --ignore-dependencies because it preserves
+// jelly's import-graph for Phase 1 use while still excluding deps from
+// the deep scan.
+func (IgnoreDeps) IncludePackages(vulns []*internal.VulnRef) []string {
+	return []string{"__scalibr_sentinel_no_such_pkg__"}
+}
+
+// MaxIndirections returns a smaller depth limit for this fallback mode.
+func (IgnoreDeps) MaxIndirections() int { return 3 }
+
+// SplitInBuckets returns false: this heuristic does not benefit from split.
+func (IgnoreDeps) SplitInBuckets() bool { return false }

--- a/enricher/reachability/javascript/scan/importmatch.go
+++ b/enricher/reachability/javascript/scan/importmatch.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scan
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/jelly"
+)
+
+var moduleTokenRegex = regexp.MustCompile(`<([^>]+)>`)
+
+// globRegexCache memoizes compiled glob→regex translations so that
+// AccessPathReachable, called on the hot Phase 1 path once per
+// (vuln × pattern × reachable-package), doesn't recompile the same
+// regex thousands of times per scan.
+var globRegexCache sync.Map // map[string]*regexp.Regexp
+
+// AccessPathReachable reports whether every <module> token in accessPath
+// maps to at least one reachable package (by name, subpath prefix, or glob).
+// Pruning a vuln requires every token to miss; any-match keeps the vuln
+// in scope for the deep Phase 2 scan.
+func AccessPathReachable(accessPath string, reachable []jelly.ReachablePackage) bool {
+	matches := moduleTokenRegex.FindAllStringSubmatch(accessPath, -1)
+	if len(matches) == 0 {
+		// No <> tokens: we can't decide from import graph alone; assume
+		// reachable to be safe (the full scan will decide).
+		return true
+	}
+	for _, m := range matches {
+		token := m[1]
+		if !tokenHasMatch(token, reachable) {
+			return false
+		}
+	}
+	return true
+}
+
+// tokenHasMatch returns true if the <> token matches at least one reachable
+// package. Supports three forms:
+//
+//  1. Plain name:    "lodash"               → exact match or startswith "lodash/"
+//  2. Subpath:       "lodash/some/sub"      → same-prefix as form 1
+//  3. Glob with *:   "react-server-dom/**"  → package name matches glob
+func tokenHasMatch(token string, reachable []jelly.ReachablePackage) bool {
+	hasGlob := strings.ContainsAny(token, "*?{")
+	if hasGlob {
+		re := globToRegex(token)
+		for _, p := range reachable {
+			if re.MatchString(p.Name) {
+				return true
+			}
+		}
+		return false
+	}
+	// Plain / subpath: take the first path segment (or all of token if
+	// there's no /). The reachable package name is what we compare against.
+	// Anything matching `name` or starting with `name/` counts.
+	name, _, _ := strings.Cut(token, "/")
+	for _, p := range reachable {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// globToRegex is a minimal glob translator. Supports `**`, `*`, `?`, and
+// brace alternation `{a,b}`. Good enough for vulnerability access paths.
+// Results are memoized in globRegexCache.
+func globToRegex(glob string) *regexp.Regexp {
+	if cached, ok := globRegexCache.Load(glob); ok {
+		return cached.(*regexp.Regexp)
+	}
+	re := buildGlobRegex(glob)
+	actual, _ := globRegexCache.LoadOrStore(glob, re)
+	return actual.(*regexp.Regexp)
+}
+
+// buildGlobRegex compiles a fresh regex from glob.
+func buildGlobRegex(glob string) *regexp.Regexp {
+	var b strings.Builder
+	b.WriteByte('^')
+	i := 0
+	for i < len(glob) {
+		c := glob[i]
+		switch c {
+		case '/':
+			// A slash followed by ** means "this slash and everything after it
+			// is optional", so that the glob "pkg/**" also matches "pkg" itself.
+			if i+2 < len(glob) && glob[i+1] == '*' && glob[i+2] == '*' {
+				b.WriteString(`(?:/.*)?`)
+				i += 3
+				continue
+			}
+			b.WriteByte('/')
+		case '*':
+			if i+1 < len(glob) && glob[i+1] == '*' {
+				b.WriteString(`.*`)
+				i += 2
+				continue
+			}
+			b.WriteString(`[^/]*`)
+		case '?':
+			b.WriteString(`[^/]`)
+		case '{':
+			// Convert {a,b,c} → (?:a|b|c). Skip empty braces ({} or {,})
+			// to avoid emitting (?:) which would match the empty string
+			// and let unrelated reachable packages satisfy the token.
+			end := strings.IndexByte(glob[i:], '}')
+			if end < 0 {
+				b.WriteString(regexp.QuoteMeta(glob[i:]))
+				i = len(glob)
+				continue
+			}
+			inside := glob[i+1 : i+end]
+			i += end + 1
+			if inside == "" {
+				continue
+			}
+			alts := strings.Split(inside, ",")
+			nonEmpty := alts[:0]
+			for _, a := range alts {
+				if a != "" {
+					nonEmpty = append(nonEmpty, a)
+				}
+			}
+			if len(nonEmpty) == 0 {
+				continue
+			}
+			b.WriteString(`(?:`)
+			for j, a := range nonEmpty {
+				if j > 0 {
+					b.WriteByte('|')
+				}
+				b.WriteString(regexp.QuoteMeta(a))
+			}
+			b.WriteByte(')')
+			continue
+		default:
+			if c == '.' || c == '+' || c == '(' || c == ')' || c == '[' || c == ']' || c == '^' || c == '$' || c == '|' || c == '\\' {
+				b.WriteByte('\\')
+			}
+			b.WriteByte(c)
+		}
+		i++
+	}
+	// Allow subpaths: a reachable "foo" also matches "foo/..." imports.
+	b.WriteString(`(?:/.*)?$`)
+	return regexp.MustCompile(b.String())
+}

--- a/enricher/reachability/javascript/scan/scan.go
+++ b/enricher/reachability/javascript/scan/scan.go
@@ -1,0 +1,467 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package scan orchestrates Phase 1 (import-reachability pre-pass) and
+// Phase 2 (heuristic-chain + bucket-split) scans against Jelly.
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/corpus"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/internal"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/jelly"
+	"github.com/google/osv-scalibr/log"
+)
+
+// Orchestrator runs Phase 1 + Phase 2 against the given Jelly Client.
+type Orchestrator struct {
+	Client     jelly.Client
+	Corpus     *corpus.Corpus
+	Heuristics []Heuristic
+	Timeouts   TimeoutConfig
+	BaseDir    string
+	// FailedPackages are (name, version) pairs that Phase 0 materialization
+	// couldn't fetch / install — also extended by the Enricher with vulns
+	// whose package isn't present on disk after Materialize. Vulns whose
+	// (PackageName, PackageVersion) matches are skipped (not analyzed,
+	// not marked unreachable) because without the package on disk jelly
+	// silently reports no matches → false negative.
+	FailedPackages []internal.FailedPackage
+	// EntryPoints is the optional positional entry-point list passed to
+	// jelly. Empty means "use the project root" (Jelly's whole-dir default).
+	EntryPoints []string
+	// MaxFileSize, if > 0, is forwarded as --max-file-size to bound Jelly's
+	// per-file analysis cost.
+	MaxFileSize int64
+	// ExcludeEntries are paths/globs passed to jelly's --exclude-entries.
+	// The enricher sets this to skip the materializer's staging tree
+	// (node_modules/.jelly/…) so jelly doesn't double-count hard-linked
+	// duplicates of installed packages as additional modules.
+	ExcludeEntries []string
+}
+
+// TimeoutConfig tunes first-attempt and bucketed-retry timeouts.
+type TimeoutConfig struct {
+	AllVulnRuns  time.Duration
+	BucketedRuns time.Duration
+}
+
+// DefaultTimeouts returns a conservative default (10min all-vuln, 3min bucketed).
+func DefaultTimeouts() TimeoutConfig {
+	return TimeoutConfig{
+		AllVulnRuns:  10 * time.Minute,
+		BucketedRuns: 3 * time.Minute,
+	}
+}
+
+// Scan runs Phase 1 (import-reachability pre-pass) followed by Phase 2
+// (heuristic chain + bucket-split) and returns per-vuln Results. Vulns
+// rooted in FailedPackages are split off first and emitted as Skipped.
+// Returns ctx.Err() promptly if cancellation arrives between phases.
+func (o *Orchestrator) Scan(ctx context.Context, vulns []*internal.VulnRef) ([]*internal.Result, error) {
+	scoped, skipped := o.partitionForFailedPackages(vulns)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	remaining, prunedResults, err := o.RunPhase1(ctx, scoped)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	phase2Results, err := o.RunPhase2(ctx, remaining)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*internal.Result, 0, len(vulns))
+	out = append(out, skipped...)
+	out = append(out, prunedResults...)
+	out = append(out, phase2Results...)
+	return out, nil
+}
+
+// partitionForFailedPackages splits vulns into (still-analyzable, Skipped).
+// Matching is version-exact when the FailedPackage entry carries a Version
+// (so foo@1.0.0-failed doesn't skip foo@2.0.0 vulns whose code is on disk)
+// and name-only when Version is empty (a deliberate "all versions absent"
+// signal callers can use for whole-package outages).
+func (o *Orchestrator) partitionForFailedPackages(vulns []*internal.VulnRef) (keep []*internal.VulnRef, skipped []*internal.Result) {
+	if len(o.FailedPackages) == 0 {
+		return vulns, nil
+	}
+	versioned := make(map[string]bool, len(o.FailedPackages))
+	nameOnly := make(map[string]bool, len(o.FailedPackages))
+	for _, fp := range o.FailedPackages {
+		if fp.Version == "" {
+			nameOnly[fp.Name] = true
+		} else {
+			versioned[fp.Name+"@"+fp.Version] = true
+		}
+	}
+	for _, v := range vulns {
+		switch {
+		case nameOnly[v.PackageName]:
+			skipped = append(skipped, &internal.Result{
+				Ref:        v,
+				OSVID:      v.OSVID,
+				Skipped:    true,
+				SkipReason: "no installed version of package: " + v.PackageName,
+			})
+		case versioned[v.PackageName+"@"+v.PackageVersion]:
+			skipped = append(skipped, &internal.Result{
+				Ref:        v,
+				OSVID:      v.OSVID,
+				Skipped:    true,
+				SkipReason: "package not installed: " + v.PackageName + "@" + v.PackageVersion,
+			})
+		default:
+			keep = append(keep, v)
+		}
+	}
+	return keep, skipped
+}
+
+// RunPhase1 performs the cheap import-reachability pre-pass and partitions
+// the input vulns into (still-in-scope VulnRefs, provably-unreachable Results).
+func (o *Orchestrator) RunPhase1(ctx context.Context, vulns []*internal.VulnRef) (remaining []*internal.VulnRef, prunedResults []*internal.Result, err error) {
+	// Build include-packages from the first heuristic so Phase 1's scope
+	// matches Phase 2's first attempt.
+	var include []string
+	if len(o.Heuristics) > 0 {
+		include = o.Heuristics[0].IncludePackages(vulns)
+	}
+	tmpDir, err := os.MkdirTemp("", "scalibr-jelly-import-")
+	if err != nil {
+		return nil, nil, fmt.Errorf("tmpdir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	reachOut := filepath.Join(tmpDir, "reach.json")
+
+	res, err := o.Client.RunImportOnly(ctx, jelly.ImportOnlyArgs{
+		BaseDir:          o.BaseDir,
+		EntryPoints:      o.EntryPoints,
+		IncludePackages:  include,
+		ExcludeEntries:   o.ExcludeEntries,
+		ReachableFileOut: reachOut,
+		Timeout:          o.Timeouts.AllVulnRuns,
+		MaxFileSize:      o.MaxFileSize,
+	})
+	if err != nil {
+		// Parent-ctx cancellation propagates upward (errors.Is matches
+		// because runJelly's classify() returned the parent ctx error
+		// verbatim for terminationCanceled). Inner wall-clock timeouts
+		// return *exec.ExitError, which does NOT satisfy errors.Is.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, nil, err
+		}
+		// Advisory failure. The salvage path returned whatever partial
+		// reachable-file jelly wrote before being killed. We can only
+		// trust a NON-EMPTY result — an empty ReachablePackages from a
+		// failed run is "no data" not "no deps reachable", and pruning
+		// every token-bearing vuln against an empty set would emit
+		// false-unreachable signals wholesale. Fall back to the no-
+		// pruning baseline (the round-1 behavior) so Phase 2 still
+		// runs against the full vuln set.
+		if len(res.ReachablePackages) == 0 {
+			return vulns, nil, nil
+		}
+		// Partial salvage: continue to the prune loop. Vulns whose
+		// tokens match the partial set get pruned; others stay in
+		// remaining for Phase 2.
+	}
+
+	for _, v := range vulns {
+		if anyAccessPathReachable(v.AccessPathPatterns, res.ReachablePackages) {
+			remaining = append(remaining, v)
+		} else {
+			prunedResults = append(prunedResults, &internal.Result{
+				Ref:       v,
+				OSVID:     v.OSVID,
+				Reachable: false,
+				Skipped:   false,
+			})
+		}
+	}
+	return remaining, prunedResults, nil
+}
+
+// anyAccessPathReachable returns true if at least one access-path pattern
+// is fully reachable. A vuln is pruned only when EVERY pattern misses —
+// the conservative choice is to keep ambiguous vulns for the full Phase 2
+// scan rather than dropping them at Phase 1.
+func anyAccessPathReachable(patterns []string, reachable []jelly.ReachablePackage) bool {
+	if len(patterns) == 0 {
+		return true // no patterns = sentinel-loc match = can't judge; proceed
+	}
+	for _, p := range patterns {
+		if AccessPathReachable(p, reachable) {
+			return true
+		}
+	}
+	return false
+}
+
+// RunOneBucket executes one Phase 2 scan for the given bucket. It writes
+// the bucket's vulnerability patterns to a tmp file, invokes Jelly, parses
+// the matches-file, and translates into per-vuln Results.
+func (o *Orchestrator) RunOneBucket(ctx context.Context, b Bucket) ([]*internal.Result, error) {
+	tmpDir, err := os.MkdirTemp("", "scalibr-jelly-bucket-")
+	if err != nil {
+		return nil, fmt.Errorf("tmpdir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	vulnsFile := filepath.Join(tmpDir, "vulns.json")
+	matchesFile := filepath.Join(tmpDir, "matches.json")
+	diagFile := filepath.Join(tmpDir, "diag.json")
+
+	if err := writeBucketVulns(vulnsFile, b.Vulns, o.Corpus); err != nil {
+		return nil, err
+	}
+
+	res, err := o.Client.RunFullScan(ctx, jelly.FullScanArgs{
+		BaseDir:             o.BaseDir,
+		EntryPoints:         o.EntryPoints,
+		VulnerabilitiesFile: vulnsFile,
+		IncludePackages:     b.Heuristic.IncludePackages(b.Vulns),
+		ExcludeEntries:      o.ExcludeEntries,
+		MatchesFile:         matchesFile,
+		DiagnosticsFile:     diagFile,
+		Timeout:             b.Timeout,
+		MaxIndirections:     b.Heuristic.MaxIndirections(),
+		MaxFileSize:         o.MaxFileSize,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res.TimedOut {
+		// Wrap TerminationError into the sentinel so operators see the
+		// real kill-signal / exit-status detail in "all heuristics
+		// exhausted; last error: ..." messages — symmetric with the
+		// TerminatedEarly branch below.
+		if res.TerminationError != nil {
+			return nil, fmt.Errorf("%w: %w", ErrBucketTimeout, res.TerminationError)
+		}
+		return nil, ErrBucketTimeout
+	}
+	// Subprocess produced output but Diagnostics flagged abort/lowmem/range
+	// or RunFullScan inferred TerminatedEarly from a non-zero exit. Treat
+	// the empty matches as untrustworthy — never as authoritative
+	// "unreachable". Surface as a non-timeout error so RunPhase2 advances
+	// heuristics rather than uselessly bucket-splitting. Wrap the
+	// underlying TerminationError so operators see the real cause
+	// (missing binary, OOM kill, etc.) instead of just "terminated early".
+	if res.TerminatedEarly {
+		if res.TerminationError != nil {
+			return nil, fmt.Errorf("%w: %w", ErrBucketTerminatedEarly, res.TerminationError)
+		}
+		return nil, ErrBucketTerminatedEarly
+	}
+
+	// Success path. RunFullScan can populate TerminationError in a third
+	// regime — Matches trusted (non-empty, analyzerRounds >= 2) but the
+	// subprocess still errored on teardown (unhandled promise, deinit
+	// SIGABRT). Neither TimedOut nor TerminatedEarly is set in that
+	// regime, so the error would silently never surface. Log it so
+	// operators have visibility that the run, while trusted, was noisy.
+	if res.TerminationError != nil {
+		log.Warnf("reachability/javascript: bucket trusted despite jelly exit error: %v", res.TerminationError)
+	}
+	out := make([]*internal.Result, 0, len(b.Vulns))
+	for _, v := range b.Vulns {
+		locs, analyzed := res.Matches[v.OSVID]
+		r := &internal.Result{
+			Ref:       v,
+			OSVID:     v.OSVID,
+			Reachable: len(locs) > 0,
+			Skipped:   !analyzed,
+		}
+		if !analyzed {
+			r.SkipReason = "vuln id absent from matches-file"
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// writeBucketVulns materializes the subset of corpus entries for this
+// bucket's vulns into a JSON file Jelly can consume. The corpus lookup
+// happens at most ONCE per OSV id even when multiple VulnRefs in the
+// bucket share that id (one CVE matched against two installed packages):
+// jelly's --vulnerabilities consumer is fed one record per (id, entry)
+// rather than one per (id, entry, vuln-ref), avoiding duplicate ids in
+// the output. The ?-vs-(cbarg) dedup runs across ALL entries belonging
+// to one id — different corpus contributors can publish the two pattern
+// shapes in separate entries that share an id, and keeping both would
+// double-count the same callback as two matches at scan time.
+func writeBucketVulns(path string, vulns []*internal.VulnRef, corp *corpus.Corpus) error {
+	seenID := make(map[string]bool, len(vulns))
+	var all []corpus.Entry
+	for _, v := range vulns {
+		if seenID[v.OSVID] {
+			continue
+		}
+		entries, ok := corp.Lookup(v.OSVID)
+		if !ok {
+			continue
+		}
+		seenID[v.OSVID] = true
+		// Union all patterns across this id's entries, then redistribute
+		// the deduped set onto entries[0]; nil out the rest so jelly
+		// receives one patterns-bearing record per id (still keeping
+		// per-entry Loc data, which jelly indexes separately).
+		var union []string
+		for _, e := range entries {
+			union = append(union, e.Patterns...)
+		}
+		deduped := dedupPatternsCbargWins(union)
+		entriesCopy := append([]corpus.Entry(nil), entries...) // don't mutate corpus
+		for i := range entriesCopy {
+			if i == 0 {
+				entriesCopy[i].Patterns = deduped
+			} else {
+				entriesCopy[i].Patterns = nil
+			}
+		}
+		all = append(all, entriesCopy...)
+	}
+	raw, err := json.Marshal(all)
+	if err != nil {
+		return fmt.Errorf("marshal vuln patterns: %w", err)
+	}
+	return os.WriteFile(path, raw, 0o600)
+}
+
+// dedupPatternsCbargWins drops `?`-containing patterns when at least one
+// `(cbarg)`-containing pattern is present in the same entry. The `?` form
+// is a vague any-argument matcher; the `(cbarg)` form is the precise
+// callback-argument variant. Keeping both double-counts the same reachable
+// callback as two distinct vuln matches.
+func dedupPatternsCbargWins(patterns []string) []string {
+	hasCbarg := false
+	for _, p := range patterns {
+		if strings.Contains(p, "(cbarg)") {
+			hasCbarg = true
+			break
+		}
+	}
+	if !hasCbarg {
+		return patterns
+	}
+	// New backing array — corpus.Lookup returns shared Entry values whose
+	// Patterns slice is owned by the corpus; writing through patterns[:0:…]
+	// would silently mutate other vulns sharing the same id.
+	out := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		if strings.Contains(p, "?") {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// RunPhase2 runs the heuristic-chain + bucket-split loop over the given vulns.
+func (o *Orchestrator) RunPhase2(ctx context.Context, vulns []*internal.VulnRef) ([]*internal.Result, error) {
+	if len(vulns) == 0 {
+		return nil, nil
+	}
+	if len(o.Heuristics) == 0 {
+		return nil, errors.New("scan: Orchestrator.Heuristics is empty")
+	}
+
+	queue := []Bucket{{
+		Heuristic: o.Heuristics[0],
+		Vulns:     vulns,
+		Timeout:   o.Timeouts.AllVulnRuns,
+	}}
+	var out []*internal.Result
+
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		b := queue[0]
+		queue = queue[1:]
+
+		results, err := o.RunOneBucket(ctx, b)
+		if err == nil {
+			out = append(out, results...)
+			continue
+		}
+
+		// Don't bother splitting if the parent ctx is already done —
+		// the next iteration's ctx.Err() check would catch it anyway,
+		// but we'd waste a Split + tempdir setup first.
+		if ctx.Err() == nil && isBucketTimeout(err) && b.Heuristic.SplitInBuckets() && len(b.Vulns) > 1 {
+			left, right := b.Split(o.Timeouts.BucketedRuns)
+			queue = append(queue, left, right)
+			continue
+		}
+		next := nextHeuristic(o.Heuristics, b.Heuristic)
+		if next != nil {
+			queue = append(queue, Bucket{
+				Heuristic: next,
+				Vulns:     b.Vulns,
+				Timeout:   b.Timeout,
+			})
+			continue
+		}
+		// Exhausted all options — emit skipped results.
+		for _, v := range b.Vulns {
+			out = append(out, &internal.Result{
+				Ref:        v,
+				OSVID:      v.OSVID,
+				Skipped:    true,
+				SkipReason: fmt.Sprintf("all heuristics exhausted; last error: %v", err),
+			})
+		}
+	}
+	// Post-loop ctx check: if the very last bucket emitted Skipped results
+	// under a cancelled context (the in-loop check only fires at the TOP
+	// of an iteration), the cancellation would otherwise ship as a
+	// normal-completion result set. Propagate it instead.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// isBucketTimeout classifies whether `err` should drive bucket-splitting.
+// Only the explicit ErrBucketTimeout sentinel and ctx.DeadlineExceeded count;
+// generic killed-by-signal errors (OOM-killer, manual SIGKILL) advance the
+// heuristic chain instead — splitting won't help if the next attempt also
+// gets OOM-killed for the same memory pressure reason.
+func isBucketTimeout(err error) bool {
+	return errors.Is(err, ErrBucketTimeout) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// nextHeuristic returns the heuristic after `cur` in `hs`, or nil.
+func nextHeuristic(hs []Heuristic, cur Heuristic) Heuristic {
+	for i, h := range hs {
+		if h.Name() == cur.Name() && i+1 < len(hs) {
+			return hs[i+1]
+		}
+	}
+	return nil
+}

--- a/enricher/reachability/javascript/scan/scan_test.go
+++ b/enricher/reachability/javascript/scan/scan_test.go
@@ -1,0 +1,451 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scan_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/corpus"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/internal"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/jelly"
+	"github.com/google/osv-scalibr/enricher/reachability/javascript/scan"
+)
+
+func TestVulnPathOnly_PerVulnRefMapKeysSurviveSharedOSVID(t *testing.T) {
+	// Regression: VulnPathOnly used to key VulnPathPackages by OSVID,
+	// which collapsed two distinct VulnRefs sharing one CVE id into one
+	// entry — the second iteration overwrote the first's paths. The fix
+	// keys by VulnRef pointer so each ref's paths survive.
+	vulnA := &internal.VulnRef{OSVID: "GHSA-shared", PackageName: "lodash"}
+	vulnB := &internal.VulnRef{OSVID: "GHSA-shared", PackageName: "underscore"}
+	h := scan.VulnPathOnly{
+		VulnPathPackages: map[*internal.VulnRef][]string{
+			vulnA: {"express", "router"},
+			vulnB: {"next", "cache"},
+		},
+	}
+	got := h.IncludePackages([]*internal.VulnRef{vulnA, vulnB})
+	want := map[string]bool{"express": true, "router": true, "next": true, "cache": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v — shared-OSVID paths must not collapse", got, want)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected package %q", p)
+		}
+	}
+}
+
+func TestVulnPathOnly_OtherVulnsLeavesStayInScope(t *testing.T) {
+	// Regression: VulnPathOnly used to exclude every package that was the
+	// leaf of ANY vuln in the same bucket. When vuln A=lodash had a path
+	// running app → express → qs → lodash AND vuln B=qs was in the same
+	// bucket, qs was dropped from the include set, breaking jelly's
+	// traversal to lodash → both vulns marked false-unreachable. Fix:
+	// each vuln only excludes its OWN leaf.
+	vulnA := &internal.VulnRef{OSVID: "GHSA-a", PackageName: "lodash"}
+	vulnB := &internal.VulnRef{OSVID: "GHSA-b", PackageName: "qs"}
+	h := scan.VulnPathOnly{
+		VulnPathPackages: map[*internal.VulnRef][]string{
+			vulnA: {"express", "qs"}, // path to A's leaf lodash
+			vulnB: {"express"},       // path to B's leaf qs
+		},
+	}
+	vulns := []*internal.VulnRef{vulnA, vulnB}
+	got := h.IncludePackages(vulns)
+	wantSet := map[string]bool{"express": true, "qs": true}
+	if len(got) != len(wantSet) {
+		t.Fatalf("got %v, want %v (qs MUST be present — it is not A's own leaf)", got, wantSet)
+	}
+	for _, p := range got {
+		if !wantSet[p] {
+			t.Errorf("unexpected package in include set: %q", p)
+		}
+	}
+}
+
+func TestVulnPathOnly_IncludePackages(t *testing.T) {
+	vulnA := &internal.VulnRef{OSVID: "GHSA-a", PackageName: "leafvuln"}
+	vulnB := &internal.VulnRef{OSVID: "GHSA-b", PackageName: "leafvuln"}
+	h := scan.VulnPathOnly{
+		VulnPathPackages: map[*internal.VulnRef][]string{
+			vulnA: {"rootdep", "middle", "leafvuln"},
+			vulnB: {"otherroot", "leafvuln"},
+		},
+	}
+	vulns := []*internal.VulnRef{vulnA, vulnB}
+	got := h.IncludePackages(vulns)
+	// Leaf (leafvuln) is excluded from the include set; everything else is in.
+	want := map[string]bool{"rootdep": true, "middle": true, "otherroot": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %d packages, want %d: %v", len(got), len(want), got)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected package %q", p)
+		}
+	}
+	if h.MaxIndirections() != 5 {
+		t.Errorf("MaxIndirections = %d, want 5", h.MaxIndirections())
+	}
+	if !h.SplitInBuckets() {
+		t.Errorf("VulnPathOnly must have SplitInBuckets = true")
+	}
+}
+
+func TestIgnoreDeps(t *testing.T) {
+	h := scan.IgnoreDeps{}
+	got := h.IncludePackages(nil)
+	if len(got) != 1 || got[0] != "__scalibr_sentinel_no_such_pkg__" {
+		t.Errorf("IgnoreDeps.IncludePackages = %v, want sentinel", got)
+	}
+	if h.MaxIndirections() != 3 {
+		t.Errorf("MaxIndirections = %d, want 3", h.MaxIndirections())
+	}
+	if h.SplitInBuckets() {
+		t.Errorf("IgnoreDeps must have SplitInBuckets = false")
+	}
+}
+
+func TestAccessPathReachable_PlainName(t *testing.T) {
+	reachable := []jelly.ReachablePackage{{Name: "lodash"}, {Name: "react"}}
+	if !scan.AccessPathReachable("call <lodash>.template", reachable) {
+		t.Error("plain name in reachable set should match")
+	}
+	if scan.AccessPathReachable("call <missing>.x", reachable) {
+		t.Error("plain name not in reachable set should miss")
+	}
+}
+
+func TestAccessPathReachable_SubpathPrefix(t *testing.T) {
+	reachable := []jelly.ReachablePackage{{Name: "react-server-dom-webpack"}}
+	ap := "call <react-server-dom-webpack/server.edge>.decodeReply"
+	if !scan.AccessPathReachable(ap, reachable) {
+		t.Error("subpath-within-reachable-package should match")
+	}
+}
+
+func TestAccessPathReachable_Glob(t *testing.T) {
+	reachable := []jelly.ReachablePackage{{Name: "react-server-dom-webpack"}}
+	ap := "call <react-server-dom-webpack/**>.decodeReply"
+	if !scan.AccessPathReachable(ap, reachable) {
+		t.Error("glob inside <> should match on prefix")
+	}
+}
+
+func TestAccessPathReachable_AllTokensMustMatch(t *testing.T) {
+	reachable := []jelly.ReachablePackage{{Name: "a"}}
+	// Multiple <> tokens: all must match.
+	if scan.AccessPathReachable("call <a>.foo.<missing>", reachable) {
+		t.Error("if any <> token misses, pattern should be unreachable")
+	}
+}
+
+func TestRunPhase1_PrunesUnreachable(t *testing.T) {
+	c := &jelly.MockClient{
+		AvailableResult: true,
+		ImportResult: jelly.ImportResult{
+			ReachablePackages: []jelly.ReachablePackage{{Name: "reachable"}},
+		},
+	}
+	corp := mustCorpusFromJSON(t, `[
+	  {"osv":{"id":"GHSA-reach"},"patterns":["call <reachable>.foo"]},
+	  {"osv":{"id":"GHSA-unreach"},"patterns":["call <not-in-graph>.bar"]}
+	]`)
+	o := &scan.Orchestrator{
+		Client: c, Corpus: corp, BaseDir: "/proj",
+		Heuristics: []scan.Heuristic{scan.VulnPathOnly{}},
+		Timeouts:   scan.DefaultTimeouts(),
+	}
+	vulns := []*internal.VulnRef{
+		{OSVID: "GHSA-reach", AccessPathPatterns: []string{"call <reachable>.foo"}},
+		{OSVID: "GHSA-unreach", AccessPathPatterns: []string{"call <not-in-graph>.bar"}},
+	}
+	remaining, pruned, err := o.RunPhase1(context.Background(), vulns)
+	if err != nil {
+		t.Fatalf("RunPhase1: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].OSVID != "GHSA-reach" {
+		t.Errorf("remaining = %+v, want [GHSA-reach]", remaining)
+	}
+	if len(pruned) != 1 || pruned[0].OSVID != "GHSA-unreach" {
+		t.Errorf("pruned = %+v, want [GHSA-unreach]", pruned)
+	}
+}
+
+func mustCorpusFromJSON(t *testing.T, contents string) *corpus.Corpus {
+	t.Helper()
+	dir := t.TempDir()
+	p := dir + "/corpus.json"
+	if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := corpus.Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestRunOneBucket_Success(t *testing.T) {
+	c := &jelly.MockClient{
+		AvailableResult: true,
+		FullScanResults: []jelly.ScanResult{
+			{Matches: map[string][]string{"GHSA-matched": {"app.js:10:1:10:5"}}},
+		},
+	}
+	corp := mustCorpusFromJSON(t, `[
+	  {"osv":{"id":"GHSA-matched"},"patterns":["call <x>.y"]},
+	  {"osv":{"id":"GHSA-nomatch"},"patterns":["call <x>.z"]}
+	]`)
+	o := &scan.Orchestrator{
+		Client: c, Corpus: corp, BaseDir: "/proj",
+		Heuristics: []scan.Heuristic{scan.VulnPathOnly{}},
+		Timeouts:   scan.DefaultTimeouts(),
+	}
+	vulns := []*internal.VulnRef{
+		{OSVID: "GHSA-matched"},
+		{OSVID: "GHSA-nomatch"},
+	}
+	b := scan.Bucket{Heuristic: scan.VulnPathOnly{}, Vulns: vulns, Timeout: o.Timeouts.AllVulnRuns}
+	results, err := o.RunOneBucket(context.Background(), b)
+	if err != nil {
+		t.Fatalf("RunOneBucket: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	m := map[string]*internal.Result{}
+	for _, r := range results {
+		m[r.OSVID] = r
+	}
+	if !m["GHSA-matched"].Reachable {
+		t.Error("GHSA-matched should be Reachable=true")
+	}
+	if m["GHSA-nomatch"].Reachable {
+		t.Error("GHSA-nomatch should be Reachable=false")
+	}
+}
+
+func TestRunPhase2_SplitsOnTimeout(t *testing.T) {
+	// First call: timeout. Next two calls (sub-buckets): success, empty matches.
+	c := &jelly.MockClient{
+		AvailableResult: true,
+		FullScanResults: []jelly.ScanResult{
+			{TimedOut: true},
+			{Matches: map[string][]string{"GHSA-a": {}}},
+			{Matches: map[string][]string{"GHSA-b": {}}},
+		},
+	}
+	corp := mustCorpusFromJSON(t, `[
+	  {"osv":{"id":"GHSA-a"},"patterns":["call <x>.a"]},
+	  {"osv":{"id":"GHSA-b"},"patterns":["call <x>.b"]}
+	]`)
+	o := &scan.Orchestrator{
+		Client: c, Corpus: corp, BaseDir: "/proj",
+		Heuristics: []scan.Heuristic{scan.VulnPathOnly{}},
+		Timeouts:   scan.TimeoutConfig{AllVulnRuns: 100, BucketedRuns: 50},
+	}
+	vulns := []*internal.VulnRef{
+		{OSVID: "GHSA-a"},
+		{OSVID: "GHSA-b"},
+	}
+	results, err := o.RunPhase2(context.Background(), vulns)
+	if err != nil {
+		t.Fatalf("RunPhase2: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.Reachable {
+			t.Errorf("%s: Reachable should be false", r.OSVID)
+		}
+	}
+	if len(c.FullScanCalls) != 3 {
+		t.Errorf("expected 3 jelly calls (1 timeout + 2 sub-buckets), got %d", len(c.FullScanCalls))
+	}
+}
+
+func TestRunOneBucket_TerminatedEarlyWrapsTerminationError(t *testing.T) {
+	// Regression: when RunFullScan returns TerminatedEarly=true with a
+	// TerminationError (e.g. ENOENT from a missing jelly binary, OOM
+	// kill signal), RunOneBucket must wrap that into the bucket error
+	// so operators see the real cause in the "all heuristics exhausted"
+	// diagnostic — not just a bare "jelly bucket terminated early".
+	underlying := errors.New("simulated OOM kill: signal: killed")
+	c := &jelly.MockClient{
+		AvailableResult: true,
+		FullScanResults: []jelly.ScanResult{
+			{TerminatedEarly: true, TerminationError: underlying},
+		},
+	}
+	corp := mustCorpusFromJSON(t, `[{"osv":{"id":"GHSA-a"},"patterns":["call <x>.a"]}]`)
+	o := &scan.Orchestrator{
+		Client: c, Corpus: corp, BaseDir: "/proj",
+		Heuristics: []scan.Heuristic{scan.IgnoreDeps{}},
+		Timeouts:   scan.DefaultTimeouts(),
+	}
+	b := scan.Bucket{Heuristic: scan.IgnoreDeps{}, Vulns: []*internal.VulnRef{{OSVID: "GHSA-a"}}, Timeout: o.Timeouts.AllVulnRuns}
+	_, err := o.RunOneBucket(context.Background(), b)
+	if !errors.Is(err, scan.ErrBucketTerminatedEarly) {
+		t.Fatalf("error must satisfy errors.Is(ErrBucketTerminatedEarly); got %v", err)
+	}
+	if !errors.Is(err, underlying) {
+		t.Errorf("error must wrap the underlying TerminationError for operator visibility; got %v", err)
+	}
+}
+
+func TestRunOneBucket_TimedOutWrapsTerminationError(t *testing.T) {
+	// Symmetric to TerminatedEarly: the TimedOut branch must ALSO wrap
+	// the underlying TerminationError so operators see e.g. the
+	// kill-signal info, not just "jelly bucket timed out".
+	underlying := errors.New("simulated: signal: killed")
+	c := &jelly.MockClient{
+		AvailableResult: true,
+		FullScanResults: []jelly.ScanResult{
+			{TimedOut: true, TerminationError: underlying},
+		},
+	}
+	corp := mustCorpusFromJSON(t, `[{"osv":{"id":"GHSA-a"},"patterns":["call <x>.a"]}]`)
+	o := &scan.Orchestrator{
+		Client: c, Corpus: corp, BaseDir: "/proj",
+		Heuristics: []scan.Heuristic{scan.IgnoreDeps{}},
+		Timeouts:   scan.DefaultTimeouts(),
+	}
+	b := scan.Bucket{Heuristic: scan.IgnoreDeps{}, Vulns: []*internal.VulnRef{{OSVID: "GHSA-a"}}, Timeout: o.Timeouts.AllVulnRuns}
+	_, err := o.RunOneBucket(context.Background(), b)
+	if !errors.Is(err, scan.ErrBucketTimeout) {
+		t.Fatalf("error must satisfy errors.Is(ErrBucketTimeout); got %v", err)
+	}
+	if !errors.Is(err, underlying) {
+		t.Errorf("error must wrap the underlying TerminationError; got %v", err)
+	}
+}
+
+func TestRunPhase2_AdvancesHeuristicOnNonTimeoutError(t *testing.T) {
+	c := &jelly.MockClient{
+		AvailableResult: true,
+		FullScanErrs:    []error{errors.New("synthetic fail"), nil},
+		FullScanResults: []jelly.ScanResult{
+			{},
+			{Matches: map[string][]string{"GHSA-a": {}}},
+		},
+	}
+	corp := mustCorpusFromJSON(t, `[{"osv":{"id":"GHSA-a"},"patterns":["call <x>.a"]}]`)
+	o := &scan.Orchestrator{
+		Client: c, Corpus: corp, BaseDir: "/proj",
+		Heuristics: []scan.Heuristic{scan.VulnPathOnly{}, scan.IgnoreDeps{}},
+		Timeouts:   scan.DefaultTimeouts(),
+	}
+	vulns := []*internal.VulnRef{{OSVID: "GHSA-a"}}
+	results, err := o.RunPhase2(context.Background(), vulns)
+	if err != nil {
+		t.Fatalf("RunPhase2: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if len(c.FullScanCalls) != 2 {
+		t.Errorf("expected 2 jelly calls (1 error + 1 fallback), got %d", len(c.FullScanCalls))
+	}
+}
+
+func TestScan_FailedPackagesAreSkippedBeforePhase1(t *testing.T) {
+	// The mock returns one match if Phase 2 were to run. A correct
+	// implementation must skip the vuln entirely and never even hit Phase 1
+	// for it, so the FullScan call count stays 0.
+	c := &jelly.MockClient{
+		AvailableResult: true,
+		ImportResult:    jelly.ImportResult{ReachablePackages: nil},
+		FullScanResults: []jelly.ScanResult{
+			{Matches: map[string][]string{"GHSA-orphan": {"x.js:1:1:1:1"}}},
+		},
+	}
+	corp := mustCorpusFromJSON(t, `[
+	  {"osv":{"id":"GHSA-orphan"},"patterns":["call <missing-pkg>.x"]}
+	]`)
+	o := &scan.Orchestrator{
+		Client: c, Corpus: corp, BaseDir: "/proj",
+		Heuristics:     []scan.Heuristic{scan.IgnoreDeps{}},
+		Timeouts:       scan.DefaultTimeouts(),
+		FailedPackages: []internal.FailedPackage{{Name: "missing-pkg"}},
+	}
+	vulns := []*internal.VulnRef{
+		{OSVID: "GHSA-orphan", PackageName: "missing-pkg"},
+	}
+	results, err := o.Scan(context.Background(), vulns)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d: %+v", len(results), results)
+	}
+	r := results[0]
+	if !r.Skipped {
+		t.Errorf("vuln in failed package must be Skipped; got %+v", r)
+	}
+	if r.Reachable {
+		t.Errorf("Skipped vuln must not be Reachable=true")
+	}
+	if len(c.FullScanCalls) != 0 {
+		t.Errorf("vuln in failed package must bypass Phase 2; got %d calls", len(c.FullScanCalls))
+	}
+}
+
+func TestScan_EndToEnd_Phase1PrunesThenPhase2(t *testing.T) {
+	c := &jelly.MockClient{
+		AvailableResult: true,
+		ImportResult: jelly.ImportResult{
+			ReachablePackages: []jelly.ReachablePackage{{Name: "reachable"}},
+		},
+		FullScanResults: []jelly.ScanResult{
+			{Matches: map[string][]string{"GHSA-reach": {"app.js:1:1:1:2"}}},
+		},
+	}
+	corp := mustCorpusFromJSON(t, `[
+	  {"osv":{"id":"GHSA-reach"},"patterns":["call <reachable>.a"]},
+	  {"osv":{"id":"GHSA-gone"},"patterns":["call <not-in-graph>.x"]}
+	]`)
+	o := &scan.Orchestrator{
+		Client: c, Corpus: corp, BaseDir: "/proj",
+		Heuristics: []scan.Heuristic{scan.VulnPathOnly{}},
+		Timeouts:   scan.DefaultTimeouts(),
+	}
+	vulns := []*internal.VulnRef{
+		{OSVID: "GHSA-reach", AccessPathPatterns: []string{"call <reachable>.a"}},
+		{OSVID: "GHSA-gone", AccessPathPatterns: []string{"call <not-in-graph>.x"}},
+	}
+	results, err := o.Scan(context.Background(), vulns)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	m := map[string]*internal.Result{}
+	for _, r := range results {
+		m[r.OSVID] = r
+	}
+	if !m["GHSA-reach"].Reachable {
+		t.Errorf("GHSA-reach: want Reachable=true (phase 2 matched)")
+	}
+	if m["GHSA-gone"].Reachable {
+		t.Errorf("GHSA-gone: want Reachable=false (phase 1 pruned)")
+	}
+}

--- a/enricher/reachability/javascript/testdata/.gitignore
+++ b/enricher/reachability/javascript/testdata/.gitignore
@@ -1,0 +1,6 @@
+# Per-CVE fixture node_modules are populated locally via `npm install`
+# (or pnpm/yarn) before integration tests run. Do not commit them — they
+# are large, environment-specific, and reproducible from the lockfiles.
+GHSA-*/positive/node_modules/
+GHSA-*/negative/node_modules/
+GHSA-*/fixed/node_modules/

--- a/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/metadata.json
+++ b/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/metadata.json
@@ -1,0 +1,71 @@
+[
+  {
+    "osv": {
+      "id": "GHSA-fv66-9v8q-g76r",
+      "affected": [
+        {
+          "package": { "ecosystem": "npm", "name": "react-server-dom-webpack" },
+          "ranges": [
+            {
+              "events": [
+                { "introduced": "19.0.0" }, { "fixed": "19.0.1" },
+                { "introduced": "19.1.0" }, { "fixed": "19.1.2" },
+                { "introduced": "19.2.0" }, { "fixed": "19.2.1" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "loc": { "filename": "__jelly_sentinel_suppress_module_wide_sink__" },
+    "patterns": [
+      "call <react-server-dom-webpack/**>.{decodeReply,decodeReplyFromBusboy,decodeReplyFromAsyncIterable,decodeAction,decodeFormState}"
+    ]
+  },
+  {
+    "osv": {
+      "id": "GHSA-fv66-9v8q-g76r",
+      "affected": [
+        {
+          "package": { "ecosystem": "npm", "name": "react-server-dom-turbopack" },
+          "ranges": [
+            {
+              "events": [
+                { "introduced": "19.0.0" }, { "fixed": "19.0.1" },
+                { "introduced": "19.1.0" }, { "fixed": "19.1.2" },
+                { "introduced": "19.2.0" }, { "fixed": "19.2.1" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "loc": { "filename": "__jelly_sentinel_suppress_module_wide_sink__" },
+    "patterns": [
+      "call <react-server-dom-turbopack/**>.{decodeReply,decodeReplyFromBusboy,decodeReplyFromAsyncIterable,decodeAction,decodeFormState}"
+    ]
+  },
+  {
+    "osv": {
+      "id": "GHSA-fv66-9v8q-g76r",
+      "affected": [
+        {
+          "package": { "ecosystem": "npm", "name": "react-server-dom-parcel" },
+          "ranges": [
+            {
+              "events": [
+                { "introduced": "19.0.0" }, { "fixed": "19.0.1" },
+                { "introduced": "19.1.0" }, { "fixed": "19.1.2" },
+                { "introduced": "19.2.0" }, { "fixed": "19.2.1" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "loc": { "filename": "__jelly_sentinel_suppress_module_wide_sink__" },
+    "patterns": [
+      "call <react-server-dom-parcel/**>.{decodeReply,decodeReplyFromBusboy,decodeReplyFromAsyncIterable,decodeAction,decodeFormState}"
+    ]
+  }
+]

--- a/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/negative/app.js
+++ b/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/negative/app.js
@@ -1,0 +1,2 @@
+const _rsdw = require('react-server-dom-webpack/server.edge');
+console.log('loaded', typeof _rsdw);

--- a/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/negative/package.json
+++ b/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/negative/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cve-2025-55182-negative",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react-server-dom-webpack": "19.2.0"
+  }
+}

--- a/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/negative/pnpm-lock.yaml
+++ b/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/negative/pnpm-lock.yaml
@@ -1,0 +1,640 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react-server-dom-webpack:
+        specifier: 19.2.0
+        version: 19.2.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2)
+
+packages:
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@types/eslint-scope@3.7.7':
+    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
+
+  '@types/eslint@9.6.1':
+    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
+
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  baseline-browser-mapping@2.10.21:
+    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  caniuse-lite@1.0.30001790:
+    resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
+
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  electron-to-chromium@1.5.344:
+    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
+    engines: {node: '>=10.13.0'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  loader-runner@4.3.1:
+    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+    engines: {node: '>=6.11.5'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-server-dom-webpack@19.2.0:
+    resolution: {integrity: sha512-ar2H1q9SvonShYYYszHx7gE3v9NF3K01AvrIvQMIRNXj+CiUDjI2C7XKexDSlOzqwSlxgDivaMdYwfEBYD6NjQ==}
+    engines: {node: '>=0.10.0'}
+    deprecated: Critical Security Vulnerability in React Server Components
+    peerDependencies:
+      react: ^19.2.0
+      react-dom: ^19.2.0
+      webpack: ^5.59.0
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  terser-webpack-plugin@5.5.0:
+    resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+
+  terser@5.46.2:
+    resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  watchpack@2.5.1:
+    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+    engines: {node: '>=10.13.0'}
+
+  webpack-sources@3.4.0:
+    resolution: {integrity: sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.106.2:
+    resolution: {integrity: sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+
+snapshots:
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@types/eslint-scope@3.7.7':
+    dependencies:
+      '@types/eslint': 9.6.1
+      '@types/estree': 1.0.8
+
+  '@types/eslint@9.6.1':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
+
+  acorn-import-phases@1.0.4(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-loose@8.5.2:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv-formats@2.1.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-keywords@5.1.0(ajv@8.18.0):
+    dependencies:
+      ajv: 8.18.0
+      fast-deep-equal: 3.1.3
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  baseline-browser-mapping@2.10.21: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.21
+      caniuse-lite: 1.0.30001790
+      electron-to-chromium: 1.5.344
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-from@1.1.2: {}
+
+  caniuse-lite@1.0.30001790: {}
+
+  chrome-trace-event@1.0.4: {}
+
+  commander@2.20.3: {}
+
+  electron-to-chromium@1.5.344: {}
+
+  enhanced-resolve@5.21.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  es-module-lexer@2.0.0: {}
+
+  escalade@3.2.0: {}
+
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
+
+  estraverse@5.3.0: {}
+
+  events@3.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  glob-to-regexp@0.4.1: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 25.6.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  json-schema-traverse@1.0.0: {}
+
+  loader-runner@4.3.1: {}
+
+  merge-stream@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  neo-async@2.6.2: {}
+
+  node-releases@2.0.38: {}
+
+  picocolors@1.1.1: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-server-dom-webpack@19.2.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      webpack: 5.106.2
+      webpack-sources: 3.4.0
+
+  react@19.2.5: {}
+
+  require-from-string@2.0.2: {}
+
+  scheduler@0.27.0: {}
+
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  tapable@2.3.3: {}
+
+  terser-webpack-plugin@5.5.0(webpack@5.106.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.2
+      webpack: 5.106.2
+
+  terser@5.46.2:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  undici-types@7.19.2: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  watchpack@2.5.1:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
+  webpack-sources@3.4.0: {}
+
+  webpack@5.106.2:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.1
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.5.0(webpack@5.106.2)
+      watchpack: 2.5.1
+      webpack-sources: 3.4.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js

--- a/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/positive/app.js
+++ b/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/positive/app.js
@@ -1,0 +1,3 @@
+const { decodeReply } = require('react-server-dom-webpack/server.edge');
+
+decodeReply('[]', {});

--- a/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/positive/package.json
+++ b/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/positive/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cve-2025-55182-positive",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react-server-dom-webpack": "19.2.0"
+  }
+}

--- a/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/positive/pnpm-lock.yaml
+++ b/enricher/reachability/javascript/testdata/GHSA-fv66-9v8q-g76r/positive/pnpm-lock.yaml
@@ -1,0 +1,640 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react-server-dom-webpack:
+        specifier: 19.2.0
+        version: 19.2.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2)
+
+packages:
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@types/eslint-scope@3.7.7':
+    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
+
+  '@types/eslint@9.6.1':
+    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
+
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  baseline-browser-mapping@2.10.21:
+    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  caniuse-lite@1.0.30001790:
+    resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
+
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  electron-to-chromium@1.5.344:
+    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
+    engines: {node: '>=10.13.0'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  loader-runner@4.3.1:
+    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+    engines: {node: '>=6.11.5'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-server-dom-webpack@19.2.0:
+    resolution: {integrity: sha512-ar2H1q9SvonShYYYszHx7gE3v9NF3K01AvrIvQMIRNXj+CiUDjI2C7XKexDSlOzqwSlxgDivaMdYwfEBYD6NjQ==}
+    engines: {node: '>=0.10.0'}
+    deprecated: Critical Security Vulnerability in React Server Components
+    peerDependencies:
+      react: ^19.2.0
+      react-dom: ^19.2.0
+      webpack: ^5.59.0
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  terser-webpack-plugin@5.5.0:
+    resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+
+  terser@5.46.2:
+    resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  watchpack@2.5.1:
+    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+    engines: {node: '>=10.13.0'}
+
+  webpack-sources@3.4.0:
+    resolution: {integrity: sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.106.2:
+    resolution: {integrity: sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+
+snapshots:
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@types/eslint-scope@3.7.7':
+    dependencies:
+      '@types/eslint': 9.6.1
+      '@types/estree': 1.0.8
+
+  '@types/eslint@9.6.1':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
+
+  acorn-import-phases@1.0.4(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-loose@8.5.2:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv-formats@2.1.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-keywords@5.1.0(ajv@8.18.0):
+    dependencies:
+      ajv: 8.18.0
+      fast-deep-equal: 3.1.3
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  baseline-browser-mapping@2.10.21: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.21
+      caniuse-lite: 1.0.30001790
+      electron-to-chromium: 1.5.344
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-from@1.1.2: {}
+
+  caniuse-lite@1.0.30001790: {}
+
+  chrome-trace-event@1.0.4: {}
+
+  commander@2.20.3: {}
+
+  electron-to-chromium@1.5.344: {}
+
+  enhanced-resolve@5.21.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  es-module-lexer@2.0.0: {}
+
+  escalade@3.2.0: {}
+
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
+
+  estraverse@5.3.0: {}
+
+  events@3.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  glob-to-regexp@0.4.1: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 25.6.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  json-schema-traverse@1.0.0: {}
+
+  loader-runner@4.3.1: {}
+
+  merge-stream@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  neo-async@2.6.2: {}
+
+  node-releases@2.0.38: {}
+
+  picocolors@1.1.1: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-server-dom-webpack@19.2.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.106.2):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      webpack: 5.106.2
+      webpack-sources: 3.4.0
+
+  react@19.2.5: {}
+
+  require-from-string@2.0.2: {}
+
+  scheduler@0.27.0: {}
+
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  tapable@2.3.3: {}
+
+  terser-webpack-plugin@5.5.0(webpack@5.106.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.2
+      webpack: 5.106.2
+
+  terser@5.46.2:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  undici-types@7.19.2: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  watchpack@2.5.1:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
+  webpack-sources@3.4.0: {}
+
+  webpack@5.106.2:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.1
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.5.0(webpack@5.106.2)
+      watchpack: 2.5.1
+      webpack-sources: 3.4.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js

--- a/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/metadata.json
+++ b/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/metadata.json
@@ -1,0 +1,25 @@
+[
+  {
+    "osv": {
+      "id": "GHSA-j5w5-568x-rq53",
+      "affected": [
+        {
+          "package": { "ecosystem": "npm", "name": "@evomap/evolver" },
+          "ranges": [
+            {
+              "type": "SEMVER",
+              "events": [
+                { "introduced": "0" },
+                { "fixed": "1.69.3" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "loc": { "filename": "__jelly_sentinel_suppress_module_wide_sink__" },
+    "patterns": [
+      "call <@evomap/evolver/**>.extractSignals"
+    ]
+  }
+]

--- a/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/negative/app.js
+++ b/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/negative/app.js
@@ -1,0 +1,2 @@
+const _evolver = require('@evomap/evolver/src/gep/signals');
+console.log('loaded', typeof _evolver);

--- a/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/negative/package.json
+++ b/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/negative/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cve-negative-test",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@evomap/evolver": "1.69.1"
+  }
+}

--- a/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/negative/pnpm-lock.yaml
+++ b/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/negative/pnpm-lock.yaml
@@ -1,0 +1,31 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@evomap/evolver':
+        specifier: 1.69.1
+        version: 1.69.1
+
+packages:
+
+  '@evomap/evolver@1.69.1':
+    resolution: {integrity: sha512-3g6c5ooEpi10LCQufQ64J6LWsKeMjokVKJeVHytlBdU5ciaFvy81u3KOYzDkgFnOJdvi9NcEDZWK0dx2zvPNbQ==}
+    hasBin: true
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@evomap/evolver@1.69.1':
+    dependencies:
+      dotenv: 16.6.1
+
+  dotenv@16.6.1: {}

--- a/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/positive/app.js
+++ b/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/positive/app.js
@@ -1,0 +1,9 @@
+const { extractSignals } = require('@evomap/evolver/src/gep/signals');
+
+extractSignals({
+  recentSessionTranscript: '',
+  todayLog: '',
+  memorySnippet: '',
+  userSnippet: '',
+  recentEvents: [],
+});

--- a/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/positive/package.json
+++ b/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/positive/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cve-positive-test",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@evomap/evolver": "1.69.1"
+  }
+}

--- a/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/positive/pnpm-lock.yaml
+++ b/enricher/reachability/javascript/testdata/GHSA-j5w5-568x-rq53/positive/pnpm-lock.yaml
@@ -1,0 +1,31 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@evomap/evolver':
+        specifier: 1.69.1
+        version: 1.69.1
+
+packages:
+
+  '@evomap/evolver@1.69.1':
+    resolution: {integrity: sha512-3g6c5ooEpi10LCQufQ64J6LWsKeMjokVKJeVHytlBdU5ciaFvy81u3KOYzDkgFnOJdvi9NcEDZWK0dx2zvPNbQ==}
+    hasBin: true
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@evomap/evolver@1.69.1':
+    dependencies:
+      dotenv: 16.6.1
+
+  dotenv@16.6.1: {}

--- a/enricher/reachability/javascript/testdata/corpus.json
+++ b/enricher/reachability/javascript/testdata/corpus.json
@@ -1,0 +1,163 @@
+[
+  {
+    "osv": {
+      "id": "GHSA-fv66-9v8q-g76r",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "npm",
+            "name": "react-server-dom-webpack"
+          },
+          "ranges": [
+            {
+              "events": [
+                {
+                  "introduced": "19.0.0"
+                },
+                {
+                  "fixed": "19.0.1"
+                },
+                {
+                  "introduced": "19.1.0"
+                },
+                {
+                  "fixed": "19.1.2"
+                },
+                {
+                  "introduced": "19.2.0"
+                },
+                {
+                  "fixed": "19.2.1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "loc": {
+      "filename": "__jelly_sentinel_suppress_module_wide_sink__"
+    },
+    "patterns": [
+      "call \u003creact-server-dom-webpack/**\u003e.{decodeReply,decodeReplyFromBusboy,decodeReplyFromAsyncIterable,decodeAction,decodeFormState}"
+    ]
+  },
+  {
+    "osv": {
+      "id": "GHSA-fv66-9v8q-g76r",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "npm",
+            "name": "react-server-dom-turbopack"
+          },
+          "ranges": [
+            {
+              "events": [
+                {
+                  "introduced": "19.0.0"
+                },
+                {
+                  "fixed": "19.0.1"
+                },
+                {
+                  "introduced": "19.1.0"
+                },
+                {
+                  "fixed": "19.1.2"
+                },
+                {
+                  "introduced": "19.2.0"
+                },
+                {
+                  "fixed": "19.2.1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "loc": {
+      "filename": "__jelly_sentinel_suppress_module_wide_sink__"
+    },
+    "patterns": [
+      "call \u003creact-server-dom-turbopack/**\u003e.{decodeReply,decodeReplyFromBusboy,decodeReplyFromAsyncIterable,decodeAction,decodeFormState}"
+    ]
+  },
+  {
+    "osv": {
+      "id": "GHSA-fv66-9v8q-g76r",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "npm",
+            "name": "react-server-dom-parcel"
+          },
+          "ranges": [
+            {
+              "events": [
+                {
+                  "introduced": "19.0.0"
+                },
+                {
+                  "fixed": "19.0.1"
+                },
+                {
+                  "introduced": "19.1.0"
+                },
+                {
+                  "fixed": "19.1.2"
+                },
+                {
+                  "introduced": "19.2.0"
+                },
+                {
+                  "fixed": "19.2.1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "loc": {
+      "filename": "__jelly_sentinel_suppress_module_wide_sink__"
+    },
+    "patterns": [
+      "call \u003creact-server-dom-parcel/**\u003e.{decodeReply,decodeReplyFromBusboy,decodeReplyFromAsyncIterable,decodeAction,decodeFormState}"
+    ]
+  },
+  {
+    "osv": {
+      "id": "GHSA-j5w5-568x-rq53",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "npm",
+            "name": "@evomap/evolver"
+          },
+          "ranges": [
+            {
+              "type": "SEMVER",
+              "events": [
+                {
+                  "introduced": "0"
+                },
+                {
+                  "fixed": "1.69.3"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "loc": {
+      "filename": "__jelly_sentinel_suppress_module_wide_sink__"
+    },
+    "patterns": [
+      "call \u003c@evomap/evolver/**\u003e.extractSignals"
+    ]
+  }
+]

--- a/enricher/reachability/javascript/testdata/gen.go
+++ b/enricher/reachability/javascript/testdata/gen.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build ignore
+
+// This file is the code-generator for testdata/corpus.json. Run:
+//
+//	go run enricher/reachability/javascript/testdata/gen.go
+//
+// It walks the per-CVE directories under testdata/, concatenates each
+// metadata.json into a single array, and writes the result to
+// testdata/corpus.json.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	root := "enricher/reachability/javascript/testdata"
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read dir:", err)
+		os.Exit(1)
+	}
+	var all []json.RawMessage
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), "GHSA-") {
+			continue
+		}
+		meta := filepath.Join(root, e.Name(), "metadata.json")
+		raw, err := os.ReadFile(meta)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "skip:", meta, err)
+			continue
+		}
+		var arr []json.RawMessage
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			fmt.Fprintln(os.Stderr, "parse:", meta, err)
+			continue
+		}
+		all = append(all, arr...)
+	}
+	out, err := json.MarshalIndent(all, "", "  ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "marshal:", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(filepath.Join(root, "corpus.json"), out, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "write:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("wrote %d entries to %s/corpus.json\n", len(all), root)
+}


### PR DESCRIPTION
## Summary

Adds a new enricher that determines whether npm-ecosystem vulnerabilities flagged by the inventory are reachable from user code, by driving the [Jelly](https://github.com/cs-au-dk/jelly) static analyzer against a materialized `node_modules` tree and emitting VEX `VulnerableCodeNotInExecutePath` signals on vulns proven unreachable.

Architecture mirrors the existing `reachability/rust` enricher: a `Client` interface for the external tool (mockable for unit tests, real impl shells out via `exec.CommandContext`), with sub-packages isolating each concern:

```
enricher/reachability/javascript/
  javascript.go         Enricher: preflight, vuln selection, scope chain
                        construction, signal emission.
  corpus/               Loads corpus.json (per-CVE jelly metadata) via
                        protojson, indexed by OSV id.
  jelly/                Client interface + MockClient + realClient
                        (split into real.go + real_unix.go + real_windows.go
                        for cross-platform builds).
  materialize/          Phase 0: pre-existing-node_modules gate, npm pack
                        with parallel chunks + per-spec retry, tarball
                        extract with strip-components, hardlink tree,
                        Tarjan-SCC + npm hoist/nest placement.
  depgraph/             Walks node_modules to recover the resolved dep
                        graph; provides version-precise IsReachableKey /
                        PathsToLeafKey for the VulnPathOnly heuristic.
  entrypoints/          Infers Jelly entry-points from package.json
                        (bin/main/module/exports) and tsconfig.json
                        (files/include) with symlink-aware containment.
  scan/                 Phase 1 import-reachability prune; Phase 2 with
                        bucket-split-on-timeout and heuristic chain
                        [VulnPathOnly, IgnoreDeps].
```

## Behavior

- **Conservative by default**: absence of a signal means "unknown or reachable"; only an explicit Jelly-confirmed-unreachable verdict emits the VEX justification. Subprocess crashes and Diagnostics-flagged early terminations are treated as "untrustworthy", never as "unreachable".
- **Skipped vs. unreachable**: vulns whose package isn't on disk (materialize failures, orphan-in-graph, version-mismatch) are returned as `Skipped` so no false-unreachable signal is emitted.
- **Wall-clock guard**: 1.5× the configured internal timeout, SIGKILL to the process group on expiry, with race-free kill-vs-reap coordination via a non-blocking re-check of the wait channel.
- **Trust-matches regime**: a non-zero subprocess exit after a fully-completed scan (≥2 analyzer rounds, matches present) trusts the results and logs the underlying error rather than discarding.
- **Cancellation taxonomy**: `terminationCause` enum (Unknown / Normal / TimedOut / Canceled) is the sole classification signal; cancellation errors are returned verbatim so downstream `errors.Is(err, context.Canceled / DeadlineExceeded)` checks work without sentinel wrapping.
- **Tar-slip defense**: `ExtractTarball` rejects `..` path segments AND verifies the cleaned absolute form lives under the cleaned `destDir` prefix (defense in depth against CWE-22).
- **CLI-flag injection defense**: `npm pack` invocations use `--` separator before positional package specs so a malformed `Name` starting with `-` can't be misinterpreted as a flag.

## Configuration

Currently via the `SCALIBR_JELLY_METADATA_FILE` environment variable. `PluginConfig` proto wiring is a follow-up.

## Plugin registration

- `enricher/enricher.go`: registers `reachability/javascript` in `EnricherOrder` after `vulnmatch/osvdev`.
- `enricher/enricherlist/list.go`: registers `javascript.New`.
- `RequiredPlugins`: `packagelockjson`, `pnpmlock`, `yarnlock`, `osvdev`.

## Runtime requirements

- Node ≥ 22 and `jelly` on PATH.
- `npm` on PATH for materialization (only used when `node_modules` doesn't already exist).
- Linux/macOS for the subprocess implementation; Windows builds compile but `Available()` returns false and the enricher skips cleanly.

## Test plan

- [x] **73 unit tests** covering:
  - corpus parsing/validation (protojson, default range type, marshal roundtrip)
  - jelly flag-builder snapshots, `NODE_OPTIONS` merge, `MockClient` queue, `parseNodeMajor`, `readScanResult` (incl. `LowConfidence` rule)
  - `runJelly` cause classification (4 branches: parent-cancel, parent-deadline, local-deadline, defensive)
  - scan heuristics (`VulnPathOnly` per-VulnRef pointer map, `IgnoreDeps` sentinel, glob `<token>` matcher with `*` / `**` / `?` / `{a,b}`)
  - scan bucket loop (timeout-split, heuristic-advance, `FailedPackages` partition, `ErrBucketTimeout` / `ErrBucketTerminatedEarly` wrap with `TerminationError`)
  - scan `writeBucketVulns` (`?`-vs-`(cbarg)` dedup, cross-entry OSVID dedup so duplicate refs don't double-write)
  - depgraph build (flat layout, nested multi-version, scoped packages, no-tree, version-precise `IsReachableKey` distinguishing orphan from reachable)
  - entrypoints inference (`bin` string/map, nested conditional `exports`, tsconfig `files` + `include` with glob-prefix reduction, symlink-aware containment with `EvalSymlinks`, pre-build acceptance via lexical fallback on `ErrNotExist`, dedup on realAbs)
  - materialize placement (single root, hoist, multi-version nest, npm alias, Tarjan SCC, duplicate `(name,version)` detection, collision losers surfaced as `FailedPackage`)
  - tarball extract (segment-aware `..` rejection, post-Join containment, hardlink tree with `os.SameFile` idempotency)
- [x] **4 integration tests** (build-tag `integration`) drive real Jelly against the `GHSA-fv66-9v8q-g76r` and `GHSA-j5w5-568x-rq53` pairs (positive / negative) under `testdata/`. Assert exact VEX signal presence/absence per fixture.
- [x] `go vet`, `gofmt`, and `golangci-lint run` clean on both `GOOS=linux` and `GOOS=windows`.
- [x] Cross-compiles for `linux/amd64` and `windows/amd64`.

