### PR TITLE
feat: add Package.swift extractor for Swift Package Manager

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -113,6 +113,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Rust binaries                                     | `rust/cargoauditable`                |
 | Swift      | Podfile.lock                                      | `swift/podfilelock`                  |
 |            | Package.resolved                                  | `swift/packageresolved`              |
+|            | Package.swift                                     | `swift/packageswift`                 |
 | Nim        | Nimble packages                                   | `nim/nimble`                         |
 | Perl       | Perl CPAN packages                                | `perl/cpan`                          |
 

--- a/extractor/filesystem/language/swift/packageswift/package_swift.go
+++ b/extractor/filesystem/language/swift/packageswift/package_swift.go
@@ -1,0 +1,235 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package packageswift extracts Package.swift files for Swift projects.
+package packageswift
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "swift/packageswift"
+
+	// defaultMaxFileSizeBytes is the default maximum file size the extractor will
+	// attempt to extract. If a file is encountered that is larger than this
+	// limit, the file is ignored by FileRequired.
+	defaultMaxFileSizeBytes = 10 * units.MiB
+)
+
+// Extractor extracts packages from Package.swift files.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New returns a Package.swift extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file is named "Package.swift".
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	if filepath.Base(path) != "Package.swift" {
+		return false
+	}
+
+	fileinfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract parses and extracts dependency data from a Package.swift file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := e.extractFromInput(input)
+	if e.Stats != nil {
+		var fileSizeBytes int64
+		if input.Info != nil {
+			fileSizeBytes = input.Info.Size()
+		}
+		e.Stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+			Path:          input.Path,
+			Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+			FileSizeBytes: fileSizeBytes,
+		})
+	}
+	return inventory.Inventory{Packages: pkgs}, err
+}
+
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Package, error) {
+	content, err := io.ReadAll(input.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Package.swift: %w", err)
+	}
+
+	packages, err := parse(string(content))
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*extractor.Package = []*extractor.Package{}
+	for _, pkg := range packages {
+		result = append(result, &extractor.Package{
+			Name:     pkg.Name,
+			Version:  pkg.Version,
+			PURLType: purl.TypeSwift,
+			Location: extractor.LocationFromPath(input.Path),
+		})
+	}
+	return result, nil
+}
+
+// pkg represents a parsed package entry from the Package.swift file.
+type pkg struct {
+	Name    string
+	Version string
+}
+
+// parse extracts package dependencies from a Package.swift file content.
+// It looks for .package(url:...) declarations with version specifiers.
+func parse(content string) ([]pkg, error) {
+	// Strip comments to avoid false matches in commented code.
+	content = stripComments(content)
+
+	var packages []pkg
+
+	// Match .package(url: "...", from: "X.Y.Z")
+	fromRe := regexp.MustCompile(`(?s)\.package\s*\(\s*url\s*:\s*"([^"]+)"\s*,\s*from\s*:\s*"([^"]+)"\s*\)`)
+	for _, match := range fromRe.FindAllStringSubmatch(content, -1) {
+		url := match[1]
+		version := match[2]
+		if name := normalizeSwiftURL(url); name != "" {
+			packages = append(packages, pkg{Name: name, Version: version})
+		}
+	}
+
+	// Match .package(url: "...", exact: "X.Y.Z")
+	exactRe := regexp.MustCompile(`(?s)\.package\s*\(\s*url\s*:\s*"([^"]+)"\s*,\s*exact\s*:\s*"([^"]+)"\s*\)`)
+	for _, match := range exactRe.FindAllStringSubmatch(content, -1) {
+		url := match[1]
+		version := match[2]
+		if name := normalizeSwiftURL(url); name != "" {
+			packages = append(packages, pkg{Name: name, Version: version})
+		}
+	}
+
+	// Match .package(url: "...", .exact("X.Y.Z"))
+	dotExactRe := regexp.MustCompile(`(?s)\.package\s*\(\s*url\s*:\s*"([^"]+)"\s*,\s*\.exact\s*\(\s*"([^"]+)"\s*\)\s*\)`)
+	for _, match := range dotExactRe.FindAllStringSubmatch(content, -1) {
+		url := match[1]
+		version := match[2]
+		if name := normalizeSwiftURL(url); name != "" {
+			packages = append(packages, pkg{Name: name, Version: version})
+		}
+	}
+
+	// Match .package(url: "...", .upToNextMajor(from: "X.Y.Z"))
+	upToNextMajorRe := regexp.MustCompile(`(?s)\.package\s*\(\s*url\s*:\s*"([^"]+)"\s*,\s*\.upToNextMajor\s*\(\s*from\s*:\s*"([^"]+)"\s*\)\s*\)`)
+	for _, match := range upToNextMajorRe.FindAllStringSubmatch(content, -1) {
+		url := match[1]
+		version := match[2]
+		if name := normalizeSwiftURL(url); name != "" {
+			packages = append(packages, pkg{Name: name, Version: version})
+		}
+	}
+
+	// Match .package(url: "...", .upToNextMinor(from: "X.Y.Z"))
+	upToNextMinorRe := regexp.MustCompile(`(?s)\.package\s*\(\s*url\s*:\s*"([^"]+)"\s*,\s*\.upToNextMinor\s*\(\s*from\s*:\s*"([^"]+)"\s*\)\s*\)`)
+	for _, match := range upToNextMinorRe.FindAllStringSubmatch(content, -1) {
+		url := match[1]
+		version := match[2]
+		if name := normalizeSwiftURL(url); name != "" {
+			packages = append(packages, pkg{Name: name, Version: version})
+		}
+	}
+
+	return packages, nil
+}
+
+// stripComments removes Swift-style comments from the content.
+func stripComments(content string) string {
+	// Remove multi-line comments: /* ... */
+	result := regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(content, "")
+	// Remove single-line comments: //... (requires start-of-line or whitespace before //)
+	result = regexp.MustCompile(`(?m)(^|\s)//.*$`).ReplaceAllString(result, "")
+	return result
+}
+
+// normalizeSwiftURL converts a Swift package repository URL to the canonical
+// package name used in PURL and OSV.dev SwiftURL ecosystem identifiers.
+//
+// Examples:
+//
+//	https://github.com/apple/swift-crypto.git → github.com/apple/swift-crypto
+//	https://github.com/apple/swift-nio.git    → github.com/apple/swift-nio
+func normalizeSwiftURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	// Strip scheme.
+	loc := strings.TrimPrefix(rawURL, "https://")
+	loc = strings.TrimPrefix(loc, "http://")
+	// Strip .git suffix.
+	loc = strings.TrimSuffix(loc, ".git")
+	return loc
+}

