### PR TITLE
feat: add JavaScript CDN extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -85,6 +85,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | gradle.lockfile                                   | `java/gradlelockfile`                |
 |            | verification-metadata.xml                         | `java/gradleverificationmetadataxml` |
 | Javascript | Installed NPM packages (package.json)             | `javascript/packagejson`             |
+|            | NPM packages from JavaScript CDN URLs in HTML     | `javascript/cdn`                     |
 |            | package-lock.json, npm-shrinkwrap.json            | `javascript/packagelockjson`         |
 |            | yarn.lock                                         | `javascript/yarnlock`                |
 |            | pnpm-lock.yaml                                    | `javascript/pnpmlock`                |

--- a/extractor/filesystem/language/javascript/cdn/cdn.go
+++ b/extractor/filesystem/language/javascript/cdn/cdn.go
@@ -1,0 +1,328 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cdn extracts NPM packages loaded from JavaScript CDN URLs in HTML.
+package cdn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"golang.org/x/net/html"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "javascript/cdn"
+
+	// defaultMaxFileSizeBytes is the default maximum file size the extractor
+	// will attempt to extract.
+	defaultMaxFileSizeBytes = 10 * units.MiB
+)
+
+var (
+	semverStartRe = regexp.MustCompile(`^\d`)
+	npmNameRe     = regexp.MustCompile(`^(@[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+|[A-Za-z0-9_.-]+)$`)
+)
+
+// Extractor extracts NPM package references from JavaScript CDN URLs in HTML.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+type importMap struct {
+	Imports map[string]string            `json:"imports"`
+	Scopes  map[string]map[string]string `json:"scopes"`
+}
+
+// New returns a JavaScript CDN extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file is an HTML file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := filepath.ToSlash(api.Path())
+	if !slices.Contains([]string{".html", ".htm"}, strings.ToLower(filepath.Ext(path))) {
+		return false
+	}
+
+	fi, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if fi.IsDir() {
+		return false
+	}
+	if e.maxFileSizeBytes > 0 && fi.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fi.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fi.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract extracts NPM packages from JavaScript CDN URLs in an HTML file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := parse(ctx, input.Reader, input.Path)
+	if err != nil {
+		e.reportFileExtracted(input.Path, input.Info, err)
+		return inventory.Inventory{}, fmt.Errorf("cdn.parse(%q): %w", input.Path, err)
+	}
+
+	e.reportFileExtracted(input.Path, input.Info, nil)
+	return inventory.Inventory{Packages: pkgs}, nil
+}
+
+func (e Extractor) reportFileExtracted(path string, fileinfo fs.FileInfo, err error) {
+	if e.Stats == nil {
+		return
+	}
+	var fileSizeBytes int64
+	if fileinfo != nil {
+		fileSizeBytes = fileinfo.Size()
+	}
+	e.Stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+		Path:          path,
+		Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+func parse(ctx context.Context, r io.Reader, path string) ([]*extractor.Package, error) {
+	doc, err := html.Parse(r)
+	if err != nil {
+		return nil, fmt.Errorf("html parse: %w", err)
+	}
+
+	var urls []string
+	var walk func(*html.Node) error
+	walk = func(n *html.Node) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if n.Type == html.ElementNode && strings.EqualFold(n.Data, "script") {
+			if src := attr(n, "src"); src != "" {
+				urls = append(urls, src)
+			}
+			if strings.EqualFold(attr(n, "type"), "importmap") {
+				urls = append(urls, importMapURLs(scriptText(n))...)
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			if err := walk(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := walk(doc); err != nil {
+		return nil, err
+	}
+
+	var pkgs []*extractor.Package
+	for _, rawURL := range urls {
+		if pkg := packageFromURL(rawURL, path); pkg != nil {
+			pkgs = append(pkgs, pkg)
+		}
+	}
+	return dedupePackages(pkgs), nil
+}
+
+func attr(n *html.Node, name string) string {
+	for _, a := range n.Attr {
+		if strings.EqualFold(a.Key, name) {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func scriptText(n *html.Node) string {
+	var b strings.Builder
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		if child.Type == html.TextNode {
+			b.WriteString(child.Data)
+		}
+	}
+	return b.String()
+}
+
+func importMapURLs(raw string) []string {
+	var im importMap
+	if err := json.Unmarshal([]byte(raw), &im); err != nil {
+		return nil
+	}
+
+	var urls []string
+	for _, spec := range im.Imports {
+		urls = append(urls, spec)
+	}
+	for _, scopeImports := range im.Scopes {
+		for _, spec := range scopeImports {
+			urls = append(urls, spec)
+		}
+	}
+	return urls
+}
+
+func packageFromURL(rawURL string, path string) *extractor.Package {
+	name, version, ok := packageNameVersionFromURL(rawURL)
+	if !ok {
+		return nil
+	}
+	return &extractor.Package{
+		Name:     name,
+		Version:  version,
+		PURLType: purl.TypeNPM,
+		Location: extractor.LocationFromPath(path),
+	}
+}
+
+func packageNameVersionFromURL(rawURL string) (string, string, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", false
+	}
+	if u.Scheme != "https" {
+		return "", "", false
+	}
+
+	trimmedPath := strings.TrimPrefix(u.EscapedPath(), "/")
+	var spec string
+	switch strings.ToLower(u.Hostname()) {
+	case "unpkg.com", "esm.run":
+		spec = trimmedPath
+	case "cdn.jsdelivr.net":
+		if !strings.HasPrefix(trimmedPath, "npm/") {
+			return "", "", false
+		}
+		spec = strings.TrimPrefix(trimmedPath, "npm/")
+	default:
+		return "", "", false
+	}
+	return splitNPMSpec(spec)
+}
+
+func splitNPMSpec(spec string) (string, string, bool) {
+	spec, err := url.PathUnescape(spec)
+	if err != nil {
+		return "", "", false
+	}
+	spec = strings.TrimSpace(spec)
+	if spec == "" || strings.HasPrefix(spec, ".") || strings.Contains(spec, "://") {
+		return "", "", false
+	}
+
+	name, rest, ok := splitNameAndRest(spec)
+	if !ok || !npmNameRe.MatchString(name) {
+		return "", "", false
+	}
+
+	if !strings.HasPrefix(rest, "@") {
+		return "", "", false
+	}
+	version := strings.TrimPrefix(rest, "@")
+	if idx := strings.Index(version, "/"); idx >= 0 {
+		version = version[:idx]
+	}
+	version = strings.TrimPrefix(version, "v")
+	if version == "" || !semverStartRe.MatchString(version) {
+		return "", "", false
+	}
+	return name, version, true
+}
+
+func splitNameAndRest(spec string) (string, string, bool) {
+	if strings.HasPrefix(spec, "@") {
+		slash := strings.Index(spec, "/")
+		if slash <= 1 {
+			return "", "", false
+		}
+		rest := spec[slash+1:]
+		at := strings.Index(rest, "@")
+		if at < 0 {
+			return "", "", false
+		}
+		return spec[:slash+1+at], rest[at:], true
+	}
+
+	at := strings.Index(spec, "@")
+	if at <= 0 {
+		return "", "", false
+	}
+	return spec[:at], spec[at:], true
+}
+
+func dedupePackages(pkgs []*extractor.Package) []*extractor.Package {
+	seen := map[string]bool{}
+	var out []*extractor.Package
+	for _, pkg := range pkgs {
+		key := strings.Join([]string{
+			pkg.PURLType,
+			pkg.Name,
+			pkg.Version,
+			pkg.Location.PathOrEmpty(),
+		}, "\x00")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, pkg)
+	}
+	return out
+}

--- a/extractor/filesystem/language/javascript/cdn/cdn_test.go
+++ b/extractor/filesystem/language/javascript/cdn/cdn_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdn_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/cdn"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		want             bool
+	}{
+		{
+			name: "html",
+			path: "index.html",
+			want: true,
+		},
+		{
+			name: "nested_htm",
+			path: "public/app.htm",
+			want: true,
+		},
+		{
+			name: "javascript_not_required",
+			path: "app.js",
+			want: false,
+		},
+		{
+			name: "markdown_not_required",
+			path: "README.md",
+			want: false,
+		},
+		{
+			name:             "too_large",
+			path:             "index.html",
+			fileSizeBytes:    2 * units.MiB,
+			maxFileSizeBytes: 1 * units.MiB,
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1 * units.KiB
+			}
+			e, err := cdn.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("cdn.New: %v", err)
+			}
+
+			got := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if got != tt.want {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantPackages []*extractor.Package
+		wantErr      error
+	}{
+		{
+			name: "html_script_and_importmap_cdns",
+			path: "testdata/index.html",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "lodash-es",
+					Version:  "4.17.21",
+					PURLType: purl.TypeNPM,
+					Location: extractor.LocationFromPath("testdata/index.html"),
+				},
+				{
+					Name:     "@scope/pkg",
+					Version:  "2.3.4",
+					PURLType: purl.TypeNPM,
+					Location: extractor.LocationFromPath("testdata/index.html"),
+				},
+				{
+					Name:     "vue",
+					Version:  "3.4.21",
+					PURLType: purl.TypeNPM,
+					Location: extractor.LocationFromPath("testdata/index.html"),
+				},
+				{
+					Name:     "react",
+					Version:  "18.2.0",
+					PURLType: purl.TypeNPM,
+					Location: extractor.LocationFromPath("testdata/index.html"),
+				},
+				{
+					Name:     "preact",
+					Version:  "10.19.6",
+					PURLType: purl.TypeNPM,
+					Location: extractor.LocationFromPath("testdata/index.html"),
+				},
+			},
+		},
+		{
+			name:         "no_supported_cdn_packages",
+			path:         "testdata/no_packages.html",
+			wantPackages: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := extracttest.GenerateScanInputMock(t, extracttest.ScanInputMockConfig{
+				Path: tt.path,
+			})
+			defer extracttest.CloseTestScanInput(t, input)
+
+			e, err := cdn.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("cdn.New: %v", err)
+			}
+			got, err := e.Extract(t.Context(), &input)
+			if !cmp.Equal(err, tt.wantErr, cmpopts.EquateErrors()) {
+				t.Fatalf("Extract(%s) error got %v, want %v", tt.path, err, tt.wantErr)
+			}
+
+			want := inventory.Inventory{Packages: tt.wantPackages}
+			if diff := cmp.Diff(want, got, cmpopts.SortSlices(extracttest.PackageCmpLess), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Extract(%s) diff (-want +got):\n%s", tt.path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/javascript/cdn/testdata/index.html
+++ b/extractor/filesystem/language/javascript/cdn/testdata/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="https://unpkg.com/lodash-es@4.17.21/lodash.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/vue@3.4.21/dist/vue.esm-browser.js"></script>
+    <script src="https://unpkg.com/@scope/pkg@2.3.4/dist/index.js"></script>
+    <script src="/static/app.js"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.run/react@18.2.0",
+          "preact/hooks": "https://esm.run/preact@10.19.6/hooks",
+          "local": "/vendor/local.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <script>
+      import("https://unpkg.com/ignored-dynamic@1.0.0/index.js");
+    </script>
+  </body>
+</html>

--- a/extractor/filesystem/language/javascript/cdn/testdata/no_packages.html
+++ b/extractor/filesystem/language/javascript/cdn/testdata/no_packages.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="/static/app.js"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "local": "/vendor/local.js"
+        }
+      }
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -54,6 +54,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradleverificationmetadataxml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/pomxml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/bunlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/cdn"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/denojson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/denotssource"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/packagejson"
@@ -211,6 +212,7 @@ var (
 	JavascriptSource = InitMap{
 		packagejson.Name:     {packagejson.New},
 		packagelockjson.Name: {packagelockjson.New},
+		cdn.Name:             {cdn.New},
 		denojson.Name:        {denojson.New},
 		denotssource.Name:    {denotssource.New},
 		pnpmlock.Name:        {pnpmlock.New},


### PR DESCRIPTION
## Summary

Adds a filesystem extractor for NPM packages loaded from JavaScript CDN URLs in HTML files.

The extractor currently covers:
- `<script src=...>` URLs for `unpkg.com`, `cdn.jsdelivr.net/npm`, and `esm.run`
- `<script type="importmap">` top-level `imports` and scoped imports
- scoped and unscoped NPM package specs with pinned versions

Extracted packages are emitted as `pkg:npm` inventory so downstream vuln matching can process them.

Refers to #2029.

## Tests

- `go test ./extractor/filesystem/language/javascript/cdn`
- `go test ./extractor/filesystem/list`
- `go test ./extractor/filesystem/language/javascript/...`
- `go test ./...`