### PR TITLE
Add Go vendor modules extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -78,6 +78,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Gleam      | gleam.toml                                        | `gleam/gleamtoml`                    |
 | Go         | Go binaries                                       | `go/binary`                          |
 |            | go.mod (OSV)                                      | `go/gomod`                           |
+|            | vendor/modules.txt                                | `go/vendormodules`                   |
 | Haskell    | stack.yaml.lock                                   | `haskell/stacklock`                  |
 |            | cabal.project.freeze                              | `haskell/cabal`                      |
 | Java       | Java archives                                     | `java/archive`                       |

--- a/extractor/filesystem/language/golang/vendormodules/testdata/no-packages/vendor/modules.txt
+++ b/extractor/filesystem/language/golang/vendormodules/testdata/no-packages/vendor/modules.txt
@@ -1,0 +1,2 @@
+# example.com/no/pkg v0.0.1
+## explicit

--- a/extractor/filesystem/language/golang/vendormodules/testdata/with-replacements/vendor/modules.txt
+++ b/extractor/filesystem/language/golang/vendormodules/testdata/with-replacements/vendor/modules.txt
@@ -1,0 +1,19 @@
+# github.com/BurntSushi/toml v1.5.0
+## explicit; go 1.23
+github.com/BurntSushi/toml
+github.com/BurntSushi/toml/internal
+# golang.org/x/sys v0.30.0
+## explicit; go 1.23
+golang.org/x/sys/unix
+# example.com/old v1.2.3 => example.com/new v1.4.5
+## explicit
+example.com/old/pkg
+# example.com/wildcard => example.com/wildcard-fork v0.2.0
+## explicit
+example.com/wildcard/pkg
+# example.com/local v0.1.0 => ./local
+## explicit
+example.com/local
+# example.com/replacement-only v1.2.3 => ./replacement
+## explicit
+# malformed

--- a/extractor/filesystem/language/golang/vendormodules/vendormodules.go
+++ b/extractor/filesystem/language/golang/vendormodules/vendormodules.go
@@ -1,0 +1,142 @@
+// Package vendormodules extracts Go vendor/modules.txt files.
+package vendormodules
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "go/vendormodules"
+)
+
+type module struct {
+	name    string
+	version string
+	line    int
+	skip    bool
+}
+
+type pkgKey struct {
+	name    string
+	version string
+}
+
+// Extractor extracts Go modules from vendor/modules.txt files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file is a Go vendor/modules.txt file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := filepath.Clean(api.Path())
+	return filepath.Base(path) == "modules.txt" && filepath.Base(filepath.Dir(path)) == "vendor"
+}
+
+// Extract extracts packages from a Go vendor/modules.txt file passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	var packages []*extractor.Package
+	seen := map[pkgKey]bool{}
+	var current module
+
+	scanner := bufio.NewScanner(input.Reader)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		if err := ctx.Err(); err != nil {
+			return inventory.Inventory{Packages: packages}, fmt.Errorf("go/vendormodules halted due to context error: %w", err)
+		}
+
+		line := scanner.Text()
+		if strings.HasPrefix(line, "# ") {
+			current = parseModuleLine(line, lineNumber)
+			continue
+		}
+
+		if current.name == "" || current.skip || strings.HasPrefix(line, "## ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 1 {
+			continue
+		}
+
+		key := pkgKey{name: current.name, version: current.version}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		packages = append(packages, &extractor.Package{
+			Name:     current.name,
+			Version:  current.version,
+			PURLType: purl.TypeGolang,
+			Location: extractor.LocationFromPathAndLine(input.Path, current.line),
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return inventory.Inventory{Packages: packages}, fmt.Errorf("could not scan %s: %w", input.Path, err)
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+func parseModuleLine(line string, lineNumber int) module {
+	fields := strings.Fields(strings.TrimPrefix(line, "# "))
+	if len(fields) < 2 {
+		return module{}
+	}
+
+	name := fields[0]
+	version := ""
+	var rest []string
+	skip := false
+
+	if semver.IsValid(fields[1]) {
+		version = strings.TrimPrefix(fields[1], "v")
+		rest = fields[2:]
+	} else if fields[1] == "=>" {
+		rest = fields[1:]
+		skip = true
+	} else {
+		return module{}
+	}
+
+	if len(rest) > 0 {
+		if len(rest) == 3 && rest[0] == "=>" && semver.IsValid(rest[2]) {
+			name = rest[1]
+			version = strings.TrimPrefix(rest[2], "v")
+			skip = false
+		} else if rest[0] == "=>" {
+			skip = true
+		}
+	}
+
+	if version == "" {
+		skip = true
+	}
+	return module{name: name, version: version, line: lineNumber, skip: skip}
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/golang/vendormodules/vendormodules_test.go
+++ b/extractor/filesystem/language/golang/vendormodules/vendormodules_test.go
@@ -1,0 +1,139 @@
+package vendormodules_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/vendormodules"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "empty",
+			inputPath: "",
+			want:      false,
+		},
+		{
+			name:      "base modules.txt",
+			inputPath: "modules.txt",
+			want:      false,
+		},
+		{
+			name:      "vendor modules.txt",
+			inputPath: filepath.FromSlash("vendor/modules.txt"),
+			want:      true,
+		},
+		{
+			name:      "nested vendor modules.txt",
+			inputPath: filepath.FromSlash("path/to/vendor/modules.txt"),
+			want:      true,
+		},
+		{
+			name:      "wrong parent",
+			inputPath: filepath.FromSlash("path/to/modules.txt"),
+			want:      false,
+		},
+		{
+			name:      "modules.txt as directory",
+			inputPath: filepath.FromSlash("path/to/vendor/modules.txt/file"),
+			want:      false,
+		},
+		{
+			name:      "wrong extension",
+			inputPath: filepath.FromSlash("path/to/vendor/modules.txt.bak"),
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := vendormodules.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("vendormodules.New() error: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%q) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantPackages []*extractor.Package
+	}{
+		{
+			name: "with replacements",
+			path: "testdata/with-replacements/vendor/modules.txt",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "github.com/BurntSushi/toml",
+					Version:  "1.5.0",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine("testdata/with-replacements/vendor/modules.txt", 1),
+				},
+				{
+					Name:     "golang.org/x/sys",
+					Version:  "0.30.0",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine("testdata/with-replacements/vendor/modules.txt", 5),
+				},
+				{
+					Name:     "example.com/new",
+					Version:  "1.4.5",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine("testdata/with-replacements/vendor/modules.txt", 8),
+				},
+				{
+					Name:     "example.com/wildcard-fork",
+					Version:  "0.2.0",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine("testdata/with-replacements/vendor/modules.txt", 11),
+				},
+			},
+		},
+		{
+			name:         "no packages",
+			path:         "testdata/no-packages/vendor/modules.txt",
+			wantPackages: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extr, err := vendormodules.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("vendormodules.New() error: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, extracttest.ScanInputMockConfig{Path: tt.path})
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+			if err != nil {
+				t.Fatalf("%s.Extract(%q) error: %v", extr.Name(), tt.path, err)
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.wantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -47,6 +47,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/gleam/gleamtoml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gobinary"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/vendormodules"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/cabal"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/stacklock"
 	javaarchive "github.com/google/osv-scalibr/extractor/filesystem/language/java/archive"
@@ -241,7 +242,8 @@ var (
 	}
 	// GoSource extractors for Go.
 	GoSource = InitMap{
-		gomod.Name: {gomod.New},
+		gomod.Name:         {gomod.New},
+		vendormodules.Name: {vendormodules.New},
 	}
 	// GoArtifact extractors for Go.
 	GoArtifact = InitMap{


### PR DESCRIPTION
## Summary
- Add `go/vendormodules` inventory extractor for Go `vendor/modules.txt` files.
- Extract modules that contribute vendored packages, including remote replacements.
- Register the extractor and document `vendor/modules.txt` support.

## Tests
- `git diff --check`
- `go test ./extractor/filesystem/language/golang/vendormodules ./extractor/filesystem/list`
- `go test ./extractor/filesystem/language/golang/...`
- `go test ./extractor/filesystem/...`
- `go mod tidy -diff`
- `make lint-plugger`
- `make lint`
- `umask 022 && CGO_ENABLED=1 go test ./...`
- `make scalibr`