--- a/extractor/filesystem/language/swift/packageswift/package_swift.go
+++ b/extractor/filesystem/language/swift/packageswift/package_swift.go
@@ -122,12 +122,9 @@ func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.P
 		return nil, fmt.Errorf("failed to read Package.swift: %w", err)
 	}
 
-	packages, err := parse(string(content))
-	if err != nil {
-		return nil, err
-	}
+	packages := parse(string(content))
 
-	var result []*extractor.Package = []*extractor.Package{}
+	result := []*extractor.Package{}
 	for _, pkg := range packages {
 		result = append(result, &extractor.Package{
 			Name:     pkg.Name,
@@ -147,7 +144,7 @@ type pkg struct {
 
 // parse extracts package dependencies from a Package.swift file content.
 // It looks for .package(url:...) declarations with version specifiers.
-func parse(content string) ([]pkg, error) {
+func parse(content string) []pkg {
 	// Strip comments to avoid false matches in commented code.
 	content = stripComments(content)
 
@@ -203,7 +200,7 @@ func parse(content string) ([]pkg, error) {
 		}
 	}
 
-	return packages, nil
+	return packages
 }
 
 // stripComments removes Swift-style comments from the content.

--- a/extractor/filesystem/language/swift/packageswift/package_swift_test.go
+++ b/extractor/filesystem/language/swift/packageswift/package_swift_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packageswift_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/packageswift"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+	"github.com/google/osv-scalibr/testing/testcollector"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+		wantResultMetric stats.FileRequiredResult
+	}{
+		{
+			name:             "Package.swift file",
+			path:             "Package.swift",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "path Package.swift file",
+			path:             "path/to/my/Package.swift",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:         "wrong file name",
+			path:         "test.swift",
+			wantRequired: false,
+		},
+		{
+			name:             "Package.swift file required if file size < max file size",
+			path:             "Package.swift",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "Package.swift file not required if file size > max file size",
+			path:             "Package.swift",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 100 * units.KiB,
+			wantRequired:     false,
+			wantResultMetric: stats.FileRequiredResultSizeLimitExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := packageswift.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("packageswift.New: %v", err)
+			}
+			e.(*packageswift.Extractor).Stats = collector
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1000
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+
+			gotResultMetric := collector.FileRequiredResult(tt.path)
+			if tt.wantResultMetric != "" && gotResultMetric != tt.wantResultMetric {
+				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "single from dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/single_from",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "github.com/apple/swift-crypto", Version: "2.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/single_from")},
+			},
+		},
+		{
+			Name: "multiple mixed dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/multiple_mixed",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "github.com/apple/swift-crypto", Version: "2.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/multiple_mixed")},
+				{Name: "github.com/apple/swift-nio", Version: "2.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/multiple_mixed")},
+				{Name: "github.com/vapor/vapor", Version: "4.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/multiple_mixed")},
+			},
+		},
+		{
+			Name: "exact version",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/exact_version",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "github.com/apple/swift-crypto", Version: "2.1.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/exact_version")},
+			},
+		},
+		{
+			Name: "dot exact version",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/dot_exact_version",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "github.com/apple/swift-nio", Version: "2.82.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/dot_exact_version")},
+			},
+		},
+		{
+			Name: "upToNextMinor",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/up_to_next_minor",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "github.com/apple/swift-crypto", Version: "2.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/up_to_next_minor")},
+			},
+		},
+		{
+			Name: "branch and revision ignored",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/branch_revision",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "local path ignored",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/local_path",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "comments and whitespace",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/comments_whitespace",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "github.com/apple/swift-crypto", Version: "2.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/comments_whitespace")},
+				{Name: "github.com/apple/swift-nio", Version: "2.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/comments_whitespace")},
+			},
+		},
+		{
+			Name: "target product dependencies ignored",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/target_deps",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "github.com/apple/swift-crypto", Version: "2.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/target_deps")},
+			},
+		},
+		{
+			Name: "no dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no_deps",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "invalid file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "multiline package declaration",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/multiline",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "github.com/apple/swift-crypto", Version: "2.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/multiline")},
+			},
+		},
+		{
+			Name: "package dependencies append syntax",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/append_syntax",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "github.com/apple/swift-crypto", Version: "2.0.0", PURLType: purl.TypeSwift, Location: extractor.LocationFromPath("testdata/append_syntax")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := packageswift.New(&cpb.PluginConfig{MaxFileSizeBytes: 100})
+			if err != nil {
+				t.Fatalf("packageswift.New: %v", err)
+			}
+			e.(*packageswift.Extractor).Stats = collector
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/swift/packageswift/testdata/append_syntax
+++ b/extractor/filesystem/language/swift/packageswift/testdata/append_syntax
@@ -1,0 +1,4 @@
+let package = Package(name: "AppendApp")
+package.dependencies += [
+    .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
+]

--- a/extractor/filesystem/language/swift/packageswift/testdata/branch_revision
+++ b/extractor/filesystem/language/swift/packageswift/testdata/branch_revision
@@ -1,0 +1,7 @@
+let package = Package(
+    name: "BranchApp",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-nio.git", revision: "abc123"),
+    ]
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/comments_whitespace
+++ b/extractor/filesystem/language/swift/packageswift/testdata/comments_whitespace
@@ -1,0 +1,9 @@
+let package = Package(
+    name: "CommentedApp",
+    dependencies: [
+        // Crypto library
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
+        /* NIO library */
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+    ]
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/dot_exact_version
+++ b/extractor/filesystem/language/swift/packageswift/testdata/dot_exact_version
@@ -1,0 +1,6 @@
+let package = Package(
+    name: "PinnedApp",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", .exact("2.82.0")),
+    ]
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/exact_version
+++ b/extractor/filesystem/language/swift/packageswift/testdata/exact_version
@@ -1,0 +1,6 @@
+let package = Package(
+    name: "PinnedApp",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", exact: "2.1.0"),
+    ]
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/invalid
+++ b/extractor/filesystem/language/swift/packageswift/testdata/invalid
@@ -1,0 +1,3 @@
+import Foundation
+
+print("Hello, World!")

--- a/extractor/filesystem/language/swift/packageswift/testdata/local_path
+++ b/extractor/filesystem/language/swift/packageswift/testdata/local_path
@@ -1,0 +1,6 @@
+let package = Package(
+    name: "LocalApp",
+    dependencies: [
+        .package(path: "../LocalLib"),
+    ]
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/multiline
+++ b/extractor/filesystem/language/swift/packageswift/testdata/multiline
@@ -1,0 +1,9 @@
+let package = Package(
+    name: "MultiApp",
+    dependencies: [
+        .package(
+            url: "https://github.com/apple/swift-crypto.git",
+            from: "2.0.0"
+        ),
+    ]
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/multiple_mixed
+++ b/extractor/filesystem/language/swift/packageswift/testdata/multiple_mixed
@@ -1,0 +1,10 @@
+import PackageDescription
+
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.0.0")),
+        .package(url: "https://github.com/vapor/vapor.git", exact: "4.0.0"),
+    ]
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/no_deps
+++ b/extractor/filesystem/language/swift/packageswift/testdata/no_deps
@@ -1,0 +1,4 @@
+let package = Package(
+    name: "NoDeps",
+    dependencies: []
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/single_from
+++ b/extractor/filesystem/language/swift/packageswift/testdata/single_from
@@ -1,0 +1,8 @@
+import PackageDescription
+
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
+    ]
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/target_deps
+++ b/extractor/filesystem/language/swift/packageswift/testdata/target_deps
@@ -1,0 +1,15 @@
+let package = Package(
+    name: "TargetApp",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyTarget",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "NIO", package: "swift-nio"),
+            ]
+        )
+    ]
+)

