### PR TITLE
Sensitive Information - SSN Detection

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -211,6 +211,11 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Discord Bot Token                           | `secrets/discordbottoken`              |
 | HTTP Basic Auth Header                      | `secrets/httpbasicauth`                |
 
+### Sensitive information
+| Type                                        | Extractor Plugin                     |
+| ------------------------------------------- | ------------------------------------ |
+| US Social Security Number                   | `sensitiveinformation/ssn`             |
+
 ### Container inventory
 
 | Type                            | Extractor Plugin                                                                   |

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -182,6 +182,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/tinkkeyset"
 	"github.com/google/osv-scalibr/veles/secrets/urlcreds"
 	"github.com/google/osv-scalibr/veles/secrets/vapid"
+	"github.com/google/osv-scalibr/veles/sensitiveinformation/ssn"
 
 	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 )
@@ -448,10 +449,15 @@ var (
 		{http.NewBasicAuthDetector(), "secrets/httpbasicauth", 0},
 	})
 
+	SensitiveInformationDetectors = initMapFromVelesPlugins([]velesPlugin{
+		{ssn.NewDetector(), "sensitiveinformation/ssn", 0},
+	})
+
 	// Secrets contains both secret extractors and detectors.
 	Secrets = concat(
 		SecretDetectors,
 		SecretExtractors,
+		SensitiveInformationDetectors,
 	)
 
 	// Misc artifact extractors.

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex.go
@@ -31,21 +31,21 @@ import (
 // It implements veles.Detector.
 type Detector struct {
 	// The maximum length of the sensitive information.
-	maxLen uint32
+	MaxLen uint32
 	// Matches on the sensitive information.
-	re *regexp.Regexp
+	Re *regexp.Regexp
 
 	// Context window size for keywords search before the match.
-	contextWindowBefore uint32
+	ContextWindowBefore uint32
 	// Context window size for keywords search after the match.
-	contextWindowAfter uint32
+	ContextWindowAfter uint32
 
 	// KeywordsRe is the regexp of the Keywords. All keywords are case insensitive.
-	keywordsRe *regexp.Regexp
+	KeywordsRe *regexp.Regexp
 
 	// Returns a sensitiveinformation.SensitiveInformation from a regexp match
 	// result.
-	fromMatch func([]byte) (sensitiveinformation.SensitiveInformation, bool)
+	FromMatch func([]byte) (sensitiveinformation.SensitiveInformation, bool)
 }
 
 // KeywordsRe returns a regexp of the keywords. All keywords are case insensitive.

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex.go
@@ -45,7 +45,7 @@ type Detector struct {
 
 	// Returns a sensitiveinformation.SensitiveInformation from a regexp match
 	// result.
-	FromMatch func([]byte) (sensitiveinformation.SensitiveInformation, bool)
+	FromMatch func([]byte, bool) (sensitiveinformation.SensitiveInformation, bool)
 }
 
 // KeywordsRe returns a regexp of the keywords. All keywords are case insensitive.
@@ -68,15 +68,12 @@ func (d Detector) Detect(data []byte) (secrets []veles.Secret, positions []int) 
 		l, r := m[0], m[1]
 		lowerBound := max(0, l-int(d.ContextWindowBefore))
 		upperBound := min(len(data), r+int(d.ContextWindowAfter))
-		// If keywordsRe is set, check if the keywords are present in the context window before or after
-		// the match.
-		if d.KeywordsRe != nil &&
-			!d.KeywordsRe.Match(data[lowerBound:l]) &&
-			!d.KeywordsRe.Match(data[r:upperBound]) {
-			continue
-		}
+		// If KeywordsRe is set, check if the keywords are present in the context
+		// window before or after the match.
+		contextMatch := d.KeywordsRe != nil &&
+			(d.KeywordsRe.Match(data[lowerBound:l]) || d.KeywordsRe.Match(data[r:upperBound]))
 
-		if match, ok := d.FromMatch(data[l:r]); ok {
+		if match, ok := d.FromMatch(data[l:r], contextMatch); ok {
 			secrets = append(secrets, match)
 			positions = append(positions, l)
 		}

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/google/osv-scalibr/veles"
-	"github.com/google/osv-scalibr/veles/sensitiveinformation"
 )
 
 // Detector finds instances of sensitive information detector that matches the
@@ -45,7 +44,7 @@ type Detector struct {
 
 	// Returns a sensitiveinformation.SensitiveInformation from a regexp match
 	// result.
-	FromMatch func([]byte) (sensitiveinformation.SensitiveInformation, bool)
+	FromMatch func([]byte) (veles.Secret, bool)
 }
 
 // KeywordsRe returns a regexp of the keywords. All keywords are case insensitive.

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex.go
@@ -58,25 +58,25 @@ func KeywordsRe(keywords []string) *regexp.Regexp {
 
 // MaxSecretLen returns the maximum length of the search window.
 func (d Detector) MaxSecretLen() uint32 {
-	return d.maxLen + d.contextWindowBefore + d.contextWindowAfter
+	return d.MaxLen + d.ContextWindowBefore + d.ContextWindowAfter
 }
 
 // Detect finds candidate tokens that match Detector.Re and returns them
 // alongside their starting positions.
 func (d Detector) Detect(data []byte) (secrets []veles.Secret, positions []int) {
-	for _, m := range d.re.FindAllIndex(data, -1) {
+	for _, m := range d.Re.FindAllIndex(data, -1) {
 		l, r := m[0], m[1]
-		lowerBound := max(0, l-int(d.contextWindowBefore))
-		upperBound := min(len(data), r+int(d.contextWindowAfter))
+		lowerBound := max(0, l-int(d.ContextWindowBefore))
+		upperBound := min(len(data), r+int(d.ContextWindowAfter))
 		// If keywordsRe is set, check if the keywords are present in the context window before or after
 		// the match.
-		if d.keywordsRe != nil &&
-			!d.keywordsRe.Match(data[lowerBound:l]) &&
-			!d.keywordsRe.Match(data[r:upperBound]) {
+		if d.KeywordsRe != nil &&
+			!d.KeywordsRe.Match(data[lowerBound:l]) &&
+			!d.KeywordsRe.Match(data[r:upperBound]) {
 			continue
 		}
 
-		if match, ok := d.fromMatch(data[l:r]); ok {
+		if match, ok := d.FromMatch(data[l:r]); ok {
 			secrets = append(secrets, match)
 			positions = append(positions, l)
 		}

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex.go
@@ -45,7 +45,7 @@ type Detector struct {
 
 	// Returns a sensitiveinformation.SensitiveInformation from a regexp match
 	// result.
-	FromMatch func([]byte, bool) (sensitiveinformation.SensitiveInformation, bool)
+	FromMatch func(blob []byte, keywordMatch bool) (sensitiveinformation.SensitiveInformation, bool)
 }
 
 // KeywordsRe returns a regexp of the keywords. All keywords are case insensitive.

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/sensitiveinformation"
 )
 
 // Detector finds instances of sensitive information detector that matches the
@@ -44,7 +45,7 @@ type Detector struct {
 
 	// Returns a sensitiveinformation.SensitiveInformation from a regexp match
 	// result.
-	FromMatch func([]byte) (veles.Secret, bool)
+	FromMatch func([]byte) (sensitiveinformation.SensitiveInformation, bool)
 }
 
 // KeywordsRe returns a regexp of the keywords. All keywords are case insensitive.

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
@@ -43,7 +43,7 @@ func TestDetect_truePositives(t *testing.T) {
 		in        []byte
 		want      []veles.Secret
 		wantPos   []int
-		fromMatch func([]byte) (sensitiveinformation.SensitiveInformation, bool)
+		fromMatch func([]byte) (veles.Secret, bool)
 	}{
 		{
 			name:   "match only",
@@ -123,7 +123,7 @@ BAZ
 				fakeSensitiveInformation([]byte("BAR")),
 			},
 			wantPos: []int{4},
-			fromMatch: func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
+			fromMatch: func(b []byte) (veles.Secret, bool) {
 				if string(b) == "FOO" {
 					return sensitiveinformation.SensitiveInformation{}, false
 				}
@@ -193,7 +193,7 @@ BAZ
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.fromMatch == nil {
-				tc.fromMatch = func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
+				tc.fromMatch = func(b []byte) (veles.Secret, bool) {
 					return fakeSensitiveInformation(b), true
 				}
 			}
@@ -253,7 +253,7 @@ func TestDetect_trueNegatives(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			fromMatch := func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
+			fromMatch := func(b []byte) (veles.Secret, bool) {
 				return fakeSensitiveInformation(b), true
 			}
 			d := Detector{

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
@@ -43,6 +43,7 @@ func TestDetect_truePositives(t *testing.T) {
 		in        []byte
 		want      []veles.Secret
 		wantPos   []int
+		wantFlags []bool
 		fromMatch func([]byte, bool) (sensitiveinformation.SensitiveInformation, bool)
 	}{
 		{
@@ -153,6 +154,10 @@ BAZ
 				fakeSensitiveInformation([]byte("BAR")),
 			},
 			wantPos: []int{0, 8},
+			wantFlags: []bool{
+				false,
+				true,
+			},
 		}, {
 			name:     "keywords after",
 			regexp:   "[A-Z]{3}",
@@ -166,6 +171,11 @@ BAZ
 				fakeSensitiveInformation([]byte("BAR")),
 			},
 			wantPos: []int{0, 4, 8},
+			wantFlags: []bool{
+				true,
+				false,
+				false,
+			},
 		}, {
 			name:     "keywords before and after",
 			regexp:   "[A-Z]{3}",
@@ -182,6 +192,13 @@ BAZ
 				fakeSensitiveInformation([]byte("ABC")),
 			},
 			wantPos: []int{0, 4, 8, 12, 16},
+			wantFlags: []bool{
+				false,
+				true,
+				false,
+				true,
+				false,
+			},
 		}, {
 			name:     "keywords matches regex",
 			regexp:   "[A-Z]{3}",
@@ -195,22 +212,32 @@ BAZ
 				fakeSensitiveInformation([]byte("ABC")),
 			},
 			wantPos: []int{0, 4, 8},
+			wantFlags: []bool{
+				false,
+				true,
+				true,
+			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.fromMatch == nil {
-				tc.fromMatch = func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
+			fromMatch := tc.fromMatch
+			if fromMatch == nil {
+				fromMatch = func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
 					return fakeSensitiveInformation(b), true
 				}
 			}
+			var gotFlags []bool
 			d := Detector{
 				MaxLen:              tc.maxLen,
 				Re:                  regexp.MustCompile(tc.regexp),
 				ContextWindowBefore: tc.before,
 				ContextWindowAfter:  tc.after,
 				KeywordsRe:          KeywordsRe(tc.keywords),
-				FromMatch:           tc.fromMatch,
+				FromMatch: func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
+					gotFlags = append(gotFlags, contextMatch)
+					return fromMatch(b, contextMatch)
+				},
 			}
 			got, gotPos := d.Detect(tc.in)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
@@ -218,6 +245,13 @@ BAZ
 			}
 			if diff := cmp.Diff(tc.wantPos, gotPos, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+			wantFlags := tc.wantFlags
+			if wantFlags == nil {
+				wantFlags = make([]bool, len(gotFlags))
+			}
+			if diff := cmp.Diff(wantFlags, gotFlags, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("FromMatch() keywordMatch diff (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
@@ -43,7 +43,7 @@ func TestDetect_truePositives(t *testing.T) {
 		in        []byte
 		want      []veles.Secret
 		wantPos   []int
-		fromMatch func([]byte) (veles.Secret, bool)
+		fromMatch func([]byte) (sensitiveinformation.SensitiveInformation, bool)
 	}{
 		{
 			name:   "match only",
@@ -123,7 +123,7 @@ BAZ
 				fakeSensitiveInformation([]byte("BAR")),
 			},
 			wantPos: []int{4},
-			fromMatch: func(b []byte) (veles.Secret, bool) {
+			fromMatch: func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
 				if string(b) == "FOO" {
 					return sensitiveinformation.SensitiveInformation{}, false
 				}
@@ -193,7 +193,7 @@ BAZ
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.fromMatch == nil {
-				tc.fromMatch = func(b []byte) (veles.Secret, bool) {
+				tc.fromMatch = func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
 					return fakeSensitiveInformation(b), true
 				}
 			}
@@ -253,7 +253,7 @@ func TestDetect_trueNegatives(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			fromMatch := func(b []byte) (veles.Secret, bool) {
+			fromMatch := func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
 				return fakeSensitiveInformation(b), true
 			}
 			d := Detector{

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
@@ -198,12 +198,12 @@ BAZ
 				}
 			}
 			d := Detector{
-				maxLen:              tc.maxLen,
-				re:                  regexp.MustCompile(tc.regexp),
-				contextWindowBefore: tc.before,
-				contextWindowAfter:  tc.after,
-				keywordsRe:          KeywordsRe(tc.keywords),
-				fromMatch:           tc.fromMatch,
+				MaxLen:              tc.maxLen,
+				Re:                  regexp.MustCompile(tc.regexp),
+				ContextWindowBefore: tc.before,
+				ContextWindowAfter:  tc.after,
+				KeywordsRe:          KeywordsRe(tc.keywords),
+				FromMatch:           tc.fromMatch,
 			}
 			got, gotPos := d.Detect(tc.in)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
@@ -257,12 +257,12 @@ func TestDetect_trueNegatives(t *testing.T) {
 				return fakeSensitiveInformation(b), true
 			}
 			d := Detector{
-				maxLen:              tc.maxLen,
-				re:                  regexp.MustCompile(tc.regexp),
-				contextWindowBefore: tc.before,
-				contextWindowAfter:  tc.after,
-				keywordsRe:          KeywordsRe(tc.keywords),
-				fromMatch:           fromMatch,
+				MaxLen:              tc.maxLen,
+				Re:                  regexp.MustCompile(tc.regexp),
+				ContextWindowBefore: tc.before,
+				ContextWindowAfter:  tc.after,
+				KeywordsRe:          KeywordsRe(tc.keywords),
+				FromMatch:           fromMatch,
 			}
 			got, gotPos := d.Detect(tc.in)
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
@@ -223,7 +223,7 @@ BAZ
 		t.Run(tc.name, func(t *testing.T) {
 			fromMatch := tc.fromMatch
 			if fromMatch == nil {
-				fromMatch = func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
+				fromMatch = func(b []byte, _ bool) (sensitiveinformation.SensitiveInformation, bool) {
 					return fakeSensitiveInformation(b), true
 				}
 			}

--- a/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
+++ b/veles/sensitiveinformation/common/simpleregex/simpleregex_test.go
@@ -43,7 +43,7 @@ func TestDetect_truePositives(t *testing.T) {
 		in        []byte
 		want      []veles.Secret
 		wantPos   []int
-		fromMatch func([]byte) (sensitiveinformation.SensitiveInformation, bool)
+		fromMatch func([]byte, bool) (sensitiveinformation.SensitiveInformation, bool)
 	}{
 		{
 			name:   "match only",
@@ -123,7 +123,7 @@ BAZ
 				fakeSensitiveInformation([]byte("BAR")),
 			},
 			wantPos: []int{4},
-			fromMatch: func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
+			fromMatch: func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
 				if string(b) == "FOO" {
 					return sensitiveinformation.SensitiveInformation{}, false
 				}
@@ -149,9 +149,10 @@ BAZ
 			before:   4,
 			keywords: []string{"abc", "def"},
 			want: []veles.Secret{
+				fakeSensitiveInformation([]byte("FOO")),
 				fakeSensitiveInformation([]byte("BAR")),
 			},
-			wantPos: []int{8},
+			wantPos: []int{0, 8},
 		}, {
 			name:     "keywords after",
 			regexp:   "[A-Z]{3}",
@@ -161,8 +162,10 @@ BAZ
 			keywords: []string{"abc", "def"},
 			want: []veles.Secret{
 				fakeSensitiveInformation([]byte("FOO")),
+				fakeSensitiveInformation([]byte("DEF")),
+				fakeSensitiveInformation([]byte("BAR")),
 			},
-			wantPos: []int{0},
+			wantPos: []int{0, 4, 8},
 		}, {
 			name:     "keywords before and after",
 			regexp:   "[A-Z]{3}",
@@ -172,10 +175,13 @@ BAZ
 			after:    4,
 			keywords: []string{"abc", "def"},
 			want: []veles.Secret{
+				fakeSensitiveInformation([]byte("ABC")),
 				fakeSensitiveInformation([]byte("FOO")),
+				fakeSensitiveInformation([]byte("DEF")),
 				fakeSensitiveInformation([]byte("BAR")),
+				fakeSensitiveInformation([]byte("ABC")),
 			},
-			wantPos: []int{4, 12},
+			wantPos: []int{0, 4, 8, 12, 16},
 		}, {
 			name:     "keywords matches regex",
 			regexp:   "[A-Z]{3}",
@@ -184,16 +190,17 @@ BAZ
 			before:   4,
 			keywords: []string{"abc", "def"},
 			want: []veles.Secret{
+				fakeSensitiveInformation([]byte("ABC")),
 				fakeSensitiveInformation([]byte("DEF")),
 				fakeSensitiveInformation([]byte("ABC")),
 			},
-			wantPos: []int{4, 8},
+			wantPos: []int{0, 4, 8},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.fromMatch == nil {
-				tc.fromMatch = func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
+				tc.fromMatch = func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
 					return fakeSensitiveInformation(b), true
 				}
 			}
@@ -211,6 +218,66 @@ BAZ
 			}
 			if diff := cmp.Diff(tc.wantPos, gotPos, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDetect_passesKeywordContextMatchToFromMatch(t *testing.T) {
+	type callbackCall struct {
+		Match        string
+		ContextMatch bool
+	}
+
+	cases := []struct {
+		name     string
+		keywords []string
+		in       []byte
+		before   uint32
+		after    uint32
+		want     []callbackCall
+	}{
+		{
+			name:     "keyword_match_and_no_keyword_match",
+			keywords: []string{"abc", "def"},
+			in:       []byte("abc FOO x BAR yyy BAZ def"),
+			before:   4,
+			after:    4,
+			want: []callbackCall{
+				{Match: "FOO", ContextMatch: true},
+				{Match: "BAR", ContextMatch: false},
+				{Match: "BAZ", ContextMatch: true},
+			},
+		},
+		{
+			name:     "no_keywords_regexp",
+			keywords: nil,
+			in:       []byte("abc FOO def"),
+			before:   4,
+			after:    4,
+			want: []callbackCall{
+				{Match: "FOO", ContextMatch: false},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []callbackCall
+			d := Detector{
+				MaxLen:              3,
+				Re:                  regexp.MustCompile("[A-Z]{3}"),
+				ContextWindowBefore: tc.before,
+				ContextWindowAfter:  tc.after,
+				KeywordsRe:          KeywordsRe(tc.keywords),
+				FromMatch: func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
+					got = append(got, callbackCall{Match: string(b), ContextMatch: contextMatch})
+					return fakeSensitiveInformation(b), true
+				},
+			}
+			d.Detect(tc.in)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("FromMatch calls diff (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -234,26 +301,10 @@ func TestDetect_trueNegatives(t *testing.T) {
 		regexp: "FOO",
 		maxLen: 3,
 		in:     []byte("BAR"),
-	}, {
-		name:     "no keyword match",
-		regexp:   "FOO",
-		keywords: []string{"abc", "def"},
-		before:   4,
-		after:    4,
-		maxLen:   3,
-		in:       []byte("FOO"),
-	}, {
-		name:     "keyword ahead of context window",
-		regexp:   "FOO",
-		keywords: []string{"abc", "def"},
-		before:   3,
-		after:    3,
-		maxLen:   3,
-		in:       []byte("abc FOO def"),
 	}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			fromMatch := func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
+			fromMatch := func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
 				return fakeSensitiveInformation(b), true
 			}
 			d := Detector{

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -28,6 +28,22 @@ const maxSecretLength = 11
 // SSN has format ddd-dd-dddd
 var ssnRe = regexp.MustCompile(`\b[0-8]\d{2}-\d{2}-\d{4}\b`)
 
+var commonExamples = map[string]struct{}{
+	"123-45-6789": {},
+
+	"111-11-1111": {},
+	"222-22-2222": {},
+	"333-33-3333": {},
+	"444-44-4444": {},
+	"555-55-5555": {},
+	"777-77-7777": {},
+	"888-88-8888": {},
+	"999-99-9999": {},
+
+	// https://www.ssa.gov/history/ssn/misused.html
+	"078-05-1120": {},
+}
+
 // NewDetector returns a Detector, that finds US Social Security Numbers (SSNs)
 func NewDetector() veles.Detector {
 	return simpleregex.Detector{
@@ -58,6 +74,10 @@ func NewDetector() veles.Detector {
 // SSN's segment cannot be all 0s
 func validSSN(s string) bool {
 	if !ssnRe.MatchString(s) {
+		return false
+	}
+
+	if _, ok := commonExamples[s]; ok {
 		return false
 	}
 

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -69,9 +69,6 @@ func NewDetector() veles.Detector {
 	}
 }
 
-// SSN CANNOT start with 666
-// SSN's first segment cannot be between 900-999
-// SSN's segment cannot be all 0s
 func validSSN(s string) bool {
 	if !ssnRe.MatchString(s) {
 		return false

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -26,7 +26,8 @@ import (
 
 const maxSecretLength = 11
 
-// SSN has format ddd-dd-dddd
+// https://www.protecto.ai/blog/personal-dataset-sample-u-s-social-security-number-ssn-download-pii-data-examples-2/
+// https://www.ssa.gov/history/ssn/geocard.html
 var ssnRe = regexp.MustCompile(`\b[0-8]\d{2}-\d{2}-\d{4}\b`)
 
 var commonExamples = map[string]struct{}{

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -8,13 +8,13 @@ import (
 	"github.com/google/osv-scalibr/veles/sensitiveinformation/common/simpleregex"
 )
 
-const maxSecretLength = 9
+const maxSecretLength = 11
 
 // SSN has format ddd-dd-dddd
 // SSN CANNOT start with 666
 // SSN's first segment cannot be between 900-999
 // SSN's segment cannot be all 0s
-var ssnRe = regexp.MustCompile("(?!666|000|9\\d{2})\\d{3}-(?!00)\\d{2}-(?!0{4})\\d{4}")
+var ssnRe = regexp.MustCompile("(00[1-9]|0[1-9][0-9]|[1-5][0-9]{2}|6[0-5][0-9]|66[0-5]|66[7-9]|[78][0-9]{2})-(0[1-9]|[1-9][0-9])-(000[1-9]|00[1-9][0-9]|0[1-9][0-9]{2}|[1-9][0-9]{3})")
 
 func NewDetector() veles.Detector {
 	return simpleregex.Detector{

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -26,17 +26,19 @@ import (
 const maxSecretLength = 11
 
 // SSN has format ddd-dd-dddd
-// SSN CANNOT start with 666
-// SSN's first segment cannot be between 900-999
-// SSN's segment cannot be all 0s
-var ssnRe = regexp.MustCompile("(00[1-9]|0[1-9][0-9]|[1-5][0-9]{2}|6[0-5][0-9]|66[0-5]|66[7-9]|[78][0-9]{2})-(0[1-9]|[1-9][0-9])-(000[1-9]|00[1-9][0-9]|0[1-9][0-9]{2}|[1-9][0-9]{3})")
+var ssnRe = regexp.MustCompile(`[0-8]\d{2}-\d{2}-\d{4}`)
 
 // NewDetector returns a Detector, that finds US Social Security Numbers (SSNs)
 func NewDetector() veles.Detector {
 	return simpleregex.Detector{
 		MaxLen: maxSecretLength,
 		Re:     ssnRe,
-		FromMatch: func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			ssn := string(b)
+			if !validSSN(ssn) {
+				return nil, false
+			}
+
 			finding := sensitiveinformation.SensitiveInformation{
 				InfoType: sensitiveinformation.InfoType{
 					Name:        "Social Security Number",
@@ -49,4 +51,22 @@ func NewDetector() veles.Detector {
 			return finding, true
 		},
 	}
+}
+
+// SSN CANNOT start with 666
+// SSN's first segment cannot be between 900-999
+// SSN's segment cannot be all 0s
+func validSSN(s string) bool {
+	if !ssnRe.MatchString(s) {
+		return false
+	}
+
+	area := s[0:3]
+	group := s[4:6]
+	serial := s[7:11]
+
+	return area != "000" &&
+		area != "666" &&
+		group != "00" &&
+		serial != "0000"
 }

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -24,11 +24,24 @@ import (
 	"github.com/google/osv-scalibr/veles/sensitiveinformation/common/simpleregex"
 )
 
-const maxSecretLength = 11
+const (
+	maxSecretLength   = 11
+	contextWindowSize = 32
+)
 
 // https://www.protecto.ai/blog/personal-dataset-sample-u-s-social-security-number-ssn-download-pii-data-examples-2/
 // https://www.ssa.gov/history/ssn/geocard.html
 var ssnRe = regexp.MustCompile(`\b[0-8]\d{2}-\d{2}-\d{4}\b`)
+
+var ssnKeywordsRe = simpleregex.KeywordsRe([]string{
+	`\bssn\b`,
+	`social security`,
+	`social security number`,
+	`social security no`,
+	`social security #`,
+	`socialsecuritynumber`,
+	`socialsecurity`,
+})
 
 var commonExamples = map[string]struct{}{
 	"123-45-6789": {},
@@ -49,12 +62,19 @@ var commonExamples = map[string]struct{}{
 // NewDetector returns a Detector, that finds US Social Security Numbers (SSNs)
 func NewDetector() veles.Detector {
 	return simpleregex.Detector{
-		MaxLen: maxSecretLength,
-		Re:     ssnRe,
+		MaxLen:              maxSecretLength,
+		Re:                  ssnRe,
+		ContextWindowBefore: contextWindowSize,
+		ContextWindowAfter:  contextWindowSize,
+		KeywordsRe:          ssnKeywordsRe,
 		FromMatch: func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
 			ssn := string(b)
 			if !validSSN(ssn) {
 				return sensitiveinformation.SensitiveInformation{}, false
+			}
+			likelihood := sensitiveinformation.LikelihoodUnlikely
+			if contextMatch {
+				likelihood = sensitiveinformation.LikelihoodLikely
 			}
 
 			finding := sensitiveinformation.SensitiveInformation{
@@ -62,7 +82,7 @@ func NewDetector() veles.Detector {
 					Name:        "SOCIAL_SECURITY_NUMBER",
 					Sensitivity: sensitiveinformation.SensitivityLevelHigh,
 				},
-				Likelihood: sensitiveinformation.LikelihoodLikely,
+				Likelihood: likelihood,
 				Raw:        bytes.Clone(b),
 			}
 

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -72,10 +72,6 @@ func NewDetector() veles.Detector {
 }
 
 func validSSN(s string) bool {
-	if !ssnRe.MatchString(s) {
-		return false
-	}
-
 	if _, ok := commonExamples[s]; ok {
 		return false
 	}

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -51,10 +51,10 @@ func NewDetector() veles.Detector {
 	return simpleregex.Detector{
 		MaxLen: maxSecretLength,
 		Re:     ssnRe,
-		FromMatch: func(b []byte) (veles.Secret, bool) {
+		FromMatch: func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
 			ssn := string(b)
 			if !validSSN(ssn) {
-				return nil, false
+				return sensitiveinformation.SensitiveInformation{}, false
 			}
 
 			finding := sensitiveinformation.SensitiveInformation{

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -60,7 +60,7 @@ func NewDetector() veles.Detector {
 			finding := sensitiveinformation.SensitiveInformation{
 				InfoType: sensitiveinformation.InfoType{
 					Name:        "SOCIAL_SECURITY_NUMBER",
-					Sensitivity: sensitiveinformation.SensitivityLevelModerate,
+					Sensitivity: sensitiveinformation.SensitivityLevelHigh,
 				},
 				Likelihood: sensitiveinformation.LikelihoodLikely,
 				Raw:        bytes.Clone(b),

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -59,7 +59,7 @@ func NewDetector() veles.Detector {
 
 			finding := sensitiveinformation.SensitiveInformation{
 				InfoType: sensitiveinformation.InfoType{
-					Name:        "Social Security Number",
+					Name:        "SOCIAL_SECURITY_NUMBER",
 					Sensitivity: sensitiveinformation.SensitivityLevelModerate,
 				},
 				Likelihood: sensitiveinformation.LikelihoodLikely,

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -26,7 +26,7 @@ import (
 const maxSecretLength = 11
 
 // SSN has format ddd-dd-dddd
-var ssnRe = regexp.MustCompile(`[0-8]\d{2}-\d{2}-\d{4}`)
+var ssnRe = regexp.MustCompile(`\b[0-8]\d{2}-\d{2}-\d{4}\b`)
 
 // NewDetector returns a Detector, that finds US Social Security Numbers (SSNs)
 func NewDetector() veles.Detector {

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package ssn implements SSN detection logic.
 package ssn
 
 import (
@@ -30,7 +31,7 @@ const maxSecretLength = 11
 // SSN's segment cannot be all 0s
 var ssnRe = regexp.MustCompile("(00[1-9]|0[1-9][0-9]|[1-5][0-9]{2}|6[0-5][0-9]|66[0-5]|66[7-9]|[78][0-9]{2})-(0[1-9]|[1-9][0-9])-(000[1-9]|00[1-9][0-9]|0[1-9][0-9]{2}|[1-9][0-9]{3})")
 
-// NewDetector() returns a Detector, that finds US Social Security Numbers (SSNs)
+// NewDetector returns a Detector, that finds US Social Security Numbers (SSNs)
 func NewDetector() veles.Detector {
 	return simpleregex.Detector{
 		MaxLen: maxSecretLength,

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -51,7 +51,7 @@ func NewDetector() veles.Detector {
 	return simpleregex.Detector{
 		MaxLen: maxSecretLength,
 		Re:     ssnRe,
-		FromMatch: func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
+		FromMatch: func(b []byte, contextMatch bool) (sensitiveinformation.SensitiveInformation, bool) {
 			ssn := string(b)
 			if !validSSN(ssn) {
 				return sensitiveinformation.SensitiveInformation{}, false

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -16,6 +16,7 @@
 package ssn
 
 import (
+	"bytes"
 	"regexp"
 
 	"github.com/google/osv-scalibr/veles"
@@ -61,7 +62,7 @@ func NewDetector() veles.Detector {
 					Sensitivity: sensitiveinformation.SensitivityLevelModerate,
 				},
 				Likelihood: sensitiveinformation.LikelihoodLikely,
-				Raw:        b,
+				Raw:        bytes.Clone(b),
 			}
 
 			return finding, true

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ssn
 
 import (
@@ -16,6 +30,7 @@ const maxSecretLength = 11
 // SSN's segment cannot be all 0s
 var ssnRe = regexp.MustCompile("(00[1-9]|0[1-9][0-9]|[1-5][0-9]{2}|6[0-5][0-9]|66[0-5]|66[7-9]|[78][0-9]{2})-(0[1-9]|[1-9][0-9])-(000[1-9]|00[1-9][0-9]|0[1-9][0-9]{2}|[1-9][0-9]{3})")
 
+// NewDetector() returns a Detector, that finds US Social Security Numbers (SSNs)
 func NewDetector() veles.Detector {
 	return simpleregex.Detector{
 		MaxLen: maxSecretLength,

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -1,0 +1,36 @@
+package ssn
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/sensitiveinformation"
+	"github.com/google/osv-scalibr/veles/sensitiveinformation/common/simpleregex"
+)
+
+const maxSecretLength = 9
+
+// SSN has format ddd-dd-dddd
+// SSN CANNOT start with 666
+// SSN's first segment cannot be between 900-999
+// SSN's segment cannot be all 0s
+var ssnRe = regexp.MustCompile("(?!666|000|9\\d{2})\\d{3}-(?!00)\\d{2}-(?!0{4})\\d{4}")
+
+func NewDetector() veles.Detector {
+	return simpleregex.Detector{
+		MaxLen: maxSecretLength,
+		Re:     ssnRe,
+		FromMatch: func(b []byte) (sensitiveinformation.SensitiveInformation, bool) {
+			finding := sensitiveinformation.SensitiveInformation{
+				InfoType: sensitiveinformation.InfoType{
+					Name:        "Social Security Number",
+					Sensitivity: sensitiveinformation.SensitivityLevelModerate,
+				},
+				Likelihood: sensitiveinformation.LikelihoodLikely,
+				Raw:        b,
+			}
+
+			return finding, true
+		},
+	}
+}

--- a/veles/sensitiveinformation/ssn/detector.go
+++ b/veles/sensitiveinformation/ssn/detector.go
@@ -18,6 +18,7 @@ package ssn
 import (
 	"bytes"
 	"regexp"
+	"strings"
 
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/sensitiveinformation"
@@ -31,7 +32,7 @@ const (
 
 // https://www.protecto.ai/blog/personal-dataset-sample-u-s-social-security-number-ssn-download-pii-data-examples-2/
 // https://www.ssa.gov/history/ssn/geocard.html
-var ssnRe = regexp.MustCompile(`\b[0-8]\d{2}-\d{2}-\d{4}\b`)
+var ssnRe = regexp.MustCompile(`\b(\d{9}|\d{3}-\d{2}-\d{4}|\d{3} \d{2} \d{4})\b`)
 
 var ssnKeywordsRe = simpleregex.KeywordsRe([]string{
 	`\bssn\b`,
@@ -44,19 +45,19 @@ var ssnKeywordsRe = simpleregex.KeywordsRe([]string{
 })
 
 var commonExamples = map[string]struct{}{
-	"123-45-6789": {},
+	"123456789": {},
 
-	"111-11-1111": {},
-	"222-22-2222": {},
-	"333-33-3333": {},
-	"444-44-4444": {},
-	"555-55-5555": {},
-	"777-77-7777": {},
-	"888-88-8888": {},
-	"999-99-9999": {},
+	"111111111": {},
+	"222222222": {},
+	"333333333": {},
+	"444444444": {},
+	"555555555": {},
+	"777777777": {},
+	"888888888": {},
+	"999999999": {},
 
 	// https://www.ssa.gov/history/ssn/misused.html
-	"078-05-1120": {},
+	"078051120": {},
 }
 
 // NewDetector returns a Detector, that finds US Social Security Numbers (SSNs)
@@ -92,15 +93,18 @@ func NewDetector() veles.Detector {
 }
 
 func validSSN(s string) bool {
-	if _, ok := commonExamples[s]; ok {
+	normalized := strings.NewReplacer("-", "", " ", "").Replace(s)
+
+	if _, ok := commonExamples[normalized]; ok {
 		return false
 	}
 
-	area := s[0:3]
-	group := s[4:6]
-	serial := s[7:11]
+	area := normalized[0:3]
+	group := normalized[3:5]
+	serial := normalized[5:9]
 
-	return area != "000" &&
+	return area[0] != '9' &&
+		area != "000" &&
 		area != "666" &&
 		group != "00" &&
 		serial != "0000"

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -15,6 +15,7 @@
 package ssn
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -24,6 +25,11 @@ import (
 )
 
 func TestDetect_truePositives(t *testing.T) {
+	e, err := veles.NewDetectionEngine([]veles.Detector{NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cases := []struct {
 		name    string
 		in      []byte
@@ -75,7 +81,7 @@ func TestDetect_truePositives(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, gotPos := NewDetector().Detect(tc.in)
+			got, gotPos := e.Detect(t.Context(), strings.NewReader(string(tc.in)))
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Detect() diff (-want +got):\n%s", diff)
 			}
@@ -87,6 +93,11 @@ func TestDetect_truePositives(t *testing.T) {
 }
 
 func TestDetect_trueNegatives(t *testing.T) {
+	e, err := veles.NewDetectionEngine([]veles.Detector{NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cases := []struct {
 		name string
 		in   []byte
@@ -128,7 +139,7 @@ func TestDetect_trueNegatives(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, gotPos := NewDetector().Detect(tc.in)
+			got, gotPos := e.Detect(t.Context(), strings.NewReader(string(tc.in)))
 			if diff := cmp.Diff([]veles.Secret(nil), got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Detect() diff (-want +got):\n%s", diff)
 			}
@@ -140,6 +151,7 @@ func TestDetect_trueNegatives(t *testing.T) {
 }
 
 func TestDetectorMaxSecretLen(t *testing.T) {
+
 	if got, want := NewDetector().MaxSecretLen(), uint32(len("123-45-6789")); got != want {
 		t.Errorf("MaxSecretLen() = %d, want %d", got, want)
 	}

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -16,6 +16,7 @@ package ssn
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -106,6 +107,15 @@ func TestDetect_truePositives(t *testing.T) {
 		{
 			name: "multiple_matches",
 			in:   []byte("223-45-6789 001-01-0001"),
+			want: []veles.Secret{
+				ssnFinding([]byte("223-45-6789")),
+				ssnFinding([]byte("001-01-0001")),
+			},
+		},
+		// Useful to catch the lack of bytes.Clone()
+		{
+			name: "multiple_matches_long_gap",
+			in:   []byte("223-45-6789" + strings.Repeat(" ", 50000) + "001-01-0001"),
 			want: []veles.Secret{
 				ssnFinding([]byte("223-45-6789")),
 				ssnFinding([]byte("001-01-0001")),

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -53,7 +53,7 @@ func TestDetect_truePositives(t *testing.T) {
 			name: "starting_with_6",
 			in:   []byte("ssn: 680-12-3456"),
 			want: []veles.Secret{
-				ssnFinding([]byte("680-12-3456")),
+				ssnFinding([]byte("680-62-6456")),
 			},
 		},
 		{

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -180,7 +180,7 @@ func TestDetectorMaxSecretLen(t *testing.T) {
 func ssnFinding(raw []byte) sensitiveinformation.SensitiveInformation {
 	return sensitiveinformation.SensitiveInformation{
 		InfoType: sensitiveinformation.InfoType{
-			Name:        "Social Security Number",
+			Name:        "SOCIAL_SECURITY_NUMBER",
 			Sensitivity: sensitiveinformation.SensitivityLevelModerate,
 		},
 		Likelihood: sensitiveinformation.LikelihoodLikely,

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -31,10 +31,9 @@ func TestDetect_truePositives(t *testing.T) {
 	}
 
 	cases := []struct {
-		name    string
-		in      []byte
-		want    []veles.Secret
-		wantPos []int
+		name string
+		in   []byte
+		want []veles.Secret
 	}{
 		{
 			name: "match_only",
@@ -42,7 +41,6 @@ func TestDetect_truePositives(t *testing.T) {
 			want: []veles.Secret{
 				ssnFinding([]byte("123-45-6789")),
 			},
-			wantPos: []int{0},
 		},
 		{
 			name: "match_in_text",
@@ -50,7 +48,6 @@ func TestDetect_truePositives(t *testing.T) {
 			want: []veles.Secret{
 				ssnFinding([]byte("123-45-6789")),
 			},
-			wantPos: []int{5},
 		},
 		{
 			name: "starting_with_6",
@@ -58,7 +55,6 @@ func TestDetect_truePositives(t *testing.T) {
 			want: []veles.Secret{
 				ssnFinding([]byte("680-12-3456")),
 			},
-			wantPos: []int{5},
 		},
 		{
 			name: "double_9_in_the_middle",
@@ -66,7 +62,6 @@ func TestDetect_truePositives(t *testing.T) {
 			want: []veles.Secret{
 				ssnFinding([]byte("675-99-1234")),
 			},
-			wantPos: []int{5},
 		},
 		{
 			name: "multiple matches",
@@ -75,18 +70,17 @@ func TestDetect_truePositives(t *testing.T) {
 				ssnFinding([]byte("123-45-6789")),
 				ssnFinding([]byte("001-01-0001")),
 			},
-			wantPos: []int{0, 12},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, gotPos := e.Detect(t.Context(), bytes.NewBuffer(tc.in))
+			got, derr := e.Detect(t.Context(), bytes.NewBuffer(tc.in))
+			if derr != nil {
+				t.Fatal(derr)
+			}
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Detect() diff (-want +got):\n%s", diff)
-			}
-			if diff := cmp.Diff(tc.wantPos, gotPos, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("Detect() positions diff (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -139,12 +133,12 @@ func TestDetect_trueNegatives(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, gotPos := e.Detect(t.Context(), bytes.NewBuffer((tc.in)))
+			got, derr := e.Detect(t.Context(), bytes.NewBuffer(tc.in))
+			if derr != nil {
+				t.Fatal(derr)
+			}
 			if diff := cmp.Diff([]veles.Secret(nil), got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Detect() diff (-want +got):\n%s", diff)
-			}
-			if diff := cmp.Diff([]int(nil), gotPos, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("Detect() positions diff (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -145,7 +145,6 @@ func TestDetect_trueNegatives(t *testing.T) {
 }
 
 func TestDetectorMaxSecretLen(t *testing.T) {
-
 	if got, want := NewDetector().MaxSecretLen(), uint32(len("123-45-6789")); got != want {
 		t.Errorf("MaxSecretLen() = %d, want %d", got, want)
 	}

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -104,7 +104,7 @@ func TestDetect_truePositives(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple matches",
+			name: "multiple_matches",
 			in:   []byte("223-45-6789 001-01-0001"),
 			want: []veles.Secret{
 				ssnFinding([]byte("223-45-6789")),

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -129,6 +129,10 @@ func TestDetect_trueNegatives(t *testing.T) {
 			name: "area_starts_with_9h",
 			in:   []byte("912-34-5678"),
 		},
+		{
+			name: "within_longer_string",
+			in:   []byte("asdf123-45-6789asdf"),
+		},
 	}
 
 	for _, tc := range cases {

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -22,7 +22,19 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/osv-scalibr/veles"
 	"github.com/google/osv-scalibr/veles/sensitiveinformation"
+	"github.com/google/osv-scalibr/veles/velestest"
 )
+
+const testSsn = "321-12-1234"
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		NewDetector(),
+		testSsn,
+		ssnFinding([]byte("321-12-1234")),
+	)
+}
 
 func TestDetect_truePositives(t *testing.T) {
 	e, err := veles.NewDetectionEngine([]veles.Detector{NewDetector()})

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -37,21 +37,21 @@ func TestDetect_truePositives(t *testing.T) {
 	}{
 		{
 			name: "match_only",
-			in:   []byte("123-45-6789"),
+			in:   []byte("223-45-6789"),
 			want: []veles.Secret{
-				ssnFinding([]byte("123-45-6789")),
+				ssnFinding([]byte("223-45-6789")),
 			},
 		},
 		{
 			name: "match_in_text",
-			in:   []byte("ssn: 123-45-6789."),
+			in:   []byte("ssn: 133-45-6789."),
 			want: []veles.Secret{
-				ssnFinding([]byte("123-45-6789")),
+				ssnFinding([]byte("133-45-6789")),
 			},
 		},
 		{
 			name: "starting_with_6",
-			in:   []byte("ssn: 680-12-3456"),
+			in:   []byte("ssn: 680-62-6456"),
 			want: []veles.Secret{
 				ssnFinding([]byte("680-62-6456")),
 			},
@@ -65,9 +65,9 @@ func TestDetect_truePositives(t *testing.T) {
 		},
 		{
 			name: "multiple matches",
-			in:   []byte("123-45-6789 001-01-0001"),
+			in:   []byte("223-45-6789 001-01-0001"),
 			want: []veles.Secret{
-				ssnFinding([]byte("123-45-6789")),
+				ssnFinding([]byte("223-45-6789")),
 				ssnFinding([]byte("001-01-0001")),
 			},
 		},
@@ -124,14 +124,25 @@ func TestDetect_trueNegatives(t *testing.T) {
 			name: "serial_all_zeroes",
 			in:   []byte("123-45-0000"),
 		},
-
 		{
-			name: "area_starts_with_9h",
+			name: "area_starts_with_9",
 			in:   []byte("912-34-5678"),
 		},
 		{
 			name: "within_longer_string",
 			in:   []byte("asdf123-45-6789asdf"),
+		},
+		{
+			name: "placeholder_pattern_123",
+			in:   []byte("123-45-6789"),
+		},
+		{
+			name: "placeholder_pattern_111",
+			in:   []byte("111-11-1111"),
+		},
+		{
+			name: "placeholder_pattern_woolworth",
+			in:   []byte("078-05-1120"),
 		},
 	}
 

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -58,21 +58,49 @@ func TestDetect_truePositives(t *testing.T) {
 			name: "match_in_text",
 			in:   []byte("ssn: 133-45-6789."),
 			want: []veles.Secret{
-				ssnFinding([]byte("133-45-6789")),
+				ssnFindingWithLikelihood([]byte("133-45-6789"), sensitiveinformation.LikelihoodLikely),
 			},
 		},
 		{
 			name: "starting_with_6",
 			in:   []byte("ssn: 680-62-6456"),
 			want: []veles.Secret{
-				ssnFinding([]byte("680-62-6456")),
+				ssnFindingWithLikelihood([]byte("680-62-6456"), sensitiveinformation.LikelihoodLikely),
 			},
 		},
 		{
 			name: "double_9_in_the_middle",
 			in:   []byte("ssn: 675-99-1234."),
 			want: []veles.Secret{
-				ssnFinding([]byte("675-99-1234")),
+				ssnFindingWithLikelihood([]byte("675-99-1234"), sensitiveinformation.LikelihoodLikely),
+			},
+		},
+		{
+			name: "keyword_before",
+			in:   []byte("social security number: 431-12-1234"),
+			want: []veles.Secret{
+				ssnFindingWithLikelihood([]byte("431-12-1234"), sensitiveinformation.LikelihoodLikely),
+			},
+		},
+		{
+			name: "keyword_after",
+			in:   []byte("431-12-1234 social security"),
+			want: []veles.Secret{
+				ssnFindingWithLikelihood([]byte("431-12-1234"), sensitiveinformation.LikelihoodLikely),
+			},
+		},
+		{
+			name: "socialsecuritynumber_keyword",
+			in:   []byte("socialsecuritynumber: 431-12-1234"),
+			want: []veles.Secret{
+				ssnFindingWithLikelihood([]byte("431-12-1234"), sensitiveinformation.LikelihoodLikely),
+			},
+		},
+		{
+			name: "socialsecurity_keyword",
+			in:   []byte("socialsecurity: 431-12-1234"),
+			want: []veles.Secret{
+				ssnFindingWithLikelihood([]byte("431-12-1234"), sensitiveinformation.LikelihoodLikely),
 			},
 		},
 		{
@@ -172,18 +200,22 @@ func TestDetect_trueNegatives(t *testing.T) {
 }
 
 func TestDetectorMaxSecretLen(t *testing.T) {
-	if got, want := NewDetector().MaxSecretLen(), uint32(len("123-45-6789")); got != want {
+	if got, want := NewDetector().MaxSecretLen(), uint32(len("123-45-6789")+(2*contextWindowSize)); got != want {
 		t.Errorf("MaxSecretLen() = %d, want %d", got, want)
 	}
 }
 
 func ssnFinding(raw []byte) sensitiveinformation.SensitiveInformation {
+	return ssnFindingWithLikelihood(raw, sensitiveinformation.LikelihoodUnlikely)
+}
+
+func ssnFindingWithLikelihood(raw []byte, likelihood sensitiveinformation.Likelihood) sensitiveinformation.SensitiveInformation {
 	return sensitiveinformation.SensitiveInformation{
 		InfoType: sensitiveinformation.InfoType{
 			Name:        "SOCIAL_SECURITY_NUMBER",
 			Sensitivity: sensitiveinformation.SensitivityLevelHigh,
 		},
-		Likelihood: sensitiveinformation.LikelihoodLikely,
+		Likelihood: likelihood,
 		Raw:        raw,
 	}
 }

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssn
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/sensitiveinformation"
+)
+
+func TestDetect_truePositives(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []byte
+		want    []veles.Secret
+		wantPos []int
+	}{
+		{
+			name: "match only",
+			in:   []byte("123-45-6789"),
+			want: []veles.Secret{
+				ssnFinding([]byte("123-45-6789")),
+			},
+			wantPos: []int{0},
+		},
+		{
+			name: "match in text",
+			in:   []byte("ssn: 123-45-6789."),
+			want: []veles.Secret{
+				ssnFinding([]byte("123-45-6789")),
+			},
+			wantPos: []int{5},
+		},
+		{
+			name: "multiple matches",
+			in:   []byte("123-45-6789 001-01-0001"),
+			want: []veles.Secret{
+				ssnFinding([]byte("123-45-6789")),
+				ssnFinding([]byte("001-01-0001")),
+			},
+			wantPos: []int{0, 12},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotPos := NewDetector().Detect(tc.in)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantPos, gotPos, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() positions diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDetect_trueNegatives(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+	}{
+		{
+			name: "no match",
+			in:   []byte("not an ssn"),
+		},
+		{
+			name: "missing dashes",
+			in:   []byte("123456789"),
+		},
+		{
+			name: "area starts with 666",
+			in:   []byte("666-45-6789"),
+		},
+		{
+			name: "area starts with 000",
+			in:   []byte("000-45-6789"),
+		},
+		{
+			name: "area between 900 and 999",
+			in:   []byte("900-45-6789"),
+		},
+		{
+			name: "group all zeroes",
+			in:   []byte("123-00-6789"),
+		},
+		{
+			name: "serial all zeroes",
+			in:   []byte("123-45-0000"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotPos := NewDetector().Detect(tc.in)
+			if diff := cmp.Diff([]veles.Secret(nil), got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff([]int(nil), gotPos, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() positions diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDetectorMaxSecretLen(t *testing.T) {
+	if got, want := NewDetector().MaxSecretLen(), uint32(len("123-45-6789")); got != want {
+		t.Errorf("MaxSecretLen() = %d, want %d", got, want)
+	}
+}
+
+func ssnFinding(raw []byte) sensitiveinformation.SensitiveInformation {
+	return sensitiveinformation.SensitiveInformation{
+		InfoType: sensitiveinformation.InfoType{
+			Name:        "Social Security Number",
+			Sensitivity: sensitiveinformation.SensitivityLevelModerate,
+		},
+		Likelihood: sensitiveinformation.LikelihoodLikely,
+		Raw:        raw,
+	}
+}

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -184,6 +184,10 @@ func TestDetect_trueNegatives(t *testing.T) {
 			in:   []byte("123 45-6789"),
 		},
 		{
+			name: "too_long",
+			in:   []byte("2234567890"),
+		},
+		{
 			name: "area_starts_with_666",
 			in:   []byte("666-45-6789"),
 		},

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -31,7 +31,7 @@ func TestDetect_truePositives(t *testing.T) {
 		wantPos []int
 	}{
 		{
-			name: "match only",
+			name: "match_only",
 			in:   []byte("123-45-6789"),
 			want: []veles.Secret{
 				ssnFinding([]byte("123-45-6789")),
@@ -39,7 +39,7 @@ func TestDetect_truePositives(t *testing.T) {
 			wantPos: []int{0},
 		},
 		{
-			name: "match in text",
+			name: "match_in_text",
 			in:   []byte("ssn: 123-45-6789."),
 			want: []veles.Secret{
 				ssnFinding([]byte("123-45-6789")),
@@ -76,31 +76,31 @@ func TestDetect_trueNegatives(t *testing.T) {
 		in   []byte
 	}{
 		{
-			name: "no match",
+			name: "no_match",
 			in:   []byte("not an ssn"),
 		},
 		{
-			name: "missing dashes",
+			name: "missing_dashes",
 			in:   []byte("123456789"),
 		},
 		{
-			name: "area starts with 666",
+			name: "area_starts_with_666",
 			in:   []byte("666-45-6789"),
 		},
 		{
-			name: "area starts with 000",
+			name: "area_starts_with_000",
 			in:   []byte("000-45-6789"),
 		},
 		{
-			name: "area between 900 and 999",
+			name: "area_between_900_and_999",
 			in:   []byte("900-45-6789"),
 		},
 		{
-			name: "group all zeroes",
+			name: "group_all_zeroes",
 			in:   []byte("123-00-6789"),
 		},
 		{
-			name: "serial all zeroes",
+			name: "serial_all_zeroes",
 			in:   []byte("123-45-0000"),
 		},
 	}

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -47,6 +47,22 @@ func TestDetect_truePositives(t *testing.T) {
 			wantPos: []int{5},
 		},
 		{
+			name: "starting_with_6",
+			in:   []byte("ssn: 680-12-3456"),
+			want: []veles.Secret{
+				ssnFinding([]byte("680-12-3456")),
+			},
+			wantPos: []int{5},
+		},
+		{
+			name: "double_9_in_the_middle",
+			in:   []byte("ssn: 675-99-1234."),
+			want: []veles.Secret{
+				ssnFinding([]byte("675-99-1234")),
+			},
+			wantPos: []int{5},
+		},
+		{
 			name: "multiple matches",
 			in:   []byte("123-45-6789 001-01-0001"),
 			want: []veles.Secret{
@@ -102,6 +118,11 @@ func TestDetect_trueNegatives(t *testing.T) {
 		{
 			name: "serial_all_zeroes",
 			in:   []byte("123-45-0000"),
+		},
+
+		{
+			name: "area_starts_with_9h",
+			in:   []byte("912-34-5678"),
 		},
 	}
 

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -56,10 +56,38 @@ func TestDetect_truePositives(t *testing.T) {
 			},
 		},
 		{
+			name: "match_unformatted",
+			in:   []byte("223456789"),
+			want: []veles.Secret{
+				ssnFinding([]byte("223456789")),
+			},
+		},
+		{
+			name: "match_spaced",
+			in:   []byte("223 45 6789"),
+			want: []veles.Secret{
+				ssnFinding([]byte("223 45 6789")),
+			},
+		},
+		{
 			name: "match_in_text",
 			in:   []byte("ssn: 133-45-6789."),
 			want: []veles.Secret{
 				ssnFindingWithLikelihood([]byte("133-45-6789"), sensitiveinformation.LikelihoodLikely),
+			},
+		},
+		{
+			name: "unformatted_with_keyword",
+			in:   []byte("ssn: 133456789"),
+			want: []veles.Secret{
+				ssnFindingWithLikelihood([]byte("133456789"), sensitiveinformation.LikelihoodLikely),
+			},
+		},
+		{
+			name: "spaced_with_keyword",
+			in:   []byte("ssn: 133 45 6789"),
+			want: []veles.Secret{
+				ssnFindingWithLikelihood([]byte("133 45 6789"), sensitiveinformation.LikelihoodLikely),
 			},
 		},
 		{
@@ -106,10 +134,11 @@ func TestDetect_truePositives(t *testing.T) {
 		},
 		{
 			name: "multiple_matches",
-			in:   []byte("223-45-6789 001-01-0001"),
+			in:   []byte("223-45-6789 001010001 331 12 4321"),
 			want: []veles.Secret{
 				ssnFinding([]byte("223-45-6789")),
-				ssnFinding([]byte("001-01-0001")),
+				ssnFinding([]byte("001010001")),
+				ssnFinding([]byte("331 12 4321")),
 			},
 		},
 		// Useful to catch the lack of bytes.Clone()
@@ -152,27 +181,67 @@ func TestDetect_trueNegatives(t *testing.T) {
 		},
 		{
 			name: "missing_dashes",
-			in:   []byte("123456789"),
+			in:   []byte("123 45-6789"),
 		},
 		{
 			name: "area_starts_with_666",
 			in:   []byte("666-45-6789"),
 		},
 		{
+			name: "unformatted_area_starts_with_666",
+			in:   []byte("666456789"),
+		},
+		{
+			name: "spaced_area_starts_with_666",
+			in:   []byte("666 45 6789"),
+		},
+		{
 			name: "area_starts_with_000",
 			in:   []byte("000-45-6789"),
+		},
+		{
+			name: "unformatted_area_starts_with_000",
+			in:   []byte("000456789"),
+		},
+		{
+			name: "spaced_area_starts_with_000",
+			in:   []byte("000 45 6789"),
 		},
 		{
 			name: "area_between_900_and_999",
 			in:   []byte("900-45-6789"),
 		},
 		{
+			name: "unformatted_area_between_900_and_999",
+			in:   []byte("900456789"),
+		},
+		{
+			name: "spaced_area_between_900_and_999",
+			in:   []byte("900 45 6789"),
+		},
+		{
 			name: "group_all_zeroes",
 			in:   []byte("123-00-6789"),
 		},
 		{
+			name: "unformatted_group_all_zeroes",
+			in:   []byte("123006789"),
+		},
+		{
+			name: "spaced_group_all_zeroes",
+			in:   []byte("123 00 6789"),
+		},
+		{
 			name: "serial_all_zeroes",
 			in:   []byte("123-45-0000"),
+		},
+		{
+			name: "unformatted_serial_all_zeroes",
+			in:   []byte("123450000"),
+		},
+		{
+			name: "spaced_serial_all_zeroes",
+			in:   []byte("123 45 0000"),
 		},
 		{
 			name: "area_starts_with_9",
@@ -187,12 +256,36 @@ func TestDetect_trueNegatives(t *testing.T) {
 			in:   []byte("123-45-6789"),
 		},
 		{
+			name: "unformatted_placeholder_pattern_123",
+			in:   []byte("123456789"),
+		},
+		{
+			name: "spaced_placeholder_pattern_123",
+			in:   []byte("123 45 6789"),
+		},
+		{
 			name: "placeholder_pattern_111",
 			in:   []byte("111-11-1111"),
 		},
 		{
+			name: "unformatted_placeholder_pattern_111",
+			in:   []byte("111111111"),
+		},
+		{
+			name: "spaced_placeholder_pattern_111",
+			in:   []byte("111 11 1111"),
+		},
+		{
 			name: "placeholder_pattern_woolworth",
 			in:   []byte("078-05-1120"),
+		},
+		{
+			name: "unformatted_placeholder_pattern_woolworth",
+			in:   []byte("078051120"),
+		},
+		{
+			name: "spaced_placeholder_pattern_woolworth",
+			in:   []byte("078 05 1120"),
 		},
 	}
 

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -15,7 +15,7 @@
 package ssn
 
 import (
-	"strings"
+	"bytes"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -81,7 +81,7 @@ func TestDetect_truePositives(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, gotPos := e.Detect(t.Context(), strings.NewReader(string(tc.in)))
+			got, gotPos := e.Detect(t.Context(), bytes.NewBuffer(tc.in))
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Detect() diff (-want +got):\n%s", diff)
 			}
@@ -139,7 +139,7 @@ func TestDetect_trueNegatives(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, gotPos := e.Detect(t.Context(), strings.NewReader(string(tc.in)))
+			got, gotPos := e.Detect(t.Context(), bytes.NewBuffer((tc.in)))
 			if diff := cmp.Diff([]veles.Secret(nil), got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Detect() diff (-want +got):\n%s", diff)
 			}

--- a/veles/sensitiveinformation/ssn/detector_test.go
+++ b/veles/sensitiveinformation/ssn/detector_test.go
@@ -181,7 +181,7 @@ func ssnFinding(raw []byte) sensitiveinformation.SensitiveInformation {
 	return sensitiveinformation.SensitiveInformation{
 		InfoType: sensitiveinformation.InfoType{
 			Name:        "SOCIAL_SECURITY_NUMBER",
-			Sensitivity: sensitiveinformation.SensitivityLevelModerate,
+			Sensitivity: sensitiveinformation.SensitivityLevelHigh,
 		},
 		Likelihood: sensitiveinformation.LikelihoodLikely,
 		Raw:        raw,

--- a/veles/sensitiveinformation/ssn/modelssn.go
+++ b/veles/sensitiveinformation/ssn/modelssn.go
@@ -1,0 +1,8 @@
+package ssn
+
+import "github.com/google/osv-scalibr/veles/sensitiveinformation"
+
+type ModelSocialSecurityNumber struct {
+	sensitiveinformation.SensitiveInformation
+	Number string
+}

--- a/veles/sensitiveinformation/ssn/modelssn.go
+++ b/veles/sensitiveinformation/ssn/modelssn.go
@@ -1,8 +1,0 @@
-package ssn
-
-import "github.com/google/osv-scalibr/veles/sensitiveinformation"
-
-type ModelSocialSecurityNumber struct {
-	sensitiveinformation.SensitiveInformation
-	Number string
-}


### PR DESCRIPTION
This PR introduces a first detector for sensitive information. It uses the `sensitiveInformation/common/simpleregex` to detect Social Security Numbers.

As it is a first entry using the sensitive information simple regex, I had to introduce some changes and patterns. I'll highlight them below in code comments.