### PR TITLE
feat: add Network Traffic (.pcap) extractor to scalibr embeddedfs

### DIFF
--- a/extractor/filesystem/embeddedfs/nettraffic/nettraffic.go
+++ b/extractor/filesystem/embeddedfs/nettraffic/nettraffic.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nettraffic extracts files from pcap/pcapng files.
+package nettraffic
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/common"
+	scalibrfs "github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+)
+
+// Name is the unique name of this extractor.
+const Name = "embeddedfs/nettraffic"
+
+// Extractor extracts files from pcap and pcapng files.
+type Extractor struct{}
+
+// New returns a new pcap extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) {
+	return &Extractor{}, nil
+}
+
+// NewDefault returns a new pcap extractor.
+func NewDefault(_ *cpb.PluginConfig) (filesystem.Extractor, error) {
+	return &Extractor{}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string {
+	return Name
+}
+
+// Version of the extractor.
+func (e Extractor) Version() int {
+	return 0
+}
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the file should be extracted.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	ext := strings.ToLower(filepath.Ext(api.Path()))
+	return ext == ".pcap" || ext == ".pcapng"
+}
+
+// Extract extracts files from pcap/pcapng files.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+
+	ext := strings.ToLower(filepath.Ext(input.Path))
+	var packetSource *gopacket.PacketSource
+
+	if ext == ".pcapng" {
+		reader, err := pcapgo.NewNgReader(input.Reader, pcapgo.DefaultNgReaderOptions)
+		if err != nil {
+			return inventory.Inventory{}, fmt.Errorf("failed to open pcapng reader: %w", err)
+		}
+		packetSource = gopacket.NewPacketSource(reader, reader.LinkType())
+	} else {
+		reader, err := pcapgo.NewReader(input.Reader)
+		if err != nil {
+			return inventory.Inventory{}, fmt.Errorf("failed to open pcap reader: %w", err)
+		}
+		packetSource = gopacket.NewPacketSource(reader, reader.LinkType())
+	}
+
+	tempDir, err := os.MkdirTemp("", "pcap_extraction_*")
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+
+	fileMap := make(map[string][]byte)
+
+	for packet := range packetSource.Packets() {
+		if app := packet.ApplicationLayer(); app != nil {
+			payload := app.Payload()
+			if len(payload) > 0 {
+				var src, dst string
+				if net := packet.NetworkLayer(); net != nil {
+					src = net.NetworkFlow().Src().String()
+					dst = net.NetworkFlow().Dst().String()
+				}
+
+				var srcPort, dstPort string
+				var protocol string
+				if tcp := packet.Layer(layers.LayerTypeTCP); tcp != nil {
+					protocol = "TCP"
+					tcpLayer := tcp.(*layers.TCP)
+					srcPort = tcpLayer.SrcPort.String()
+					dstPort = tcpLayer.DstPort.String()
+				} else if udp := packet.Layer(layers.LayerTypeUDP); udp != nil {
+					protocol = "UDP"
+					udpLayer := udp.(*layers.UDP)
+					srcPort = udpLayer.SrcPort.String()
+					dstPort = udpLayer.DstPort.String()
+				}
+
+				if protocol != "" {
+					filename := fmt.Sprintf("%s_%s_%s_%s_to_%s_%s.txt", protocol, protocol, src, srcPort, dst, dstPort)
+					filename = strings.ReplaceAll(filename, ":", "_") // Sanitize for filesystem
+
+					if _, exists := fileMap[filename]; !exists {
+						fileMap[filename] = append([]byte{}, payload...)
+					} else {
+						fileMap[filename] = append(fileMap[filename], payload...)
+					}
+				}
+			}
+		}
+	}
+
+	for filename, payload := range fileMap {
+		filePath := filepath.Join(tempDir, filename)
+		os.WriteFile(filePath, payload, 0644)
+	}
+
+	var refCount int32 = 1
+	var refMu sync.Mutex
+	getEmbeddedFS := func(ctx context.Context) (scalibrfs.FS, error) {
+		return &common.EmbeddedDirFS{
+			FS:       scalibrfs.DirFS(tempDir),
+			File:     nil,
+			TmpPaths: []string{tempDir},
+			RefCount: &refCount,
+			RefMu:    &refMu,
+		}, nil
+	}
+
+	return inventory.Inventory{
+		EmbeddedFSs: []*inventory.EmbeddedFS{
+			{
+				Path:          input.Path,
+				GetEmbeddedFS: getEmbeddedFS,
+			}},
+	}, nil
+}

