### PR TITLE
Add Go vendor modules extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -78,6 +78,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Gleam      | gleam.toml                                        | `gleam/gleamtoml`                    |
 | Go         | Go binaries                                       | `go/binary`                          |
 |            | go.mod (OSV)                                      | `go/gomod`                           |
+|            | vendor/modules.txt                                | `go/vendormodules`                   |
 | Haskell    | stack.yaml.lock                                   | `haskell/stacklock`                  |
 |            | cabal.project.freeze                              | `haskell/cabal`                      |
 | Java       | Java archives                                     | `java/archive`                       |

--- a/extractor/filesystem/language/golang/vendormodules/testdata/invalid/vendor/modules.txt
+++ b/extractor/filesystem/language/golang/vendormodules/testdata/invalid/vendor/modules.txt
@@ -1,0 +1,12 @@
+## explicit; go 1.20
+github.com/example/no-header
+# github.com/example/no-version
+# github.com/example/local => ../local
+# github.com/example/unused v1.2.3
+## explicit; go 1.20
+# github.com/example/badversion nope
+github.com/example/badversion
+# github.com/example/v2 v1.0.0
+github.com/example/v2
+# github.com/example/replaced v1.0.0 => not a local path
+github.com/example/replaced

--- a/extractor/filesystem/language/golang/vendormodules/testdata/valid/vendor/modules.txt
+++ b/extractor/filesystem/language/golang/vendormodules/testdata/valid/vendor/modules.txt
@@ -1,0 +1,31 @@
+# github.com/BurntSushi/toml v1.2.1
+## explicit; go 1.21; toolchain go1.21.8
+github.com/BurntSushi/toml
+# golang.org/x/crypto v0.31.0
+## explicit; go 1.20
+golang.org/x/crypto/chacha20
+# golang.org/x/net v0.5.6 => example.com/fork/net v1.4.5
+## explicit
+example.com/fork/net/http2
+# example.com/local v1.0.0 => ./local
+## explicit
+example.com/local
+# example.com/noversion => ./local
+# malformed
+# github.com/example/incompatible v2.0.0+incompatible
+## explicit
+github.com/example/incompatible
+# example.com/transitive v0.2.0
+## implicit; go 1.21
+example.com/transitive/pkg
+# github.com/BurntSushi/toml v1.2.1
+## explicit; go 1.21
+github.com/BurntSushi/toml/internal
+# example.com/headeronly v0.1.0
+## explicit; go 1.21
+# example.com/afterheaderonly v0.3.0
+## implicit; go 1.21
+example.com/afterheaderonly/pkg
+# example.com/wildcard => example.com/wildcard-fork v0.2.0
+## explicit
+example.com/wildcard-fork/pkg

