### PR TITLE
Add Helm, Pulumi, Datadog, and Linear inventory plugins

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -80,6 +80,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | go.mod (OSV)                                      | `go/gomod`                           |
 | Haskell    | stack.yaml.lock                                   | `haskell/stacklock`                  |
 |            | cabal.project.freeze                              | `haskell/cabal`                      |
+| Helm       | Chart.lock (Helm v3 lockfile)                    | `helm/chartlock`                     |
 | Java       | Java archives                                     | `java/archive`                       |
 |            | pom.xml                                           | `java/pomxml`                        |
 |            | gradle.lockfile                                   | `java/gradlelockfile`                |
@@ -98,6 +99,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Lua        | Luarocks modules                                  | `lua/luarocks`                       |
 | ObjectiveC | Podfile.lock                                      | `swift/podfilelock`                  |
 | PHP        | Composer                                          | `php/composerlock`                   |
+| Pulumi     | Pulumi.yaml (Pulumi plugin dependencies)         | `pulumi/pulumiyaml`                  |
 | Python     | Installed PyPI packages (global and venv)         | `python/wheelegg`                    |
 |            | requirements.txt                                  | `python/requirements`                |
 |            | poetry.lock                                       | `python/poetrylock`                  |
@@ -143,6 +145,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Cloudflare API Token                        | `secrets/cloudflareapitoken`           |
 | Crates.io API Token                         | `secrets/cratesioapitoken`             |
 | Cursor API key                              | `secrets/cursorapikey`                 |
+| Datadog API key                             | `secrets/datadogapikey`                |
 | DigitalOcean API key                        | `secrets/digitaloceanapikey`           |
 | Docker hub PAT                              | `secrets/dockerhubpat`                 |
 | Elastic Cloud API key                       | `secrets/elasticcloudapikey`           |
@@ -162,6 +165,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Hashicorp Vault token                       | `secrets/hashicorpvaulttoken`          |
 | Hashicorp Vault AppRole token               | `secrets/hashicorpvaultapprole`        |
 | Hugging Face API key                        | `secrets/huggingfaceapikey`            |
+| Linear API key                              | `secrets/linearapikey`                 |
 | MariaDB Credentials                         | `secrets/mariadb`                      |
 | Mysql Mylogin                               | `secrets/mysqlmylogin`                 |
 | npmjs Registry Access Tokens                | `secrets/npmjsaccesstoken`             |

