### PR TITLE
Add Clojars and Databricks secret detectors

### DIFF
--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -131,6 +131,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/azurestorageaccountaccesskey"
 	"github.com/google/osv-scalibr/veles/secrets/azuretoken"
 	"github.com/google/osv-scalibr/veles/secrets/circleci"
+	"github.com/google/osv-scalibr/veles/secrets/clojars"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
@@ -372,6 +373,7 @@ var (
 		{azurestorageaccountaccesskey.NewDetector(), "secrets/azurestorageaccountaccesskey", 0},
 		{circleci.NewPersonalAccessTokenDetector(), "secrets/circlecipat", 0},
 		{circleci.NewProjectTokenDetector(), "secrets/circleciproject", 0},
+		{clojars.NewDetector(), "secrets/clojars", 0},
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -134,6 +134,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/clojars"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
+	"github.com/google/osv-scalibr/veles/secrets/databrickspat"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
 	"github.com/google/osv-scalibr/veles/secrets/digitaloceanapikey"
 	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
@@ -375,6 +376,7 @@ var (
 		{circleci.NewProjectTokenDetector(), "secrets/circleciproject", 0},
 		{clojars.NewDetector(), "secrets/clojars", 0},
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
+		{databrickspat.NewDetector(), "secrets/databrickspat", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},

--- a/veles/secrets/clojars/clojars.go
+++ b/veles/secrets/clojars/clojars.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clojars
+
+// DeployToken is a Veles Secret that holds relevant information for a
+// Clojars Deploy Token (prefix `CLOJARS_`).
+type DeployToken struct {
+	Token string
+}

--- a/veles/secrets/clojars/detector.go
+++ b/veles/secrets/clojars/detector.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clojars contains a Veles Secret type and Detector for Clojars Deploy
+// Tokens (prefix `CLOJARS_`).
+package clojars
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+// maxTokenLength is the maximum size of a Clojars Deploy Token.
+const maxTokenLength = 68
+
+// deployTokenRe is a regular expression that matches a Clojars Deploy Token.
+// Deploy tokens have the form: `CLOJARS_` followed by exactly 60 hexadecimal
+// characters.
+var deployTokenRe = regexp.MustCompile(`\bCLOJARS_[A-Fa-f0-9]{60}\b`)
+
+// NewDetector returns a new simpletoken.Detector that matches Clojars Deploy
+// Tokens.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: maxTokenLength,
+		Re:     deployTokenRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return DeployToken{Token: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/clojars/detector_test.go
+++ b/veles/secrets/clojars/detector_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clojars_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/clojars"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+const testDeployToken = `CLOJARS_0123456789abcdefABCDEF0123456789abcdefABCDEF0123456789abcdef`
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		clojars.NewDetector(),
+		testDeployToken,
+		clojars.DeployToken{Token: testDeployToken},
+	)
+}
+
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{clojars.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherToken := testDeployToken[:len(testDeployToken)-1] + "0"
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "simple matching string",
+		input: testDeployToken,
+		want: []veles.Secret{
+			clojars.DeployToken{Token: testDeployToken},
+		},
+	}, {
+		name:  "match at end of env assignment",
+		input: `CLOJARS_DEPLOY_TOKEN=` + testDeployToken,
+		want: []veles.Secret{
+			clojars.DeployToken{Token: testDeployToken},
+		},
+	}, {
+		name:  "match in quoted config value",
+		input: `:deploy-token "` + testDeployToken + `"`,
+		want: []veles.Secret{
+			clojars.DeployToken{Token: testDeployToken},
+		},
+	}, {
+		name:  "multiple distinct matches",
+		input: testDeployToken + "\n" + otherToken,
+		want: []veles.Secret{
+			clojars.DeployToken{Token: testDeployToken},
+			clojars.DeployToken{Token: otherToken},
+		},
+	}, {
+		name: "larger input containing token",
+		input: fmt.Sprintf(`
+	:username "example"
+	:password "%s"
+		`, testDeployToken),
+		want: []veles.Secret{
+			clojars.DeployToken{Token: testDeployToken},
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDetector_trueNegatives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{clojars.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "empty input",
+		input: "",
+	}, {
+		name:  "short token should not match",
+		input: testDeployToken[:len(testDeployToken)-1],
+	}, {
+		name:  "long token should not match",
+		input: testDeployToken + "0",
+	}, {
+		name:  "invalid hex character should not match",
+		input: testDeployToken[:len(testDeployToken)-1] + "g",
+	}, {
+		name:  "incorrect prefix should not match",
+		input: "CLOJURE_" + testDeployToken[len("CLOJARS_"):],
+	}, {
+		name:  "lowercase prefix should not match",
+		input: strings.ToLower(testDeployToken[:len("CLOJARS_")]) + testDeployToken[len("CLOJARS_"):],
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/databrickspat/databrickspat.go
+++ b/veles/secrets/databrickspat/databrickspat.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databrickspat
+
+// UserAccountPAT is a Veles Secret that holds relevant information for a
+// Databricks User Account Personal Access Token (prefix `dapi`).
+type UserAccountPAT struct {
+	Token string
+}

--- a/veles/secrets/databrickspat/detector.go
+++ b/veles/secrets/databrickspat/detector.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package databrickspat contains a Veles Secret type and Detector for
+// Databricks User Account Personal Access Tokens (prefix `dapi`).
+package databrickspat
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+// maxTokenLength is the maximum size of a Databricks User Account PAT, plus
+// one optional terminating delimiter consumed by patRe.
+const maxTokenLength = 40
+
+// patRe is a regular expression that matches a Databricks User Account PAT.
+// Databricks API tokens have the form: `dapi` followed by 32 lowercase
+// hexadecimal characters, with an optional single digit suffix.
+var patRe = regexp.MustCompile(`\bdapi[a-f0-9]{32}(?:-\d)?(?:[^A-Za-z0-9-]|$)`)
+
+// NewDetector returns a new simpletoken.Detector that matches Databricks User
+// Account Personal Access Tokens.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: maxTokenLength,
+		Re:     patRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			if len(b) > 0 && !isHexChar(b[len(b)-1]) {
+				b = b[:len(b)-1]
+			}
+			return UserAccountPAT{Token: string(b)}, true
+		},
+	}
+}
+
+func isHexChar(b byte) bool {
+	return (b >= 'a' && b <= 'f') || (b >= '0' && b <= '9')
+}

--- a/veles/secrets/databrickspat/detector_test.go
+++ b/veles/secrets/databrickspat/detector_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databrickspat_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/databrickspat"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+const testPAT = `dapi0123456789abcdef0123456789abcdef`
+const testPATWithSuffix = `dapi0123456789abcdef0123456789abcdef-2`
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		databrickspat.NewDetector(),
+		testPAT,
+		databrickspat.UserAccountPAT{Token: testPAT},
+	)
+}
+
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{databrickspat.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherToken := testPAT[:len(testPAT)-1] + "0"
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "simple matching string",
+		input: testPAT,
+		want: []veles.Secret{
+			databrickspat.UserAccountPAT{Token: testPAT},
+		},
+	}, {
+		name:  "optional single digit suffix",
+		input: testPATWithSuffix,
+		want: []veles.Secret{
+			databrickspat.UserAccountPAT{Token: testPATWithSuffix},
+		},
+	}, {
+		name:  "match at end of env assignment",
+		input: `DATABRICKS_TOKEN=` + testPAT,
+		want: []veles.Secret{
+			databrickspat.UserAccountPAT{Token: testPAT},
+		},
+	}, {
+		name:  "multiple distinct matches",
+		input: testPAT + "\n" + otherToken,
+		want: []veles.Secret{
+			databrickspat.UserAccountPAT{Token: testPAT},
+			databrickspat.UserAccountPAT{Token: otherToken},
+		},
+	}, {
+		name: "larger input containing token",
+		input: fmt.Sprintf(`
+	[DEFAULT]
+	token = "%s"
+		`, testPAT),
+		want: []veles.Secret{
+			databrickspat.UserAccountPAT{Token: testPAT},
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDetector_trueNegatives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{databrickspat.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "empty input",
+		input: "",
+	}, {
+		name:  "short token should not match",
+		input: testPAT[:len(testPAT)-1],
+	}, {
+		name:  "long token should not match",
+		input: testPAT + "0",
+	}, {
+		name:  "invalid hex character should not match",
+		input: testPAT[:len(testPAT)-1] + "g",
+	}, {
+		name:  "uppercase hex should not match",
+		input: strings.ToUpper(testPAT),
+	}, {
+		name:  "incorrect prefix should not match",
+		input: "dapo" + testPAT[len("dapi"):],
+	}, {
+		name:  "two digit suffix should not match as full token",
+		input: testPAT + "-20",
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds Veles secret detectors for two accepted OSV-SCALIBR Patch Rewards Program requests:

- Clojars Deploy Tokens (`CLOJARS_` followed by exactly 60 hexadecimal characters) for #1749
- Databricks User Account Personal Access Tokens (`dapi` followed by 32 lowercase hexadecimal characters, with an optional single-digit suffix) for #1719

Both detectors use local regex-only matching and fake test tokens. No active validation or network calls are performed.

## Test Plan

```bash
go test ./veles/secrets/clojars/... ./veles/secrets/databrickspat/... ./extractor/filesystem/list/...
go test ./veles/secrets/... ./extractor/filesystem/list/...
```

## Notes

- The Clojars detector follows the issue's strict token format: `CLOJARS_` + 60 hex characters.
- The Databricks detector intentionally uses a conservative known scanner-style pattern to reduce false positives: `dapi` + 32 lowercase hex characters, with optional `-<digit>` suffix.

Refs #1749
Refs #1719