--- a/extractor/filesystem/language/golang/vendormodules/vendormodules.go
+++ b/extractor/filesystem/language/golang/vendormodules/vendormodules.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package vendormodules extracts Go vendor/modules.txt files.
+package vendormodules
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"golang.org/x/mod/module"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "go/vendormodules"
+)
+
+type pkgKey struct {
+	name    string
+	version string
+}
+
+type moduleEntry struct {
+	name       string
+	version    string
+	lineNumber int
+}
+
+// Extractor extracts Go packages from vendor/modules.txt files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the specified file matches Go vendored module manifests.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	// Normalize both OS-native paths and Windows-style paths used by tests.
+	path := strings.ReplaceAll(api.Path(), "\\", "/")
+	path = filepath.ToSlash(filepath.Clean(path))
+	return path == "vendor/modules.txt" || strings.HasSuffix(path, "/vendor/modules.txt")
+}
+
+// Extract extracts packages from vendor/modules.txt files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	scanner := bufio.NewScanner(input.Reader)
+	packages := map[pkgKey]*extractor.Package{}
+	var pending *moduleEntry
+
+	for lineNumber := 1; scanner.Scan(); lineNumber++ {
+		if err := ctx.Err(); err != nil {
+			return inventory.Inventory{}, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
+		}
+
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "# ") {
+			pending = nil
+			name, version, ok := parseModuleHeader(line)
+			if ok {
+				pending = &moduleEntry{name: name, version: version, lineNumber: lineNumber}
+			}
+			continue
+		}
+
+		if pending == nil || !isVendoredPackageLine(line) {
+			continue
+		}
+
+		key := pkgKey{name: pending.name, version: pending.version}
+		if _, ok := packages[key]; !ok {
+			packages[key] = packageFromModuleEntry(input.Path, pending)
+		}
+		// Emit once per module header. Additional package lines under the same
+		// header do not change the module-level inventory record.
+		pending = nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
+	}
+
+	return inventory.Inventory{Packages: sortedPackages(packages)}, nil
+}
+
+func packageFromModuleEntry(path string, entry *moduleEntry) *extractor.Package {
+	return &extractor.Package{
+		Name:     entry.name,
+		Version:  entry.version,
+		PURLType: purl.TypeGolang,
+		Location: extractor.LocationFromPathAndLine(path, entry.lineNumber),
+	}
+}
+
+func sortedPackages(packages map[pkgKey]*extractor.Package) []*extractor.Package {
+	if len(packages) == 0 {
+		return nil
+	}
+
+	pkgs := make([]*extractor.Package, 0, len(packages))
+	for _, pkg := range packages {
+		pkgs = append(pkgs, pkg)
+	}
+	slices.SortFunc(pkgs, func(a, b *extractor.Package) int {
+		if c := strings.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Version, b.Version)
+	})
+	return pkgs
+}
+
+func parseModuleHeader(line string) (string, string, bool) {
+	fields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(line, "#")))
+	if len(fields) < 2 {
+		return "", "", false
+	}
+
+	arrow := slices.Index(fields, "=>")
+	if arrow == -1 {
+		return moduleFromFields(fields)
+	}
+
+	replacementName, replacementVersion, ok := moduleFromFields(fields[arrow+1:])
+	if ok {
+		return replacementName, replacementVersion, true
+	}
+
+	if isLocalReplacement(fields[arrow+1:]) {
+		return moduleFromFields(fields[:arrow])
+	}
+
+	return "", "", false
+}
+
+func moduleFromFields(fields []string) (string, string, bool) {
+	// The selected module identity is encoded as exactly "module version".
+	if len(fields) != 2 {
+		return "", "", false
+	}
+	return normalizeModule(fields[0], fields[1])
+}
+
+func normalizeModule(name, version string) (string, string, bool) {
+	if err := module.Check(name, version); err != nil {
+		return "", "", false
+	}
+	return name, strings.TrimPrefix(version, "v"), true
+}
+
+func isLocalReplacement(fields []string) bool {
+	if len(fields) != 1 {
+		return false
+	}
+
+	path := fields[0]
+	return strings.HasPrefix(path, "./") ||
+		strings.HasPrefix(path, "../") ||
+		strings.HasPrefix(path, "/") ||
+		strings.HasPrefix(path, ".\\") ||
+		strings.HasPrefix(path, "..\\")
+}
+
+func isVendoredPackageLine(line string) bool {
+	if line == "" || strings.HasPrefix(line, "#") {
+		return false
+	}
+	return module.CheckImportPath(line) == nil
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/golang/vendormodules/vendormodules_test.go
+++ b/extractor/filesystem/language/golang/vendormodules/vendormodules_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vendormodules_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/vendormodules"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "empty",
+			inputPath: "",
+			want:      false,
+		},
+		{
+			name:      "root_vendor_modules",
+			inputPath: "vendor/modules.txt",
+			want:      true,
+		},
+		{
+			name:      "nested_vendor_modules",
+			inputPath: "path/to/vendor/modules.txt",
+			want:      true,
+		},
+		{
+			name:      "windows_vendor_modules",
+			inputPath: `path\to\vendor\modules.txt`,
+			want:      true,
+		},
+		{
+			name:      "modules_txt_outside_vendor",
+			inputPath: "path/to/modules.txt",
+			want:      false,
+		},
+		{
+			name:      "other_file_in_vendor",
+			inputPath: "path/to/vendor/other.txt",
+			want:      false,
+		},
+		{
+			name:      "vendor_modules_child",
+			inputPath: "path/to/vendor/modules.txt/file",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := vendormodules.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("vendormodules.New() error: %v", err)
+			}
+
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%q) got %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []*extracttest.TestTableEntry{
+		{
+			Name: "valid_modules",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/valid/vendor/modules.txt",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "example.com/afterheaderonly",
+					Version:  "0.3.0",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine(
+						"testdata/valid/vendor/modules.txt", 26),
+				},
+				{
+					Name:     "github.com/BurntSushi/toml",
+					Version:  "1.2.1",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine(
+						"testdata/valid/vendor/modules.txt", 1),
+				},
+				{
+					Name:     "golang.org/x/crypto",
+					Version:  "0.31.0",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine(
+						"testdata/valid/vendor/modules.txt", 4),
+				},
+				{
+					Name:     "example.com/fork/net",
+					Version:  "1.4.5",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine(
+						"testdata/valid/vendor/modules.txt", 7),
+				},
+				{
+					Name:     "example.com/local",
+					Version:  "1.0.0",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine(
+						"testdata/valid/vendor/modules.txt", 10),
+				},
+				{
+					Name:     "example.com/transitive",
+					Version:  "0.2.0",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine(
+						"testdata/valid/vendor/modules.txt", 18),
+				},
+				{
+					Name:     "example.com/wildcard-fork",
+					Version:  "0.2.0",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine(
+						"testdata/valid/vendor/modules.txt", 29),
+				},
+				{
+					Name:     "github.com/example/incompatible",
+					Version:  "2.0.0+incompatible",
+					PURLType: purl.TypeGolang,
+					Location: extractor.LocationFromPathAndLine(
+						"testdata/valid/vendor/modules.txt", 15),
+				},
+			},
+		},
+		{
+			Name: "empty_file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty/vendor/modules.txt",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "invalid_modules",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid/vendor/modules.txt",
+			},
+			WantPackages: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := vendormodules.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("vendormodules.New() error: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract_ContextCancelled(t *testing.T) {
+	extr, err := vendormodules.New(&cpb.PluginConfig{})
+	if err != nil {
+		t.Fatalf("vendormodules.New() error: %v", err)
+	}
+
+	scanInput := extracttest.GenerateScanInputMock(t, extracttest.ScanInputMockConfig{
+		Path: "testdata/valid/vendor/modules.txt",
+	})
+	defer extracttest.CloseTestScanInput(t, scanInput)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = extr.Extract(ctx, &scanInput)
+	if err == nil || !strings.Contains(err.Error(), "context error") {
+		t.Fatalf("%s.Extract() error got %v, want context error", extr.Name(), err)
+	}
+}

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -47,6 +47,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/gleam/gleamtoml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gobinary"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/vendormodules"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/cabal"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/stacklock"
 	javaarchive "github.com/google/osv-scalibr/extractor/filesystem/language/java/archive"