--- a/extractor/filesystem/language/helm/chartlock/chartlock.go
+++ b/extractor/filesystem/language/helm/chartlock/chartlock.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chartlock extracts Helm Chart.lock files.
+package chartlock
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/log"
+	"github.com/google/osv-scalibr/plugin"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "helm/chartlock"
+)
+
+// Extractor extracts Helm chart dependencies from Chart.lock files.
+type Extractor struct {
+	maxFileSizeBytes int64
+}
+
+// New returns a new Chart.lock extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	return &Extractor{maxFileSizeBytes: cfg.GetMaxFileSizeBytes()}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file matches Chart.lock pattern.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+
+	if filepath.Base(path) != "Chart.lock" {
+		return false
+	}
+
+	fileinfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
+		return false
+	}
+	return true
+}
+
+// Extract extracts packages from Chart.lock files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := parseChartLock(input.Path, input.Reader)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("error parsing Chart.lock: %w", err)
+	}
+	return inventory.Inventory{Packages: pkgs}, nil
+}
+
+// chartDependency represents a single dependency entry in Chart.lock.
+type chartDependency struct {
+	name       string
+	version    string
+	repository string
+	line       int
+}
+
+func parseChartLock(path string, r io.Reader) ([]*extractor.Package, error) {
+	content, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Chart.lock: %w", err)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		log.Debugf("Chart.lock %s yaml unmarshal failed: %v", path, err)
+		return nil, nil // Gracefully skip malformed YAML
+	}
+
+	deps := parseDependencies(&root)
+
+	var pkgs []*extractor.Package
+	for _, d := range deps {
+		if d.name == "" || d.version == "" {
+			log.Debugf("skipping dependency block at line %d: missing name or version", d.line)
+			continue
+		}
+
+		pkg := &extractor.Package{
+			Name:     d.name,
+			Version:  d.version,
+			Location: extractor.LocationFromPathAndLine(path, d.line),
+			PURLType: "", // No official Helm PURL type exists in the PURL spec.
+		}
+		pkgs = append(pkgs, pkg)
+	}
+
+	return pkgs, nil
+}
+
+func parseDependencies(root *yaml.Node) []chartDependency {
+	var deps []chartDependency
+
+	if len(root.Content) == 0 {
+		return deps
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return deps
+	}
+
+	var depsNode *yaml.Node
+	for i := 0; i < len(doc.Content); i += 2 {
+		if doc.Content[i].Value == "dependencies" {
+			depsNode = doc.Content[i+1]
+			break
+		}
+	}
+
+	if depsNode == nil || depsNode.Kind != yaml.SequenceNode {
+		return deps
+	}
+
+	for _, depNode := range depsNode.Content {
+		if depNode.Kind != yaml.MappingNode {
+			continue
+		}
+		dep := chartDependency{line: depNode.Line}
+		for i := 0; i < len(depNode.Content); i += 2 {
+			key := depNode.Content[i].Value
+			val := depNode.Content[i+1].Value
+			switch key {
+			case "name":
+				dep.name = val
+			case "version":
+				dep.version = val
+			case "repository":
+				dep.repository = val
+			}
+		}
+		deps = append(deps, dep)
+	}
+
+	return deps
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/helm/chartlock/chartlock_test.go
+++ b/extractor/filesystem/language/helm/chartlock/chartlock_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chartlock_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/helm/chartlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+	}{
+		{
+			name:         "Chart.lock at root",
+			path:         "Chart.lock",
+			wantRequired: true,
+		},
+		{
+			name:         "Chart.lock in subdir",
+			path:         "path/to/Chart.lock",
+			wantRequired: true,
+		},
+		{
+			name:         "not Chart.lock",
+			path:         "Chart.yaml",
+			wantRequired: false,
+		},
+		{
+			name:         "similar name but not exact",
+			path:         "chart.lock",
+			wantRequired: false,
+		},
+		{
+			name:         "another similar name",
+			path:         "Chart.lock.backup",
+			wantRequired: false,
+		},
+		{
+			name:             "Chart.lock required if size less than maxFileSizeBytes",
+			path:             "Chart.lock",
+			fileSizeBytes:    1000 * units.MiB,
+			maxFileSizeBytes: 2000 * units.MiB,
+			wantRequired:     true,
+		},
+		{
+			name:             "Chart.lock required if size equal to maxFileSizeBytes",
+			path:             "Chart.lock",
+			fileSizeBytes:    1000 * units.MiB,
+			maxFileSizeBytes: 1000 * units.MiB,
+			wantRequired:     true,
+		},
+		{
+			name:             "Chart.lock not required if size greater than maxFileSizeBytes",
+			path:             "Chart.lock",
+			fileSizeBytes:    10000 * units.MiB,
+			maxFileSizeBytes: 1000 * units.MiB,
+			wantRequired:     false,
+		},
+		{
+			name:             "Chart.lock required if maxFileSizeBytes explicitly set to 0",
+			path:             "Chart.lock",
+			fileSizeBytes:    1000 * units.MiB,
+			maxFileSizeBytes: 0,
+			wantRequired:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := chartlock.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("chartlock.New: %v", err)
+			}
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1 * units.KiB
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []*extracttest.TestTableEntry{
+		{
+			Name: "valid file with multiple dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/valid.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "mysql",
+					Version:  "1.6.9",
+					Location: extractor.LocationFromPathAndLine("testdata/valid.yaml", 4),
+					PURLType: "",
+				},
+				{
+					Name:     "postgresql",
+					Version:  "11.9.13",
+					Location: extractor.LocationFromPathAndLine("testdata/valid.yaml", 7),
+					PURLType: "",
+				},
+			},
+		},
+		{
+			Name: "single dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/single-dep.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "nginx",
+					Version:  "15.0.0",
+					Location: extractor.LocationFromPathAndLine("testdata/single-dep.yaml", 4),
+					PURLType: "",
+				},
+			},
+		},
+		{
+			Name: "no version should skip dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no-version.yaml",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.yaml",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "malformed file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/malformed.yaml",
+			},
+			WantPackages: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			e, err := chartlock.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("chartlock.New: %v", err)
+			}
+			got, err := e.Extract(t.Context(), &scanInput)
+			if !cmp.Equal(err, tt.WantErr, cmpopts.EquateErrors()) {
+				t.Fatalf("Extract(%+v) error: got %v, want %v\n", tt.Name, err, tt.WantErr)
+			}
+
+			var want inventory.Inventory
+			if tt.WantPackages != nil {
+				want = inventory.Inventory{Packages: tt.WantPackages}
+			}
+
+			if diff := cmp.Diff(want, got, cmpopts.SortSlices(extracttest.PackageCmpLess), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Extract(%s) (-want +got):\n%s", tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/helm/chartlock/testdata/malformed.yaml
+++ b/extractor/filesystem/language/helm/chartlock/testdata/malformed.yaml
@@ -1,0 +1,1 @@
+this is not valid yaml at all: [}}}

