### PR TITLE
extractor/os/rpm: add Mageia ecosystem mapping

### DIFF
--- a/extractor/filesystem/os/ecosystem/ecosystem.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem.go
@@ -80,6 +80,9 @@ func MakeEcosystem(metadata any) osvecosystem.Parsed {
 		if m.OSID == "openEuler" {
 			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemOpenEuler, Suffix: m.OpenEulerEcosystemSuffix()}
 		}
+		if m.OSID == "mageia" {
+			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemMageia, Suffix: m.OSVersionID}
+		}
 
 	case *snapmeta.Metadata:
 		if m.OSID == "ubuntu" {

--- a/extractor/filesystem/os/ecosystem/ecosystem_test.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem_test.go
@@ -316,6 +316,14 @@ func TestEcosystemRPM(t *testing.T) {
 			want: "openEuler",
 		},
 		{
+			desc: "Mageia",
+			metadata: &rpmmeta.Metadata{
+				OSID:        "mageia",
+				OSVersionID: "9",
+			},
+			want: "Mageia:9",
+		},
+		{
 			desc:     "OS ID not present",
 			metadata: &rpmmeta.Metadata{},
 			want:     "",


### PR DESCRIPTION
# OSV-SCALIBR Mageia RPM ecosystem notes

Candidate issue: https://github.com/google/osv-scalibr/issues/2177

## Why this is a good 5 USD experiment target

- Public, legal, and reviewable.
- Open issue with a concrete bug report.
- Maintainer-quality repository rather than a noisy bounty farm.
- Small code surface: RPM ecosystem mapping only.
- Existing `EcosystemMageia` constant is already valid in `inventory/osvecosystem/parsed.go`.
- Open PR scan found AlmaLinux/SUSE-related RPM PRs, but no obvious Mageia PR.

## Proposed issue/PR summary

Add Mageia handling to the RPM ecosystem mapper so packages extracted from Mageia systems are mapped to the OSV `Mageia` ecosystem with the distro version as suffix.

## Patch summary

- In `extractor/filesystem/os/ecosystem/ecosystem.go`, add `OSID == "mageia"` handling in the `*rpmmeta.Metadata` branch.
- In `extractor/filesystem/os/ecosystem/ecosystem_test.go`, add a Mageia RPM regression case expecting `Mageia:9`.

## Validation target

```bash
go test ./extractor/filesystem/os/ecosystem
```

Validated on 2026-06-04 with Go toolchain download/cache redirected to `/private/tmp`:

```bash
GOTOOLCHAIN=auto GOPATH=/private/tmp/codex-gopath GOCACHE=/private/tmp/codex-go-cache GOMODCACHE=/private/tmp/codex-go-mod go test ./extractor/filesystem/os/ecosystem
```

Result:

```text
ok  	github.com/google/osv-scalibr/extractor/filesystem/os/ecosystem	0.460s
```

## PR body draft

```markdown
## Summary

- Map RPM metadata with `OSID == "mageia"` to the OSV `Mageia` ecosystem.
- Preserve `OSVersionID` as the ecosystem suffix so Mageia 9 packages produce `Mageia:9`.
- Add a focused RPM ecosystem regression test.

Fixes #2177.

## Tests

- `go test ./extractor/filesystem/os/ecosystem`

## AI disclosure

I used AI assistance to inspect the issue, identify the existing RPM ecosystem mapping pattern, and prepare this focused patch. I reviewed the change and validation target before submission.
```
