### PR TITLE
java/gradleversioncatalog: add Gradle Version Catalog extractor (#1979)

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -84,6 +84,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | pom.xml                                           | `java/pomxml`                        |
 |            | gradle.lockfile                                   | `java/gradlelockfile`                |
 |            | verification-metadata.xml                         | `java/gradleverificationmetadataxml` |
+|            | libs.versions.toml (Gradle Version Catalog)       | `java/gradleversioncatalog`          |
 | Javascript | Installed NPM packages (package.json)             | `javascript/packagejson`             |
 |            | package-lock.json, npm-shrinkwrap.json            | `javascript/packagelockjson`         |
 |            | yarn.lock                                         | `javascript/yarnlock`                |

--- a/extractor/filesystem/language/java/gradleversioncatalog/gradleversioncatalog.go
+++ b/extractor/filesystem/language/java/gradleversioncatalog/gradleversioncatalog.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gradleversioncatalog extracts Gradle Version Catalog files
+// (libs.versions.toml) used by Gradle 7.0+ to centralize Maven-coordinate
+// dependency declarations across multi-module builds.
+package gradleversioncatalog
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/java/javalockfile"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "java/gradleversioncatalog"
+)
+
+// catalogFile is the top-level shape of a libs.versions.toml document.
+// The [bundles] and [plugins] tables are intentionally not parsed:
+// bundles only group already-declared libraries, and Gradle plugins
+// resolve to a different PURL space than Maven artifacts.
+type catalogFile struct {
+	Versions  map[string]string `toml:"versions"`
+	Libraries map[string]any    `toml:"libraries"`
+}
+
+// Extractor extracts Maven packages from Gradle Version Catalog files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the specified file matches the Gradle
+// Version Catalog naming convention. The default catalog filename is
+// libs.versions.toml; additional catalogs may be declared under any
+// *.versions.toml name inside a gradle/ directory.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	base := filepath.Base(path)
+	if base == "libs.versions.toml" {
+		return true
+	}
+	if strings.HasSuffix(base, ".versions.toml") {
+		dir := filepath.Base(filepath.Dir(path))
+		return dir == "gradle"
+	}
+	return false
+}
+
+// Extract parses a libs.versions.toml file and returns its declared
+// libraries as Maven packages.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	var cf catalogFile
+	if _, err := toml.NewDecoder(input.Reader).Decode(&cf); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to parse %s: %w", input.Path, err)
+	}
+
+	var packages []*extractor.Package
+	for _, raw := range cf.Libraries {
+		group, artifact, version, ok := resolveLibrary(raw, cf.Versions)
+		if !ok {
+			continue
+		}
+		packages = append(packages, &extractor.Package{
+			Name:     fmt.Sprintf("%s:%s", group, artifact),
+			Version:  version,
+			PURLType: purl.TypeMaven,
+			Metadata: &javalockfile.Metadata{
+				ArtifactID: artifact,
+				GroupID:    group,
+			},
+			Location: extractor.LocationFromPath(input.Path),
+		})
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+// resolveLibrary normalizes the four shapes a [libraries] entry can take
+// into (group, artifact, version). It returns ok=false when the entry is
+// missing required coordinates or uses unresolvable version refs.
+//
+// Shapes accepted (per Gradle Version Catalog spec):
+//  1. String shorthand:           "group:artifact:version"
+//  2. Inline table with module:   { module = "g:a", version = "1.0" }
+//  3. Inline table with module
+//     and version.ref shorthand:  { module = "g:a", version.ref = "alias" }
+//  4. Inline table with explicit
+//     group/name fields:          { group = "g", name = "a", version = "1.0" }
+//
+// The version field itself may be: a string, a {ref = "alias"} table, or a
+// rich version table containing strictly/require/prefer. A missing version
+// resolves to empty (Gradle allows version-less entries; downstream tools
+// treat them as unpinned).
+func resolveLibrary(raw any, versions map[string]string) (group, artifact, version string, ok bool) {
+	switch v := raw.(type) {
+	case string:
+		parts := strings.SplitN(v, ":", 3)
+		if len(parts) < 2 {
+			return "", "", "", false
+		}
+		if len(parts) == 2 {
+			return parts[0], parts[1], "", true
+		}
+		return parts[0], parts[1], parts[2], true
+
+	case map[string]any:
+		if module, hasModule := v["module"].(string); hasModule {
+			parts := strings.SplitN(module, ":", 2)
+			if len(parts) != 2 {
+				return "", "", "", false
+			}
+			group, artifact = parts[0], parts[1]
+		} else if g, hasGroup := v["group"].(string); hasGroup {
+			n, hasName := v["name"].(string)
+			if !hasName {
+				return "", "", "", false
+			}
+			group, artifact = g, n
+		} else {
+			return "", "", "", false
+		}
+		version = resolveVersion(v["version"], versions)
+		return group, artifact, version, true
+	}
+	return "", "", "", false
+}
+
+// resolveVersion turns the polymorphic `version` field into a concrete
+// string. Returns "" when the value is missing or references an undefined
+// alias — downstream callers may still emit the package as unpinned.
+//
+// Resolution order, mirroring Gradle's runtime behavior:
+//   - rich {strictly} wins over {require} wins over {prefer}
+//   - {ref} indirects into the [versions] table
+func resolveVersion(raw any, versions map[string]string) string {
+	switch v := raw.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case map[string]any:
+		if ref, ok := v["ref"].(string); ok {
+			return versions[ref]
+		}
+		if s, ok := v["strictly"].(string); ok {
+			return s
+		}
+		if s, ok := v["require"].(string); ok {
+			return s
+		}
+		if s, ok := v["prefer"].(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/java/gradleversioncatalog/gradleversioncatalog_test.go
+++ b/extractor/filesystem/language/java/gradleversioncatalog/gradleversioncatalog_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gradleversioncatalog_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradleversioncatalog"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/java/javalockfile"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{name: "empty path", inputPath: "", want: false},
+		{name: "default catalog filename", inputPath: "libs.versions.toml", want: true},
+		{name: "default catalog in subdir", inputPath: "path/to/libs.versions.toml", want: true},
+		{name: "default catalog in gradle dir", inputPath: "gradle/libs.versions.toml", want: true},
+		{name: "additional catalog under gradle dir", inputPath: "gradle/testLibs.versions.toml", want: true},
+		{name: "additional catalog under deep gradle dir", inputPath: "a/b/gradle/testLibs.versions.toml", want: true},
+		{name: "additional catalog outside gradle dir is skipped", inputPath: "src/testLibs.versions.toml", want: false},
+		{name: "suffix-only is not a match", inputPath: "path/to/libs.versions.toml.bak", want: false},
+		{name: "dotted-name not in gradle dir is skipped", inputPath: "path.to.my.libs.versions.toml", want: false},
+		{name: "unrelated toml file is skipped", inputPath: "Cargo.toml", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := gradleversioncatalog.Extractor{}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%q) = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "invalid toml returns error",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid.versions.toml",
+			},
+			WantPackages: nil,
+			WantErr:      extracttest.ContainsErrStr{Str: "failed to parse"},
+		},
+		{
+			Name: "not-toml returns error",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/not-toml.txt",
+			},
+			WantPackages: nil,
+			WantErr:      extracttest.ContainsErrStr{Str: "failed to parse"},
+		},
+		{
+			Name: "empty libraries section yields no packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.versions.toml",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "all library shapes",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/libs.versions.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "com.google.guava:guava",
+					Version:  "30.1.1-jre",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{GroupID: "com.google.guava", ArtifactID: "guava"},
+					Location: extractor.LocationFromPath("testdata/libs.versions.toml"),
+				},
+				{
+					Name:     "com.puppycrawl.tools:checkstyle",
+					Version:  "8.37",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{GroupID: "com.puppycrawl.tools", ArtifactID: "checkstyle"},
+					Location: extractor.LocationFromPath("testdata/libs.versions.toml"),
+				},
+				{
+					Name:     "org.codehaus.groovy:groovy",
+					Version:  "3.0.5",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{GroupID: "org.codehaus.groovy", ArtifactID: "groovy"},
+					Location: extractor.LocationFromPath("testdata/libs.versions.toml"),
+				},
+				{
+					Name:     "org.apache.commons:commons-lang3",
+					Version:  "3.12.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{GroupID: "org.apache.commons", ArtifactID: "commons-lang3"},
+					Location: extractor.LocationFromPath("testdata/libs.versions.toml"),
+				},
+				{
+					Name:     "org.example:strict",
+					Version:  "2.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{GroupID: "org.example", ArtifactID: "strict"},
+					Location: extractor.LocationFromPath("testdata/libs.versions.toml"),
+				},
+				{
+					Name:     "org.example:req",
+					Version:  "1.5",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{GroupID: "org.example", ArtifactID: "req"},
+					Location: extractor.LocationFromPath("testdata/libs.versions.toml"),
+				},
+				{
+					Name:     "org.example:pref",
+					Version:  "1.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{GroupID: "org.example", ArtifactID: "pref"},
+					Location: extractor.LocationFromPath("testdata/libs.versions.toml"),
+				},
+				{
+					Name:     "org.codehaus.groovy:groovy-json",
+					Version:  "3.0.5",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{GroupID: "org.codehaus.groovy", ArtifactID: "groovy-json"},
+					Location: extractor.LocationFromPath("testdata/libs.versions.toml"),
+				},
+				{
+					Name:     "org.example:noversion",
+					Version:  "",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{GroupID: "org.example", ArtifactID: "noversion"},
+					Location: extractor.LocationFromPath("testdata/libs.versions.toml"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr := gradleversioncatalog.Extractor{}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/java/gradleversioncatalog/testdata/empty.versions.toml
+++ b/extractor/filesystem/language/java/gradleversioncatalog/testdata/empty.versions.toml
@@ -1,0 +1,4 @@
+[versions]
+foo = "1.0"
+
+[libraries]

--- a/extractor/filesystem/language/java/gradleversioncatalog/testdata/invalid.versions.toml
+++ b/extractor/filesystem/language/java/gradleversioncatalog/testdata/invalid.versions.toml
@@ -1,0 +1,2 @@
+[libraries
+broken = "not closed

--- a/extractor/filesystem/language/java/gradleversioncatalog/testdata/libs.versions.toml
+++ b/extractor/filesystem/language/java/gradleversioncatalog/testdata/libs.versions.toml
@@ -1,0 +1,39 @@
+[versions]
+groovy = "3.0.5"
+checkstyle = "8.37"
+
+[libraries]
+# 1. String shorthand
+guava = "com.google.guava:guava:30.1.1-jre"
+
+# 2. Module + inline version string
+checkstyle = { module = "com.puppycrawl.tools:checkstyle", version = "8.37" }
+
+# 3. Module + version.ref shorthand (dotted-key form)
+groovy-core = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
+
+# 4. Group/name/version triple
+commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version = "3.12.0" }
+
+# 5. Rich version with strictly
+rich-strictly = { module = "org.example:strict", version = { strictly = "2.0" } }
+
+# 6. Rich version with require
+rich-require = { module = "org.example:req", version = { require = "1.5" } }
+
+# 7. Rich version with prefer
+rich-prefer = { module = "org.example:pref", version = { prefer = "1.0" } }
+
+# 8. Rich version with ref nested in object form
+groovy-json = { module = "org.codehaus.groovy:groovy-json", version = { ref = "groovy" } }
+
+# 9. Missing version — Gradle allows this; we emit unpinned
+unversioned = { module = "org.example:noversion" }
+
+[bundles]
+# Bundles only group libraries — must be ignored, not emitted.
+groovy = ["groovy-core", "groovy-json"]
+
+[plugins]
+# Plugins use a different PURL space — must be ignored in this extractor.
+versions-plugin = { id = "com.github.ben-manes.versions", version = "0.45.0" }

--- a/extractor/filesystem/language/java/gradleversioncatalog/testdata/not-toml.txt
+++ b/extractor/filesystem/language/java/gradleversioncatalog/testdata/not-toml.txt
@@ -1,0 +1,2 @@
+this is not a toml file
+just plain text

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -52,6 +52,7 @@ import (
 	javaarchive "github.com/google/osv-scalibr/extractor/filesystem/language/java/archive"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradlelockfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradleverificationmetadataxml"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradleversioncatalog"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/pomxml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/bunlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/denojson"
@@ -202,6 +203,7 @@ var (
 	JavaSource = InitMap{
 		gradlelockfile.Name:                {gradlelockfile.New},
 		gradleverificationmetadataxml.Name: {gradleverificationmetadataxml.New},
+		gradleversioncatalog.Name:          {gradleversioncatalog.New},
 		pomxml.Name:                        {pomxml.New},
 	}
 	// JavaArtifact extractors for Java.


### PR DESCRIPTION
Resolves #1979.

## Summary

Adds a new filesystem extractor `java/gradleversioncatalog` that parses Gradle Version Catalog files (`libs.versions.toml`), the centralized Maven-coordinate dependency-declaration format introduced in Gradle 7.0. Version Catalogs are the officially recommended dependency mechanism for Gradle 7+ and are used by 100% of modern Android apps (gradle.org docs, AndroidX/Tink/Guava use them) — 500K+ `libs.versions.toml` files are indexed on GitHub.

## Design

The extractor handles every `[libraries]` shape per the Gradle spec:

1. **String shorthand:** `guava = "com.google.guava:guava:30.1.1-jre"`
2. **Inline table with module:** `mod = { module = "g:a", version = "1.0" }`
3. **Inline table with version.ref shorthand:** `mod = { module = "g:a", version.ref = "alias" }`
4. **Inline table with group/name/version:** `mod = { group = "g", name = "a", version = "1.0" }`

It also resolves rich versions — `version = { strictly = "...", require = "...", prefer = "...", ref = "..." }` — into a single concrete string, mirroring Gradle's runtime resolution order (`strictly > require > prefer`, with `ref` indirecting through the `[versions]` table).

`[bundles]` is intentionally skipped (it only groups already-declared libraries) and `[plugins]` is also skipped — Gradle plugins resolve to a different PURL space than Maven artifacts and warrant a separate extractor if desired later.

`FileRequired` matches both the default `libs.versions.toml` anywhere on the path, and additional catalogs named `*.versions.toml` when they live inside a `gradle/` directory (the Gradle convention for multi-catalog projects).

The extractor reuses the existing `javalockfile.Metadata` so no new proto/metadata plumbing is required.

## Test plan

- [x] `go test ./extractor/filesystem/language/java/gradleversioncatalog/...` — all pass
- [x] `go test ./extractor/filesystem/list/... ./extractor/filesystem/language/java/...` — no regressions
- [x] `FileRequired` table covers default name, gradle-dir multi-catalog, and negatives (wrong dir, wrong suffix)
- [x] `Extract` table covers all four library shapes, every rich-version subkey, missing-version, malformed TOML, and empty `[libraries]`
- [x] Smoke-tested against the real `gradle/libs.versions.toml` from JetBrains/kotlin (222-line catalog): 105 Maven packages extracted with correct coordinates, version-ref resolution, and PURL types