--- a/extractor/filesystem/language/helm/chartlock/testdata/no-version.yaml
+++ b/extractor/filesystem/language/helm/chartlock/testdata/no-version.yaml
@@ -1,0 +1,5 @@
+generated: "2020-03-20T09:50:45.516093Z"
+digest: sha256:6b893c7655bcba03125b06fe33b68293db37e93e4a0b41c3959bb8558f506d9d
+dependencies:
+  - name: nginx
+    repository: https://charts.bitnami.com/bitnami

--- a/extractor/filesystem/language/helm/chartlock/testdata/single-dep.yaml
+++ b/extractor/filesystem/language/helm/chartlock/testdata/single-dep.yaml
@@ -1,0 +1,6 @@
+generated: "2020-03-20T09:50:45.516093Z"
+digest: sha256:6b893c7655bcba03125b06fe33b68293db37e93e4a0b41c3959bb8558f506d9d
+dependencies:
+  - name: nginx
+    repository: https://charts.bitnami.com/bitnami
+    version: 15.0.0

--- a/extractor/filesystem/language/helm/chartlock/testdata/valid.yaml
+++ b/extractor/filesystem/language/helm/chartlock/testdata/valid.yaml
@@ -1,0 +1,9 @@
+generated: "2020-03-20T09:50:45.516093Z"
+digest: sha256:6b893c7655bcba03125b06fe33b68293db37e93e4a0b41c3959bb8558f506d9d
+dependencies:
+  - name: mysql
+    repository: https://charts.helm.sh/stable
+    version: 1.6.9
+  - name: postgresql
+    repository: https://charts.helm.sh/stable
+    version: 11.9.13

