### PR TITLE
Add Clojure deps.edn extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -72,6 +72,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Microsoft Build Engine (MSBuild) project files    | `dotnet/csproj`                      |
 |            | project.assets.json                               | `dotnet/projectassetsjson`           |
 | C++        | Conan packages                                    | `cpp/conanlock`                      |
+| Clojure    | deps.edn                                          | `clojure/depsedn`                    |
 | Dart       | pubspec.lock                                      | `dart/pubspec`                       |
 | Erlang     | mix.lock                                          | `erlang/mixlock`                     |
 | Elixir     | mix.lock                                          | `elixir/mixlock`                     |

--- a/extractor/filesystem/language/clojure/depsedn/depsedn.go
+++ b/extractor/filesystem/language/clojure/depsedn/depsedn.go
@@ -1,0 +1,410 @@
+// Package depsedn extracts Maven dependencies from Clojure deps.edn files.
+package depsedn
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/java/javalockfile"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "clojure/depsedn"
+)
+
+// Extractor extracts Maven packages from Clojure deps.edn files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file matches Clojure deps.edn files.
+func (Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "deps.edn"
+}
+
+// Extract extracts packages from Clojure deps.edn files passed through the scan input.
+func (Extractor) Extract(
+	_ context.Context,
+	input *filesystem.ScanInput,
+) (inventory.Inventory, error) {
+	content, err := io.ReadAll(input.Reader)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("could not read input: %w", err)
+	}
+
+	deps := parseMavenDeps(stripComments(content))
+	packages := make([]*extractor.Package, 0, len(deps))
+	seen := map[string]bool{}
+
+	for _, dep := range deps {
+		groupID, artifactID := splitLib(dep.lib)
+		if groupID == "" || artifactID == "" || dep.version == "" {
+			continue
+		}
+
+		key := groupID + ":" + artifactID + "@" + dep.version
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		line := 1 + bytes.Count(content[:dep.offset], []byte("\n"))
+		packages = append(packages, &extractor.Package{
+			Name:     groupID + ":" + artifactID,
+			Version:  dep.version,
+			PURLType: purl.TypeMaven,
+			Metadata: &javalockfile.Metadata{
+				ArtifactID: artifactID,
+				GroupID:    groupID,
+			},
+			Location: extractor.LocationFromPathAndLine(input.Path, line),
+		})
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+type mavenDep struct {
+	lib     string
+	version string
+	offset  int
+}
+
+func parseMavenDeps(content []byte) []mavenDep {
+	deps := []mavenDep{}
+	position := 0
+	for position < len(content) {
+		position = skipWhitespace(content, position)
+		if position >= len(content) {
+			break
+		}
+		switch content[position] {
+		case '"':
+			position = skipString(content, position)
+			continue
+		case '{', '[', '(':
+			position++
+			continue
+		case '}', ']', ')':
+			position++
+			continue
+		}
+
+		token, nextPosition := readToken(content, position)
+		if token == "" {
+			position++
+			continue
+		}
+		position = nextPosition
+		if !isDependencyMapKey(token) {
+			continue
+		}
+
+		position = skipWhitespace(content, position)
+		if position >= len(content) || content[position] != '{' {
+			continue
+		}
+		dependencyMapDeps, mapEnd := parseDependencyMap(content, position)
+		deps = append(deps, dependencyMapDeps...)
+		if mapEnd == -1 {
+			break
+		}
+		position = mapEnd + 1
+	}
+	return deps
+}
+
+func parseDependencyMap(content []byte, mapStart int) ([]mavenDep, int) {
+	mapEnd := matchingDelimiter(content, mapStart)
+	if mapEnd == -1 {
+		return nil, -1
+	}
+
+	deps := []mavenDep{}
+	position := mapStart + 1
+	for position < mapEnd {
+		position = skipWhitespace(content, position)
+		if position >= mapEnd {
+			break
+		}
+
+		libStart := position
+		lib, nextPosition := readToken(content, position)
+		if !isLibraryToken(lib) {
+			position = skipForm(content, position)
+			continue
+		}
+
+		position = skipWhitespace(content, nextPosition)
+		if position >= mapEnd {
+			break
+		}
+		if content[position] != '{' {
+			position = skipForm(content, position)
+			continue
+		}
+
+		valueEnd := matchingDelimiter(content, position)
+		if valueEnd == -1 {
+			return deps, mapEnd
+		}
+		if version, ok := findMvnVersion(content[position+1 : valueEnd]); ok {
+			deps = append(deps, mavenDep{
+				lib:     lib,
+				version: version,
+				offset:  libStart,
+			})
+		}
+		position = valueEnd + 1
+	}
+	return deps, mapEnd
+}
+
+func isDependencyMapKey(token string) bool {
+	switch token {
+	case ":deps", ":extra-deps", ":replace-deps", ":override-deps", ":default-deps":
+		return true
+	default:
+		return false
+	}
+}
+
+func isLibraryToken(token string) bool {
+	return token != "" && !strings.HasPrefix(token, ":") &&
+		!strings.HasPrefix(token, "#")
+}
+
+func stripComments(content []byte) []byte {
+	stripped := bytes.Clone(content)
+	inString := false
+	escaped := false
+
+	for index, currentByte := range stripped {
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch currentByte {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch currentByte {
+		case '"':
+			inString = true
+		case ';':
+			for commentIndex := index; commentIndex < len(stripped) &&
+				stripped[commentIndex] != '\n'; commentIndex++ {
+				stripped[commentIndex] = ' '
+			}
+		}
+	}
+
+	return stripped
+}
+
+func findMvnVersion(mapBody []byte) (string, bool) {
+	position := 0
+	depth := 0
+	for position < len(mapBody) {
+		position = skipWhitespace(mapBody, position)
+		if position >= len(mapBody) {
+			break
+		}
+		switch mapBody[position] {
+		case '{', '[', '(':
+			depth++
+			position++
+			continue
+		case '}', ']', ')':
+			if depth > 0 {
+				depth--
+			}
+			position++
+			continue
+		case '"':
+			position = skipString(mapBody, position)
+			continue
+		}
+
+		token, nextPosition := readToken(mapBody, position)
+		if token == "" {
+			position++
+			continue
+		}
+		position = nextPosition
+		if depth == 0 && token == ":mvn/version" {
+			position = skipWhitespace(mapBody, position)
+			version, nextPosition, ok := readString(mapBody, position)
+			if !ok {
+				return "", false
+			}
+			_ = nextPosition
+			return version, true
+		}
+	}
+	return "", false
+}
+
+func splitLib(lib string) (string, string) {
+	lib = strings.TrimSpace(lib)
+	groupID, artifactID, ok := strings.Cut(lib, "/")
+	if !ok {
+		return lib, lib
+	}
+	return groupID, artifactID
+}
+
+func skipForm(content []byte, position int) int {
+	if position >= len(content) {
+		return position
+	}
+	if content[position] == '"' {
+		return skipString(content, position)
+	}
+	if isOpeningDelimiter(content[position]) {
+		end := matchingDelimiter(content, position)
+		if end == -1 {
+			return len(content)
+		}
+		return end + 1
+	}
+	_, nextPosition := readToken(content, position)
+	if nextPosition == position {
+		return position + 1
+	}
+	return nextPosition
+}
+
+func skipWhitespace(content []byte, position int) int {
+	for position < len(content) {
+		currentRune := rune(content[position])
+		if content[position] != ',' && !unicode.IsSpace(currentRune) {
+			break
+		}
+		position++
+	}
+	return position
+}
+
+func readToken(content []byte, position int) (string, int) {
+	start := position
+	for position < len(content) && !isTokenDelimiter(content[position]) {
+		position++
+	}
+	return string(content[start:position]), position
+}
+
+func readString(content []byte, position int) (string, int, bool) {
+	if position >= len(content) || content[position] != '"' {
+		return "", position, false
+	}
+	start := position + 1
+	position++
+	escaped := false
+	for position < len(content) {
+		currentByte := content[position]
+		if escaped {
+			escaped = false
+			position++
+			continue
+		}
+		switch currentByte {
+		case '\\':
+			escaped = true
+		case '"':
+			return string(content[start:position]), position + 1, true
+		}
+		position++
+	}
+	return "", position, false
+}
+
+func skipString(content []byte, position int) int {
+	_, nextPosition, ok := readString(content, position)
+	if !ok {
+		return len(content)
+	}
+	return nextPosition
+}
+
+func matchingDelimiter(content []byte, position int) int {
+	if position >= len(content) || !isOpeningDelimiter(content[position]) {
+		return -1
+	}
+	stack := []byte{content[position]}
+	position++
+	for position < len(content) {
+		currentByte := content[position]
+		if currentByte == '"' {
+			position = skipString(content, position)
+			continue
+		}
+		if isOpeningDelimiter(currentByte) {
+			stack = append(stack, currentByte)
+			position++
+			continue
+		}
+		if isClosingDelimiter(currentByte) {
+			if len(stack) == 0 || !matchesDelimiter(stack[len(stack)-1], currentByte) {
+				return -1
+			}
+			stack = stack[:len(stack)-1]
+			if len(stack) == 0 {
+				return position
+			}
+		}
+		position++
+	}
+	return -1
+}
+
+func isTokenDelimiter(currentByte byte) bool {
+	return currentByte == ',' || currentByte == '"' || currentByte == ';' ||
+		isOpeningDelimiter(currentByte) || isClosingDelimiter(currentByte) ||
+		unicode.IsSpace(rune(currentByte))
+}
+
+func isOpeningDelimiter(currentByte byte) bool {
+	return currentByte == '{' || currentByte == '[' || currentByte == '('
+}
+
+func isClosingDelimiter(currentByte byte) bool {
+	return currentByte == '}' || currentByte == ']' || currentByte == ')'
+}
+
+func matchesDelimiter(opening byte, closing byte) bool {
+	return (opening == '{' && closing == '}') ||
+		(opening == '[' && closing == ']') ||
+		(opening == '(' && closing == ')')
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/clojure/depsedn/depsedn_test.go
+++ b/extractor/filesystem/language/clojure/depsedn/depsedn_test.go
@@ -1,0 +1,200 @@
+package depsedn_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/clojure/depsedn"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/java/javalockfile"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "deps_edn", path: "deps.edn", want: true},
+		{name: "nested_deps_edn", path: "path/to/deps.edn", want: true},
+		{name: "other_edn", path: "bb.edn", want: false},
+		{name: "suffix", path: "deps.edn.bak", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractorPlugin, err := depsedn.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("depsedn.New: %v", err)
+			}
+			if got := extractorPlugin.FileRequired(simplefileapi.New(tt.path, nil)); got != tt.want {
+				t.Errorf("FileRequired(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "deps",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/deps.edn",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "org.clojure:clojure",
+					Version:  "1.11.1",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "clojure",
+						GroupID:    "org.clojure",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/deps.edn", 3),
+				},
+				{
+					Name:     "com.github.seancorfield:next.jdbc",
+					Version:  "1.3.955",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "next.jdbc",
+						GroupID:    "com.github.seancorfield",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/deps.edn", 4),
+				},
+				{
+					Name:     "cheshire:cheshire",
+					Version:  "5.12.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "cheshire",
+						GroupID:    "cheshire",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/deps.edn", 13),
+				},
+			},
+		},
+		{
+			Name: "edge_cases",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/edge-cases.deps.edn",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "org.example:complex",
+					Version:  "1.2.3",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "complex",
+						GroupID:    "org.example",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/edge-cases.deps.edn", 2),
+				},
+				{
+					Name:     "org.example:duplicate",
+					Version:  "1.0.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "duplicate",
+						GroupID:    "org.example",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/edge-cases.deps.edn", 5),
+				},
+				{
+					Name:     "dev.local:tool",
+					Version:  "2.0.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "tool",
+						GroupID:    "dev.local",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/edge-cases.deps.edn", 10),
+				},
+				{
+					Name:     "org.example:replaced",
+					Version:  "3.0.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "replaced",
+						GroupID:    "org.example",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/edge-cases.deps.edn", 13),
+				},
+				{
+					Name:     "org.replace:core",
+					Version:  "4.0.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "core",
+						GroupID:    "org.replace",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/edge-cases.deps.edn", 15),
+				},
+				{
+					Name:     "default.lib:core",
+					Version:  "5.0.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "core",
+						GroupID:    "default.lib",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/edge-cases.deps.edn", 17),
+				},
+				{
+					Name:     "override.lib:core",
+					Version:  "6.0.0",
+					PURLType: purl.TypeMaven,
+					Metadata: &javalockfile.Metadata{
+						ArtifactID: "core",
+						GroupID:    "override.lib",
+					},
+					Location: extractor.LocationFromPathAndLine("testdata/edge-cases.deps.edn", 18),
+				},
+			},
+		},
+		{
+			Name: "malformed_deps",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/malformed-deps.edn",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "no_maven_dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no-maven-deps.edn",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := depsedn.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("depsedn.New: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/clojure/depsedn/testdata/deps.edn
+++ b/extractor/filesystem/language/clojure/depsedn/testdata/deps.edn
@@ -1,0 +1,14 @@
+{:paths ["src"]
+ :deps
+ {org.clojure/clojure {:mvn/version "1.11.1"}
+  com.github.seancorfield/next.jdbc
+  {:mvn/version "1.3.955"
+   :exclusions [org.clojure/clojure]}
+  ;; commented/example dependency must be ignored:
+  ;; org.slf4j/slf4j-api {:mvn/version "2.0.17"}
+  io.github.some/lib {:git/sha "abcdef"}}
+ :aliases
+ {:test
+  {:extra-deps
+   {cheshire {:mvn/version "5.12.0"}
+    org.clojure/clojure {:mvn/version "1.11.1"}}}}}

--- a/extractor/filesystem/language/clojure/depsedn/testdata/edge-cases.deps.edn
+++ b/extractor/filesystem/language/clojure/depsedn/testdata/edge-cases.deps.edn
@@ -1,0 +1,21 @@
+{:deps
+ {org.example/complex
+  {:exclusions [bad/thing {:mvn/version "0.0.0"}]
+   :mvn/version "1.2.3"}
+  org.example/duplicate {:mvn/version "1.0.0"}
+  org.example/duplicate {:mvn/version "1.0.0"}}
+ :aliases
+ {:dev
+  {:extra-deps
+   {dev.local/tool
+    {:scope "test;comment-marker"
+     :mvn/version "2.0.0"}
+    org.example/replaced {:mvn/version "3.0.0"}}}
+  :old
+  {:replace-deps {org.replace/core {:mvn/version "4.0.0"}}}
+  :defaults
+  {:default-deps {default.lib/core {:mvn/version "5.0.0"}}
+   :override-deps {override.lib/core {:mvn/version "6.0.0"}}}}
+ :metadata
+ {not.a.dependency/library {:mvn/version "0.0.1"}}
+ :paths ["src;not-comment"]}

--- a/extractor/filesystem/language/clojure/depsedn/testdata/malformed-deps.edn
+++ b/extractor/filesystem/language/clojure/depsedn/testdata/malformed-deps.edn
@@ -1,0 +1,1 @@
+{:deps {org.example/broken {:mvn/version "1.0.0"

--- a/extractor/filesystem/language/clojure/depsedn/testdata/no-maven-deps.edn
+++ b/extractor/filesystem/language/clojure/depsedn/testdata/no-maven-deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ :deps {io.github.some/lib {:git/url "https://github.com/example/lib"
+                            :git/sha "abcdef"}}
+ :aliases {:test {:jvm-opts ["-Dexample=true"]}}}

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/vdi"
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/vmdk"
 	"github.com/google/osv-scalibr/extractor/filesystem/ffa/unknownbinariesextr"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/clojure/depsedn"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspec"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/csproj"
@@ -198,6 +199,8 @@ var (
 
 	// CppSource extractors for C++.
 	CppSource = InitMap{conanlock.Name: {conanlock.New}}
+	// ClojureSource extractors for Clojure.
+	ClojureSource = InitMap{depsedn.Name: {depsedn.New}}
 	// JavaSource extractors for Java.
 	JavaSource = InitMap{
 		gradlelockfile.Name:                {gradlelockfile.New},
@@ -493,6 +496,7 @@ var (
 	// SourceCode extractors find packages in source code contexts (e.g. lockfiles).
 	SourceCode = concat(
 		CppSource,
+		ClojureSource,
 		JavaSource,
 		JavascriptSource,
 		PythonSource,
@@ -554,6 +558,7 @@ var (
 	extractorNames = concat(All, InitMap{
 		// Languages.
 		"cpp":        vals(CppSource),
+		"clojure":    vals(ClojureSource),
 		"java":       vals(concat(JavaSource, JavaArtifact)),
 		"javascript": vals(concat(JavascriptSource, JavascriptArtifact)),
 		"python":     vals(concat(PythonSource, PythonArtifact)),


### PR DESCRIPTION
This adds a new Clojure `deps.edn` source extractor. `deps.edn` is the standard Clojure CLI dependency file and commonly declares Maven dependencies with `:mvn/version`. The extractor emits Maven PURLs and Java lockfile metadata so OSV-SCALIBR can inventory Clojure source dependencies alongside existing Java/Maven ecosystems.

The extractor:

- Requires files named `deps.edn`.
- Parses Maven entries from `:deps`, `:extra-deps`, `:replace-deps`, `:override-deps`, and `:default-deps` maps containing `:mvn/version`.
- Supports qualified symbols like `org.clojure/clojure` and unqualified symbols like `cheshire`.
- Handles aliases/extra-deps, replace-deps, override-deps, default-deps, comments, strings, nested vectors/maps, malformed input, duplicate declarations, and git-only deps.
- Adds focused unit tests and updates supported inventory docs.

Validation performed locally:

- `git diff --check origin/main...HEAD`
- `go test ./extractor/filesystem/language/clojure/depsedn ./extractor/filesystem/list`
- `go test ./extractor/filesystem/...`
- `go mod tidy -diff`
- `make lint-plugger`
- `make scalibr`
- `make lint` (`0 issues`)
- `umask 022 && CGO_ENABLED=1 go test ./...`
