### PR TITLE
fix(python/setup): match package names containing '-', '.', '_'

### DIFF
--- a/extractor/filesystem/language/python/setup/setup.go
+++ b/extractor/filesystem/language/python/setup/setup.go
@@ -123,7 +123,11 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	return inventory.Inventory{Packages: pkgs}, err
 }
 
-var packageVersionRe = regexp.MustCompile(`['"]\W?(\w+)\W?(==|>=|<=)\W?([\w.]*)`)
+// packageVersionRe matches a Python distribution name and version specifier inside
+// a quoted string (e.g. "Flask-Security-Too==3.4.3"). The name group permits the
+// characters allowed by PEP 508 distribution names: letters, digits, ".", "-", "_",
+// with the first and last characters constrained to be alphanumeric.
+var packageVersionRe = regexp.MustCompile(`['"]\s*([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)\s*(==|>=|<=)\s*([\w.]+)`)
 
 func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Package, error) {
 	s := bufio.NewScanner(input.Reader)

--- a/extractor/filesystem/language/python/setup/setup_test.go
+++ b/extractor/filesystem/language/python/setup/setup_test.go
@@ -224,6 +224,27 @@ func TestExtract(t *testing.T) {
 					Location: extractor.LocationFromPathAndLine("testdata/valid", 29),
 					Metadata: &setup.Metadata{VersionComparator: "<="},
 				},
+				{
+					Name:     "Flask-Security-Too",
+					Version:  "3.4.3",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid", 30),
+					Metadata: &setup.Metadata{VersionComparator: "=="},
+				},
+				{
+					Name:     "python-dateutil",
+					Version:  "2.8.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid", 31),
+					Metadata: &setup.Metadata{VersionComparator: ">="},
+				},
+				{
+					Name:     "zope.interface",
+					Version:  "5.4.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid", 32),
+					Metadata: &setup.Metadata{VersionComparator: "=="},
+				},
 			},
 		},
 		{
@@ -324,6 +345,13 @@ func TestExtract(t *testing.T) {
 			Name: "empty package setup.py file",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/empty",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "setup.py file with invalid package names",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid_names",
 			},
 			WantPackages: []*extractor.Package{},
 		},

--- a/extractor/filesystem/language/python/setup/testdata/invalid_names
+++ b/extractor/filesystem/language/python/setup/testdata/invalid_names
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    install_requires=[
+        "pkg-==1.0",
+        "pkg.==1.0",
+        "pkg_==1.0",
+        "-pkg==1.0",
+        ".pkg==1.0",
+        "_pkg==1.0",
+    ],
+)

--- a/extractor/filesystem/language/python/setup/testdata/valid
+++ b/extractor/filesystem/language/python/setup/testdata/valid
@@ -27,6 +27,9 @@ setup(
         "pydantic>=1.8.2,<2.0",
         "certifi>=2017.4.17",
         "pkg3<= 1.2.3",
+        "Flask-Security-Too==3.4.3",
+        "python-dateutil>=2.8.0",
+        "zope.interface==5.4.0",
         # 'sslyze>=4.0.4', # todo,
         "foo"
       ],


### PR DESCRIPTION
Fix https://github.com/google/osv-scalibr/issues/2113

## Problem

The `python/setup` extractor's `packageVersionRe` used `\w+` for the package name, which matches only `[A-Za-z0-9_]`. As a result, valid PEP 508 distribution names containing `-` or `.` were silently dropped:

- `Flask-Security-Too==3.4.3`
- `python-dateutil>=2.8.0`
- `zope.interface==5.4.0`

## Changes

- Relax the name capture group to `[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?`, matching PEP 508 (letters, digits, `.`, `-`, `_`; first and last characters must be alphanumeric).
- Tighten surrounding whitespace handling from `\W?` to `\s*`.
- Require at least one version character (`[\w.]*` → `[\w.]+`).
- Add `Flask-Security-Too`, `python-dateutil`, `zope.interface` cases to `testdata/valid`.
- Add `testdata/invalid_names` negative fixture covering 6 PEP 508 boundary violations (leading / trailing `-`, `.`, `_`).