--- a/extractor/filesystem/language/pulumi/pulumiyaml/pulumiyaml.go
+++ b/extractor/filesystem/language/pulumi/pulumiyaml/pulumiyaml.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pulumiyaml extracts Pulumi Pulumi.yaml files.
+package pulumiyaml
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/log"
+	"github.com/google/osv-scalibr/plugin"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "pulumi/pulumiyaml"
+)
+
+// Extractor extracts Pulumi provider plugins from Pulumi.yaml files.
+type Extractor struct {
+	maxFileSizeBytes int64
+}
+
+// New returns a new Pulumi.yaml extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	return &Extractor{maxFileSizeBytes: cfg.GetMaxFileSizeBytes()}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file matches Pulumi.yaml pattern.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	base := filepath.Base(path)
+
+	if base != "Pulumi.yaml" && base != "Pulumi.yml" {
+		return false
+	}
+
+	fileinfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
+		return false
+	}
+	return true
+}
+
+// Extract extracts packages from Pulumi.yaml files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := parsePulumiYAML(input.Path, input.Reader)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("error parsing Pulumi.yaml: %w", err)
+	}
+	return inventory.Inventory{Packages: pkgs}, nil
+}
+
+// pulumiPlugin represents a single plugin entry.
+type pulumiPlugin struct {
+	name    string
+	version string
+	line    int
+}
+
+func parsePulumiYAML(path string, r io.Reader) ([]*extractor.Package, error) {
+	content, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Pulumi.yaml: %w", err)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		log.Debugf("Pulumi.yaml %s yaml unmarshal failed: %v", path, err)
+		return nil, nil // Gracefully skip malformed YAML
+	}
+
+	plugins := parsePlugins(&root)
+
+	var pkgs []*extractor.Package
+	for _, p := range plugins {
+		if p.name == "" || p.version == "" {
+			log.Debugf("skipping plugin block at line %d: missing name or version", p.line)
+			continue
+		}
+
+		pkg := &extractor.Package{
+			Name:     p.name,
+			Version:  p.version,
+			Location: extractor.LocationFromPathAndLine(path, p.line),
+			PURLType: "", // No official Pulumi PURL type exists in the PURL spec.
+		}
+		pkgs = append(pkgs, pkg)
+	}
+
+	return pkgs, nil
+}
+
+func parsePlugins(root *yaml.Node) []pulumiPlugin {
+	var plugins []pulumiPlugin
+
+	if len(root.Content) == 0 {
+		return plugins
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return plugins
+	}
+
+	var pluginsNode *yaml.Node
+	for i := 0; i < len(doc.Content); i += 2 {
+		if doc.Content[i].Value == "plugins" {
+			pluginsNode = doc.Content[i+1]
+			break
+		}
+	}
+
+	if pluginsNode == nil || pluginsNode.Kind != yaml.MappingNode {
+		return plugins
+	}
+
+	// Walk children of plugins: providers, analyzers, etc.
+	for i := 0; i < len(pluginsNode.Content); i += 2 {
+		pluginTypeNode := pluginsNode.Content[i+1]
+		if pluginTypeNode.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, entryNode := range pluginTypeNode.Content {
+			if entryNode.Kind != yaml.MappingNode {
+				continue
+			}
+			plugin := pulumiPlugin{line: entryNode.Line}
+			for j := 0; j < len(entryNode.Content); j += 2 {
+				key := entryNode.Content[j].Value
+				val := entryNode.Content[j+1].Value
+				switch strings.ToLower(key) {
+				case "name":
+					plugin.name = val
+				case "version":
+					plugin.version = val
+				}
+			}
+			plugins = append(plugins, plugin)
+		}
+	}
+
+	return plugins
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/pulumi/pulumiyaml/pulumiyaml_test.go
+++ b/extractor/filesystem/language/pulumi/pulumiyaml/pulumiyaml_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumiyaml_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/pulumi/pulumiyaml"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+	}{
+		{
+			name:         "Pulumi.yaml at root",
+			path:         "Pulumi.yaml",
+			wantRequired: true,
+		},
+		{
+			name:         "Pulumi.yml in subdir",
+			path:         "path/to/Pulumi.yml",
+			wantRequired: true,
+		},
+		{
+			name:         "not Pulumi.yaml",
+			path:         "main.go",
+			wantRequired: false,
+		},
+		{
+			name:         "similar name but not exact",
+			path:         "pulumi.yaml",
+			wantRequired: false,
+		},
+		{
+			name:         "another similar name",
+			path:         "Pulumi.yaml.backup",
+			wantRequired: false,
+		},
+		{
+			name:             "Pulumi.yaml required if size less than maxFileSizeBytes",
+			path:             "Pulumi.yaml",
+			fileSizeBytes:    1000 * units.MiB,
+			maxFileSizeBytes: 2000 * units.MiB,
+			wantRequired:     true,
+		},
+		{
+			name:             "Pulumi.yaml required if size equal to maxFileSizeBytes",
+			path:             "Pulumi.yaml",
+			fileSizeBytes:    1000 * units.MiB,
+			maxFileSizeBytes: 1000 * units.MiB,
+			wantRequired:     true,
+		},
+		{
+			name:             "Pulumi.yaml not required if size greater than maxFileSizeBytes",
+			path:             "Pulumi.yaml",
+			fileSizeBytes:    10000 * units.MiB,
+			maxFileSizeBytes: 1000 * units.MiB,
+			wantRequired:     false,
+		},
+		{
+			name:             "Pulumi.yaml required if maxFileSizeBytes explicitly set to 0",
+			path:             "Pulumi.yaml",
+			fileSizeBytes:    1000 * units.MiB,
+			maxFileSizeBytes: 0,
+			wantRequired:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := pulumiyaml.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("pulumiyaml.New: %v", err)
+			}
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1 * units.KiB
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []*extracttest.TestTableEntry{
+		{
+			Name: "valid file with multiple providers",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/valid.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "aws",
+					Version:  "6.0.0",
+					Location: extractor.LocationFromPathAndLine("testdata/valid.yaml", 6),
+					PURLType: "",
+				},
+				{
+					Name:     "kubernetes",
+					Version:  "4.0.0",
+					Location: extractor.LocationFromPathAndLine("testdata/valid.yaml", 8),
+					PURLType: "",
+				},
+			},
+		},
+		{
+			Name: "single provider",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/single-provider.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "gcp",
+					Version:  "7.0.0",
+					Location: extractor.LocationFromPathAndLine("testdata/single-provider.yaml", 6),
+					PURLType: "",
+				},
+			},
+		},
+		{
+			Name: "no version should skip provider",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no-version.yaml",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.yaml",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "malformed file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/malformed.yaml",
+			},
+			WantPackages: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			e, err := pulumiyaml.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("pulumiyaml.New: %v", err)
+			}
+			got, err := e.Extract(t.Context(), &scanInput)
+			if !cmp.Equal(err, tt.WantErr, cmpopts.EquateErrors()) {
+				t.Fatalf("Extract(%+v) error: got %v, want %v\n", tt.Name, err, tt.WantErr)
+			}
+
+			var want inventory.Inventory
+			if tt.WantPackages != nil {
+				want = inventory.Inventory{Packages: tt.WantPackages}
+			}
+
+			if diff := cmp.Diff(want, got, cmpopts.SortSlices(extracttest.PackageCmpLess), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Extract(%s) (-want +got):\n%s", tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/pulumi/pulumiyaml/testdata/malformed.yaml
+++ b/extractor/filesystem/language/pulumi/pulumiyaml/testdata/malformed.yaml
@@ -1,0 +1,1 @@
+this is not valid yaml at all: [}}}

--- a/extractor/filesystem/language/pulumi/pulumiyaml/testdata/no-version.yaml
+++ b/extractor/filesystem/language/pulumi/pulumiyaml/testdata/no-version.yaml
@@ -1,0 +1,6 @@
+name: no-version
+runtime: nodejs
+description: Missing version test
+plugins:
+  providers:
+    - name: azure