--- a/extractor/filesystem/embeddedfs/nettraffic/nettraffic_test.go
+++ b/extractor/filesystem/embeddedfs/nettraffic/nettraffic_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nettraffic_test
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/nettraffic"
+)
+
+type mockFileAPI struct {
+	path string
+}
+
+func (m *mockFileAPI) Path() string { return m.path }
+func (m *mockFileAPI) Stat() (fs.FileInfo, error) { return nil, nil }
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"pcap file", "test.pcap", true},
+		{"pcapng file", "test.pcapng", true},
+		{"uppercase pcap", "test.PCAP", true},
+		{"uppercase pcapng", "test.PCAPNG", true},
+		{"other file", "test.txt", false},
+	}
+	
+	e, _ := nettraffic.New(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &mockFileAPI{path: tt.path}
+			if got := e.FileRequired(api); got != tt.want {
+				t.Errorf("Extractor.FileRequired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/containers/k8simage"
 	"github.com/google/osv-scalibr/extractor/filesystem/containers/podman"
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/archive"
+	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/nettraffic"
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/ova"
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/qcow2"
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/vdi"
@@ -474,11 +475,12 @@ var (
 
 	// EmbeddedFS extractors.
 	EmbeddedFS = InitMap{
-		archive.Name: {archive.New},
-		vdi.Name:     {vdi.New},
-		vmdk.Name:    {vmdk.New},
-		ova.Name:     {ova.New},
-		qcow2.Name:   {qcow2.New},
+		archive.Name:    {archive.New},
+		nettraffic.Name: {nettraffic.New},
+		vdi.Name:        {vdi.New},
+		vmdk.Name:       {vmdk.New},
+		ova.Name:        {ova.New},
+		qcow2.Name:      {qcow2.New},
 	}
 
 	// FFA extractor.

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/google/gopacket v1.1.19 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/google/go-containerregistry v0.20.6 h1:cvWX87UxxLgaH76b4hIvya6Dzz9qHB
 github.com/google/go-containerregistry v0.20.6/go.mod h1:T0x8MuoAoKX/873bkeSfLD2FAkwCDf9/HZgsFJ02E2Y=
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932 h1:5/4TSDzpDnHQ8rKEEQBjRlYx77mHOvXu08oGchxej7o=
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932/go.mod h1:cC6EdPbj/17GFCPDK39NRarlMI+kt+O60S12cNB5J9Y=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -509,6 +511,8 @@ golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a/go.mod h1:d2fgXJLVs4dYDHUk5l
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
@@ -615,6 +619,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=


### PR DESCRIPTION
## Description
Closes #1901

This PR introduces the `embeddedfs/nettraffic` extractor for `.pcap` and `.pcapng` files.
It fulfills the requirement to scan network capture artifacts for sensitive information, credentials, and potential C2 traffic payload leaks.

### Implementation Details:
- Integrated `gopacket` library to parse `.pcap` and `.pcapng` streams.
- Reconstructs packet payloads (TCP/UDP) and stores them virtually in `common.EmbeddedDirFS` for subsequent SCALIBR secrets and vulnerability detectors.
- Naming convention uses: `<PROTOCOL>_<PROTOCOL>_<SRC_IP>_<SRC_PORT>_to_<DST_IP>_<DST_PORT>.txt` to allow precise incident response correlation.
- Validated via `make test` over the entire `extractor/filesystem/list` and embeddedfs package structure.

---
**Bounty Payout Note:**
If this contribution is eligible for an open-source bounty or reward program under Google/OSV-SCALIBR initiatives, please route the bounty allocation to the following Solana address:
`6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp`