### PR TITLE
extractor/os/rpm: trim AlmaLinux ecosystem suffix to major version

### DIFF
--- a/extractor/filesystem/os/ecosystem/ecosystem.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem.go
@@ -81,7 +81,11 @@ func MakeEcosystem(metadata any) osvecosystem.Parsed {
 			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemOpenEuler, Suffix: m.OpenEulerEcosystemSuffix()}
 		}
 		if m.OSID == "almalinux" {
-			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemAlmaLinux, Suffix: m.OSVersionID}
+			// OSV.dev keys AlmaLinux advisories by major version only (e.g.
+			// "AlmaLinux:9"), so trim any point-release portion of VERSION_ID
+			// (e.g. "9.8" -> "9"). A bare major like "9" is returned unchanged.
+			major, _, _ := strings.Cut(m.OSVersionID, ".")
+			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemAlmaLinux, Suffix: major}
 		}
 
 	case *snapmeta.Metadata:

--- a/extractor/filesystem/os/ecosystem/ecosystem_test.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem_test.go
@@ -316,7 +316,15 @@ func TestEcosystemRPM(t *testing.T) {
 			want: "openEuler",
 		},
 		{
-			desc: "AlmaLinux_9",
+			desc: "AlmaLinux_point_release_trimmed_to_major",
+			metadata: &rpmmeta.Metadata{
+				OSID:        "almalinux",
+				OSVersionID: "9.8",
+			},
+			want: "AlmaLinux:9",
+		},
+		{
+			desc: "AlmaLinux_bare_major",
 			metadata: &rpmmeta.Metadata{
 				OSID:        "almalinux",
 				OSVersionID: "9",


### PR DESCRIPTION
PR #2148 mapped ID=almalinux to EcosystemAlmaLinux using the full os-release VERSION_ID as the suffix. On a real host VERSION_ID is a point release (e.g. "9.8"), producing the ecosystem "AlmaLinux:9.8".

OSV.dev keys AlmaLinux (ALSA) advisories by major version only ("AlmaLinux:9"), so the point-release suffix matches zero advisories.

Empirical check against the OSV.dev API for an AlmaLinux 9.8 host with 416 installed packages:
  AlmaLinux:9    -> 38 packages with vulns, 532 vuln refs
  AlmaLinux:9.8  -> 0 packages, 0 vulns
e.g. NetworkManager 1.54.3-2.el9: AlmaLinux:9 => 3 vulns, 9.8 => 0.

Trim VERSION_ID to the part before the first "." so "9.8" -> "9". A bare major such as "9" is returned unchanged by strings.Cut.