@@ -262,7 +263,8 @@ var (
 	}
 	// GoSource extractors for Go.
 	GoSource = InitMap{
-		gomod.Name: {protoCfg(gomod.New)},
+		gomod.Name:         {protoCfg(gomod.New)},
+		vendormodules.Name: {protoCfg(vendormodules.New)},
 	}
 	// GoArtifact extractors for Go.
 	GoArtifact = InitMap{


### PR DESCRIPTION
Fixes #2188

## Summary

Adds a filesystem inventory extractor for Go vendored module manifests at `vendor/modules.txt`.

The extractor parses module entries recorded in the vendored dependency manifest generated by `go mod vendor` and emits Go package inventory records. A module is emitted only when a valid module header is followed by a valid vendored package import line, reducing false positives from malformed or header-only files.

## Scope

- Registers the extractor as `go/vendormodules`
- Matches only `vendor/modules.txt`
- Emits packages with `purl.TypeGolang`
- Records line-number locations from the manifest
- Emits only when a module path and concrete version are available
- Handles versioned remote replacements, e.g. `old v1.0.0 => new v1.2.0`
- Handles local replacements by preserving the versioned original module identity, e.g. `old v1.0.0 => ./local`
- Skips local-only replacements without a version
- Ignores `## explicit`, `## implicit`, Go version, and toolchain annotation lines
- Deduplicates repeated module/version entries while preserving the first observed location
- Returns inventory deterministically sorted by module name and version

This change does not add dependency resolution, graph metadata, OSV lookups, new package metadata, proto changes, detector logic, or cross-file reconciliation with `go.mod`.

## Testing

```sh
go test ./extractor/filesystem/language/golang/vendormodules
go test ./extractor/filesystem/list
go test ./extractor/filesystem/language/golang/...
```

Additional coverage includes:

- Valid and invalid manifests
- Empty files
- Remote and local replacements
- Annotation lines (`## explicit`, `## implicit`, toolchain metadata)
- Duplicate modules
- Windows path handling
- Context cancellation

A local SCALIBR build was also smoke-tested against a real Go project generated with `go mod vendor`.