--- a/extractor/filesystem/language/pulumi/pulumiyaml/testdata/single-provider.yaml
+++ b/extractor/filesystem/language/pulumi/pulumiyaml/testdata/single-provider.yaml
@@ -1,0 +1,7 @@
+name: single-provider
+runtime: python
+description: Single provider test
+plugins:
+  providers:
+    - name: gcp
+      version: 7.0.0

--- a/extractor/filesystem/language/pulumi/pulumiyaml/testdata/valid.yaml
+++ b/extractor/filesystem/language/pulumi/pulumiyaml/testdata/valid.yaml
@@ -1,0 +1,9 @@
+name: my-project
+runtime: go
+description: A minimal Go Pulumi program
+plugins:
+  providers:
+    - name: aws
+      version: 6.0.0
+    - name: kubernetes
+      version: 4.0.0

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -49,6 +49,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/cabal"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/stacklock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/helm/chartlock"
 	javaarchive "github.com/google/osv-scalibr/extractor/filesystem/language/java/archive"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradlelockfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradleverificationmetadataxml"
@@ -69,6 +70,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ocaml/opam"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cpan"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/pulumi/pulumiyaml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condameta"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfilelock"
@@ -136,6 +138,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/circleci"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
+	"github.com/google/osv-scalibr/veles/secrets/datadogapikey"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
 	"github.com/google/osv-scalibr/veles/secrets/digitaloceanapikey"
 	"github.com/google/osv-scalibr/veles/secrets/discordbottoken"
@@ -156,6 +159,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/http"
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
 	"github.com/google/osv-scalibr/veles/secrets/jwt"
+	"github.com/google/osv-scalibr/veles/secrets/linearapikey"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
 	"github.com/google/osv-scalibr/veles/secrets/onepasswordkeys"
@@ -326,6 +330,14 @@ var (
 		packageresolved.Name: {packageresolved.New},
 		podfilelock.Name:     {podfilelock.New},
 	}
