### PR TITLE
fix(image/unpack): confine symlink/hardlink extraction to os.Root

### DIFF
--- a/artifact/image/unpack/unpack.go
+++ b/artifact/image/unpack/unpack.go
@@ -342,8 +342,16 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 			// TODO: b/406760694 - Remove this once the bug is fixed.
 
 		case tar.TypeLink, tar.TypeSymlink:
-			parent := filepath.Dir(fullPath)
-			if err := os.MkdirAll(parent, fs.ModePerm); err != nil {
+			// Create the parent directory of the link through the os.Root API so the
+			// location stays confined to the extraction root. The previous raw
+			// os.MkdirAll allowed a link entry whose name contained "../" to create
+			// directories outside the root (b/412444199).
+			parent := path.Dir(cleanPath)
+			if err := root.MkdirAll(parent, fs.ModePerm); err != nil {
+				if strings.Contains(err.Error(), "path escapes from parent") {
+					log.Warnf("path escapes from parent, potential path traversal attack detected: %q: %v", fullPath, err)
+					continue
+				}
 				log.Errorf("failed to create directory %q: %v", parent, err)
 				if symlinkErrStrategy == SymlinkErrReturn {
 					return nil, fmt.Errorf("failed to create directory %q: %w", parent, err)
@@ -369,8 +377,15 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 			}
 
 			if symlinkResolution == SymlinkRetain {
-				// TODO: b/412444199 - Use the os.Root API to create symlinks when root.Symlink is available.
-				if err := os.Symlink(targetPath, fullPath); err != nil {
+				// Create the symlink through the os.Root API (resolves b/412444199) so the
+				// link location is confined to the root. Previously os.Symlink was called
+				// with the unconfined fullPath, letting a "../" entry name place the
+				// symlink outside the extraction root.
+				if err := root.Symlink(targetPath, cleanPath); err != nil {
+					if strings.Contains(err.Error(), "path escapes from parent") {
+						log.Warnf("path escapes from parent, potential path traversal attack detected: %q: %v", fullPath, err)
+						continue
+					}
 					log.Errorf("failed to symlink %q to %q: %v", fullPath, targetPath, err)
 					if symlinkErrStrategy == SymlinkErrReturn {
 						return nil, fmt.Errorf("failed to symlink %q to %q: %w", fullPath, targetPath, err)


### PR DESCRIPTION
## Summary

The container-image unpacker's symlink/hardlink branch in `artifact/image/unpack/unpack.go` creates the link's parent directory and the link itself with the raw, unconfined `os.MkdirAll` and `os.Symlink`. A tar entry of type symlink/hardlink whose name contains `../` therefore creates **directories and symlinks at arbitrary paths outside the extraction root**.

The regular-file branch (`tar.TypeReg`) was already hardened to use `os.Root` and rejects such escapes (`"path escapes from parent"` — the CVE-2025-5981 fix). This PR brings the symlink/hardlink branch to parity and resolves the existing `// TODO: b/412444199` now that `os.Root.Symlink` / `os.Root.MkdirAll` are available (Go ≥ 1.25; this module already requires 1.26).

## Root cause

`artifact/image/unpack/unpack.go`, `case tar.TypeLink, tar.TypeSymlink`:

- `os.MkdirAll(filepath.Dir(fullPath), …)` — raw. `fullPath` is built from the attacker-controlled `header.Name`, so a `../` entry creates a directory **outside** the root.
- `os.Symlink(targetPath, fullPath)` — raw. Creates the symlink at the attacker-controlled `fullPath`, **outside** the root.
- The existing `symlink.TargetOutsideRoot` guard validates the link **target**, not its **location**, so it does not prevent this.

## Fix

Use the `os.Root` API for both operations, relative to the extraction root:

- `root.MkdirAll(path.Dir(cleanPath), fs.ModePerm)`
- `root.Symlink(targetPath, cleanPath)`

An escaping location is now rejected by `os.Root` with `"path escapes from parent"` and skipped (warn + continue), mirroring the existing `tar.TypeReg` handling. The symlink **target** string is left unchanged, so in-root links extract exactly as before.

## Verification

Built against `HEAD` with a small harness that imports the unpacker via `replace` and feeds it a tar whose symlink/hardlink entries are named `../../<outside>/…`.

**Before (current `main`):**
```
created symlink "/tmp/victim-host-area-XXXX/dropped_symlink" -> ".../etc/passwd"
[PRIMITIVE 1: arbitrary symlink creation OUTSIDE root]
[PRIMITIVE 2: arbitrary directory creation OUTSIDE root]
```

**After (this PR):**
```
path escapes from parent, potential path traversal attack detected: ".../dropped_symlink"
[symlink NOT created]  ... no such file or directory
[dir NOT created]      ... no such file or directory
RESULT: NO escape — fix holds.
```

A regular-file entry with the same `../` escape was already (and remains) blocked, and in-root symlinks still extract correctly. `go build ./artifact/image/unpack/` and `go vet` are clean.

## Notes

- Same vulnerability class as the patched **CVE-2025-5981**, in the sibling code path the `os.Root` hardening had not yet reached.
- Resolves the in-code `TODO: b/412444199`.