--- a/extractor/filesystem/language/swift/packageswift/testdata/up_to_next_minor
+++ b/extractor/filesystem/language/swift/packageswift/testdata/up_to_next_minor
@@ -1,0 +1,6 @@
+let package = Package(
+    name: "MinorApp",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "2.0.0")),
+    ]
+)

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -84,6 +84,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargolock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargotoml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/packageresolved"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/packageswift"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/podfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/bazelmaven"
 	chromeextensions "github.com/google/osv-scalibr/extractor/filesystem/misc/chrome/extensions"
@@ -320,6 +321,7 @@ var (
 	// SwiftSource extractors for Swift.
 	SwiftSource = InitMap{
 		packageresolved.Name: {packageresolved.New},
+		packageswift.Name:    {packageswift.New},
 		podfilelock.Name:     {podfilelock.New},
 	}
 


### PR DESCRIPTION
This PR adds a new filesystem extractor `swift/packageswift` that parses `Package.swift` manifest files to discover declared Swift package dependencies.

What it does:
- Matches files named `Package.swift`
- Extracts `.package(url:..., from: ...)`, `exact: ...`, `.exact(...)`, `.upToNextMajor(from: ...)`, and `.upToNextMinor(from: ...)` declarations
- Emits packages with PURL type `swift`
- Ignores non-versioned dependencies such as `branch:`, `revision:`, and local `path:` entries
- Strips line and block comments before parsing

Why:
`Package.resolved` captures locked dependencies when present. `Package.swift` captures the declared dependency graph, which is useful for inventory generation and vulnerability analysis in repositories that do not commit a lockfile.

Test coverage:
- FileRequired behavior
- versioned dependency declarations
- multiline declarations
- comments and whitespace
- append syntax
- branch, revision, local path, target product dependency, empty, and invalid-file cases

Validation run locally:
- `go test ./extractor/filesystem/language/swift/packageswift/ -v`
- `go test ./extractor/filesystem/language/swift/...`
- `go test ./extractor/filesystem/list/...`
- `go build ./extractor/filesystem/...`
- `go build ./...`
- `git diff --check`