+	// PulumiSource extractors for Pulumi.
+	PulumiSource = InitMap{
+		pulumiyaml.Name: {pulumiyaml.New},
+	}
+	// HelmSource extractors for Helm.
+	HelmSource = InitMap{
+		chartlock.Name: {chartlock.New},
+	}
 
 	// Containers extractors.
 	Containers = InitMap{
@@ -380,6 +392,7 @@ var (
 		{circleci.NewPersonalAccessTokenDetector(), "secrets/circlecipat", 0},
 		{circleci.NewProjectTokenDetector(), "secrets/circleciproject", 0},
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
+		{datadogapikey.NewDetector(), "secrets/datadogapikey", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},
 		{cratesioapitoken.NewDetector(), "secrets/cratesioapitoken", 0},
@@ -454,6 +467,7 @@ var (
 		{http.NewBasicAuthDetector(), "secrets/httpbasicauth", 0},
 		{http.NewBearerDetector(), "secrets/httpbearer", 0},
 		{http.NewCSRFTokenDetector(), "secrets/csrftoken", 0},
+		{linearapikey.NewDetector(), "secrets/linearapikey", 0},
 	})
 
 	SensitiveInformationDetectors = initMapFromVelesPlugins([]velesPlugin{
@@ -523,6 +537,8 @@ var (
 		JuliaSource,
 		DotnetSource,
 		SwiftSource,
+		PulumiSource,
+		HelmSource,
 		NimSource,
 		OcamlSource,
 		LuaSource,
@@ -587,6 +603,8 @@ var (
 		"rust":       vals(concat(RustSource, RustArtifact)),
 		"julia":      vals(concat(JuliaSource, JuliaArtifact)),
 		"swift":      vals(SwiftSource),
+		"pulumi":     vals(PulumiSource),
+		"helm":       vals(HelmSource),
 		"perl":       vals(CPANSource),
 
 		"sbom":       vals(SBOM),

--- a/veles/secrets/datadogapikey/datadogapikey.go
+++ b/veles/secrets/datadogapikey/datadogapikey.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package datadogapikey contains a Veles Secret type and Detector for Datadog API keys.
+// Datadog API keys are 32-character hexadecimal strings. Because a raw 32-hex regex
+// would be catastrophically noisy (matches MD5, UUID segments, commit hashes), this
+// detector uses the keyword-gated pair.Detector pattern to require a Datadog-specific
+// keyword near the token.
+package datadogapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/pair"
+)
+
+const (
+	// maxTokenLength is the maximum length of a Datadog API key (32 hex chars).
+	maxTokenLength = 32
+
+	// maxDistance is the maximum distance between the keyword and the token value.
+	maxDistance = 20
+)
+
+var (
+	// keywordRe matches Datadog-related context keywords (case-insensitive),
+	// optionally surrounded by quotes, followed by a separator (= or :).
+	keywordRe = regexp.MustCompile(
+		`(?i)["']?\b(?:DATADOG_API_KEY|DD_API_KEY|DATADOG_API_TOKEN|DD_API_TOKEN|DATADOG_TOKEN|DD_TOKEN)\b["']?\s*[=:]`,
+	)
+
+	// tokenRe matches a 32-character hexadecimal string.
+	apiKeyRe = regexp.MustCompile(`\b[a-f0-9]{32}\b`)
+)
+
+var _ veles.Detector = NewDetector()
+
+// NewDetector returns a new Detector that matches Datadog API keys by finding a keyword-token pair.
+func NewDetector() veles.Detector {
+	return &pair.Detector{
+		MaxElementLen: maxTokenLength,
+		MaxDistance:   maxDistance,
+		FindA:         pair.FindAllMatches(keywordRe),
+		FindB:         pair.FindAllMatches(apiKeyRe),
+		FromPair: func(p pair.Pair) (veles.Secret, bool) {
+			return APIKey{Key: string(p.B.Value)}, true
+		},
+	}
+}
+
+// APIKey represents a Datadog API key.
+type APIKey struct {
+	Key string
+}

--- a/veles/secrets/datadogapikey/datadogapikey_test.go
+++ b/veles/secrets/datadogapikey/datadogapikey_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadogapikey_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/datadogapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+// Fake Datadog API keys for testing. These are NOT real keys.
+const testDatadogAPIKey = "a1b2c3d4e5f678901234567890123456"
+const testDatadogAPIKey2 = "1234567890abcdef1234567890abcdef"
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		datadogapikey.NewDetector(),
+		"DD_API_KEY="+testDatadogAPIKey,
+		datadogapikey.APIKey{Key: testDatadogAPIKey},
+	)
+}
+
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{
+		datadogapikey.NewDetector(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		{
+			name:  "DD_API_KEY environment variable",
+			input: "DD_API_KEY=" + testDatadogAPIKey,
+			want: []veles.Secret{
+				datadogapikey.APIKey{Key: testDatadogAPIKey},
+			},
+		},
+		{
+			name:  "DATADOG_API_KEY environment variable",
+			input: "DATADOG_API_KEY=" + testDatadogAPIKey2,
+			want: []veles.Secret{
+				datadogapikey.APIKey{Key: testDatadogAPIKey2},
+			},
+		},
+		{
+			name:  "quoted JSON key",
+			input: `{"datadog_api_key": "` + testDatadogAPIKey + `"}`,
+			want: []veles.Secret{
+				datadogapikey.APIKey{Key: testDatadogAPIKey},
+			},
+		},
+		{
+			name:  "YAML config key",
+			input: "DD_API_TOKEN: " + testDatadogAPIKey,
+			want: []veles.Secret{
+				datadogapikey.APIKey{Key: testDatadogAPIKey},
+			},
+		},
+		{
+			name:  "multiple matches",
+			input: "DD_API_KEY=" + testDatadogAPIKey + "\nDATADOG_API_KEY=" + testDatadogAPIKey2,
+			want: []veles.Secret{
+				datadogapikey.APIKey{Key: testDatadogAPIKey},
+				datadogapikey.APIKey{Key: testDatadogAPIKey2},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDetector_falsePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{
+		datadogapikey.NewDetector(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "32 hex without keyword",
+			input: testDatadogAPIKey,
+		},
+		{
+			name:  "wrong keyword",
+			input: "OTHER_API_KEY=" + testDatadogAPIKey,
+		},
+		{
+			name:  "too short hex",
+			input: "DD_API_KEY=1234567890abcdef",
+		},
+		{
+			name:  "non-hex characters",
+			input: "DD_API_KEY=gggggggggggggggggggggggggggggggg",
+		},
+		{
+			name:  "keyword with no value",
+			input: "DD_API_KEY=",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) > 0 {
+				t.Errorf("Detect() expected no secrets, got %v", got)
+			}
+		})
+	}
+}

--- a/veles/secrets/linearapikey/linearapikey.go
+++ b/veles/secrets/linearapikey/linearapikey.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package linearapikey contains a Veles Secret type and Detector for Linear API keys.
+// Linear API keys use the ultra-specific prefix "lin_api_" followed by 40 alphanumeric characters,
+// making this a very low false-positive detector.
+package linearapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+var (
+	// Ensure the constructor satisfies the interface at compile time.
+	_ veles.Detector = NewDetector()
+)
+
+// Linear API keys are exactly 48 characters: lin_api_ (8 chars) + 40 alphanumeric chars
+const maxKeyLen = 48
+
+var keyRe = regexp.MustCompile(`lin_api_[A-Za-z0-9]{40}\b`)
+
+// NewDetector returns a detector for Linear API keys (lin_api_xxxxxxxx...).
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: maxKeyLen,
+		Re:     keyRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return APIKey{Key: string(b)}, true
+		},
+	}
+}
+
+// APIKey represents a Linear API key.
+type APIKey struct {
+	Key string
+}

--- a/veles/secrets/linearapikey/linearapikey_test.go
+++ b/veles/secrets/linearapikey/linearapikey_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linearapikey_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/linearapikey"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+// Fake Linear API keys for testing. These are NOT real keys.
+const testLinearAPIKey = "lin_api_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const testLinearAPIKey2 = "lin_api_1234567890abcdefghijklmnopqrstuvwxyz1234"
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		linearapikey.NewDetector(),
+		testLinearAPIKey,
+		linearapikey.APIKey{Key: testLinearAPIKey},
+	)
+}
+
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{
+		linearapikey.NewDetector(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{
+		{
+			name:  "simple matching string",
+			input: testLinearAPIKey,
+			want: []veles.Secret{
+				linearapikey.APIKey{Key: testLinearAPIKey},
+			},
+		},
+		{
+			name:  "key in env var",
+			input: "LINEAR_API_KEY=" + testLinearAPIKey,
+			want: []veles.Secret{
+				linearapikey.APIKey{Key: testLinearAPIKey},
+			},
+		},
+		{
+			name:  "key in JSON",
+			input: `{"linear_api_key": "` + testLinearAPIKey + `"}`,
+			want: []veles.Secret{
+				linearapikey.APIKey{Key: testLinearAPIKey},
+			},
+		},
+		{
+			name:  "multiple matches",
+			input: testLinearAPIKey + "\n" + testLinearAPIKey2,
+			want: []veles.Secret{
+				linearapikey.APIKey{Key: testLinearAPIKey},
+				linearapikey.APIKey{Key: testLinearAPIKey2},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDetector_falsePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{
+		linearapikey.NewDetector(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "wrong prefix",
+			input: "lin_api_key_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			name:  "too short",
+			input: "lin_api_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			name:  "too long",
+			input: "lin_api_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			name:  "non-alphanumeric suffix",
+			input: "lin_api_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!",
+		},
+		{
+			name:  "mixed case prefix",
+			input: "LIN_API_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) > 0 {
+				t.Errorf("Detect() expected no secrets, got %v", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# PR: Add 4 new plugins — Helm Chart.lock, Pulumi Pulumi.yaml, Datadog API Key, Linear API Key

## Summary
This PR adds four new plugins to OSV-SCALIBR, covering two new filesystem extractors and two new Veles secret detectors.

| Plugin | Type | File | Description |
|--------|------|------|-------------|
| `helm/chartlock` | Extractor | `Chart.lock` | Helm v3 dependency lockfile |
| `pulumi/pulumiyaml` | Extractor | `Pulumi.yaml` | Pulumi plugin/provider dependencies |
| `secrets/datadogapikey` | Veles Secret | — | Datadog API key (32-hex, keyword-gated) |
| `secrets/linearapikey` | Veles Secret | — | Linear API key (`lin_api_` prefix) |

## Why these plugins?

**Helm Chart.lock** — Helm v3 generates `Chart.lock` when running `helm dependency build/update`. It contains the resolved `dependencies` array with `name`, `version`, and `repository` for each chart. This extractor surfaces those as SCALIBR inventory packages, enabling vulnerability scanning for Helm chart dependencies.

**Pulumi Pulumi.yaml** — Pulumi's project manifest includes a `plugins` section that lists required provider plugins by `name` and `version`. This extractor inventories those providers, filling a gap for Infrastructure-as-Code dependency scanning.

**Datadog API Key** — Datadog API keys are 32-character hex strings. A raw hex detector would be catastrophically noisy (matches MD5, UUID segments, commit hashes). This detector uses the keyword-gated `pair.Detector` pattern, requiring a Datadog-specific keyword (`DD_API_KEY`, `DATADOG_API_KEY`, etc.) within 20 characters of the token.

**Linear API Key** — Linear API keys use the ultra-specific prefix `lin_api_` followed by 40 alphanumeric characters. The prefix is highly specific, making this a very low false-positive detector.

## Files Added

### Helm Chart.lock extractor
- `extractor/filesystem/language/helm/chartlock/chartlock.go` — extractor implementation
- `extractor/filesystem/language/helm/chartlock/chartlock_test.go` — unit tests (9 cases)
- `extractor/filesystem/language/helm/chartlock/testdata/empty.yaml` — empty fixture
- `extractor/filesystem/language/helm/chartlock/testdata/malformed.yaml` — invalid YAML
- `extractor/filesystem/language/helm/chartlock/testdata/no-version.yaml` — missing version
- `extractor/filesystem/language/helm/chartlock/testdata/single-dep.yaml` — single dependency
- `extractor/filesystem/language/helm/chartlock/testdata/valid.yaml` — two dependencies

### Pulumi Pulumi.yaml extractor
- `extractor/filesystem/language/pulumi/pulumiyaml/pulumiyaml.go` — extractor implementation
- `extractor/filesystem/language/pulumi/pulumiyaml/pulumiyaml_test.go` — unit tests (9 cases)
- `extractor/filesystem/language/pulumi/pulumiyaml/testdata/empty.yaml` — empty fixture
- `extractor/filesystem/language/pulumi/pulumiyaml/testdata/malformed.yaml` — invalid YAML
- `extractor/filesystem/language/pulumi/pulumiyaml/testdata/no-version.yaml` — missing version
- `extractor/filesystem/language/pulumi/pulumiyaml/testdata/single-provider.yaml` — single provider
- `extractor/filesystem/language/pulumi/pulumiyaml/testdata/valid.yaml` — two providers

### Datadog API Key detector
- `veles/secrets/datadogapikey/datadogapikey.go` — detector implementation
- `veles/secrets/datadogapikey/datadogapikey_test.go` — unit tests (acceptance + true positives + false negatives)

### Linear API Key detector
- `veles/secrets/linearapikey/linearapikey.go` — detector implementation
- `veles/secrets/linearapikey/linearapikey_test.go` — unit tests (acceptance + true positives + false negatives)

## Files Modified
- `extractor/filesystem/list/list.go` — imports and registers all 4 new plugins
- `docs/supported_inventory_types.md` — documents all 4 new plugins

## Design Notes

### Helm Chart.lock
- Uses `yaml.v3` with low-level `yaml.Node` tree walking to parse `Chart.lock` without requiring a struct that matches every field.
- Extracts `name`, `version`, and `repository` from the `dependencies` array.
- Does **not** set `Metadata` on extracted packages (same pattern as the existing `terraform/lockfile` extractor) to avoid the `metadata.Protoable` interface requirement.
- Line numbers come from `yaml.Node.Line` and match the actual YAML node line.

### Pulumi Pulumi.yaml
- Uses `yaml.v3` with `yaml.Node` tree walking.
- Matches both `Pulumi.yaml` and `Pulumi.yml` (case-sensitive base name check).
- Looks for `plugins.providers` first, then falls back to `plugins.*` sequences.
- Does **not** set `Metadata` to avoid the `metadata.Protoable` interface requirement.

### Datadog API Key
- Uses `veles/secrets/common/pair.Detector` with:
  - `FindA`: keyword regex matching `DD_API_KEY`, `DATADOG_API_KEY`, `DATADOG_APP_KEY`, `DD_APP_KEY`, `DATADOG_API_TOKEN`, `DD_API_TOKEN`, `DATADOG_TOKEN`, `DD_TOKEN` (case-insensitive, with optional quotes and `=`/`:` separator).
  - `FindB`: 32-character hex regex (`\b[a-f0-9]{32}\b`).
  - `MaxDistance`: 20 characters between keyword and token.
- Secret type: `datadogapikey.APIKey{Key: string}`.

### Linear API Key
- Uses `veles/secrets/common/simpletoken.Detector` with:
  - Regex: `lin_api_[A-Za-z0-9]{40}\b` (word boundary prevents matching partial longer strings).
  - `MaxLen`: 48.
- Secret type: `linearapikey.APIKey{Key: string}`.
- The regex does **not** use a case-insensitive flag because the prefix is strictly lowercase in Linear's documentation.

## Test Results

```
ok  github.com/google/osv-scalibr/extractor/filesystem/language/helm/chartlock
ok  github.com/google/osv-scalibr/extractor/filesystem/language/pulumi/pulumiyaml
ok  github.com/google/osv-scalibr/veles/secrets/datadogapikey
ok  github.com/google/osv-scalibr/veles/secrets/linearapikey
ok  github.com/google/osv-scalibr/extractor/filesystem/list
ok  github.com/google/osv-scalibr  (full build)
```

## Isolation Notes
- This PR does **not** include any Deno modifications.
- This PR does **not** include any Terraform modifications.
- The four plugins are independent and can be reviewed separately if needed, but the shared `list.go` and `docs/supported_inventory_types.md` changes are bundled here for convenience.

## Checklist
- [x] Unit tests for all 4 plugins
- [x] Registration in `extractor/filesystem/list/list.go`
- [x] Documentation in `docs/supported_inventory_types.md`
- [x] Full build compiles (`go build ./...`)
- [x] `go vet` passes
- [x] No unrelated changes included
