### PR TITLE
feat: add composer.json extractor for PHP projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -97,6 +97,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Lua        | Luarocks modules                                  | `lua/luarocks`                       |
 | ObjectiveC | Podfile.lock                                      | `swift/podfilelock`                  |
 | PHP        | Composer                                          | `php/composerlock`                   |
+|            | composer.json                                     | `php/composerjson`                   |
 | Python     | Installed PyPI packages (global and venv)         | `python/wheelegg`                    |
 |            | requirements.txt                                  | `python/requirements`                |
 |            | poetry.lock                                       | `python/poetrylock`                  |

--- a/extractor/filesystem/language/php/composerjson/composer_json.go
+++ b/extractor/filesystem/language/php/composerjson/composer_json.go
@@ -1,0 +1,249 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package composerjson extracts composer.json files for PHP projects.
+package composerjson
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "php/composerjson"
+
+	// defaultMaxFileSizeBytes is the default maximum file size the extractor will
+	// attempt to extract. If a file is encountered that is larger than this
+	// limit, the file is ignored by FileRequired.
+	defaultMaxFileSizeBytes = 10 * units.MiB
+)
+
+// composerJSON represents the subset of a composer.json file needed for extraction.
+type composerJSON struct {
+	Require    map[string]string `json:"require"`
+	RequireDev map[string]string `json:"require-dev"`
+}
+
+// Extractor extracts packages from composer.json files.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New returns a composer.json extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file is named "composer.json".
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	if filepath.Base(path) != "composer.json" {
+		return false
+	}
+
+	fileinfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract parses and extracts dependency data from a composer.json file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := e.extractFromInput(input)
+	if e.Stats != nil {
+		var fileSizeBytes int64
+		if input.Info != nil {
+			fileSizeBytes = input.Info.Size()
+		}
+		e.Stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+			Path:          input.Path,
+			Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+			FileSizeBytes: fileSizeBytes,
+		})
+	}
+	return inventory.Inventory{Packages: pkgs}, err
+}
+
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Package, error) {
+	content, err := io.ReadAll(input.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read composer.json: %w", err)
+	}
+
+	var parsed composerJSON
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse composer.json: %w", err)
+	}
+
+	packages := []*extractor.Package{}
+
+	for name, version := range parsed.Require {
+		if pkg := buildPackage(input, name, version, nil); pkg != nil {
+			packages = append(packages, pkg)
+		}
+	}
+
+	for name, version := range parsed.RequireDev {
+		if pkg := buildPackage(input, name, version, []string{"dev"}); pkg != nil {
+			packages = append(packages, pkg)
+		}
+	}
+
+	return packages, nil
+}
+
+func buildPackage(input *filesystem.ScanInput, name, version string, groups []string) *extractor.Package {
+	if !isValidPackageName(name) {
+		return nil
+	}
+
+	v := simplifyVersion(version)
+	if v == "" {
+		return nil
+	}
+
+	return &extractor.Package{
+		Name:     name,
+		Version:  v,
+		PURLType: purl.TypeComposer,
+		Location: extractor.LocationFromPath(input.Path),
+		Metadata: &osv.DepGroupMetadata{
+			DepGroupVals: groups,
+		},
+	}
+}
+
+// isValidPackageName returns true if the name is a valid Composer package name
+// and not a platform package (php, ext-*, lib-*).
+func isValidPackageName(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	// Skip platform packages.
+	if name == "php" || strings.HasPrefix(name, "ext-") || strings.HasPrefix(name, "lib-") || strings.HasPrefix(name, "php-") {
+		return false
+	}
+
+	// Composer package names are vendor/package with a single slash.
+	parts := strings.Split(name, "/")
+	if len(parts) != 2 {
+		return false
+	}
+
+	// Each part must be non-empty and contain only valid characters.
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.') {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// simplifyVersion extracts a conservative minimum version from a Composer
+// version constraint. It returns an empty string if the version should be
+// skipped (wildcards, branch names, etc.).
+func simplifyVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+
+	// Skip wildcards and branch names.
+	if v == "*" || strings.HasPrefix(v, "dev-") || strings.HasPrefix(v, "feature/") || strings.HasPrefix(v, "bugfix/") {
+		return ""
+	}
+
+	// Skip inline aliases (e.g., "1.0 as 2.0").
+	if strings.Contains(v, " as ") || strings.Contains(v, " AS ") {
+		return ""
+	}
+
+	// Skip hyphen ranges (e.g., "1.0 - 2.0").
+	if strings.Contains(v, " - ") {
+		return ""
+	}
+
+	// Take the first part of an OR constraint.
+	if idx := strings.Index(v, "||"); idx != -1 {
+		v = strings.TrimSpace(v[:idx])
+	}
+
+	// Strip leading constraint operators.
+	v = strings.TrimLeftFunc(v, func(r rune) bool {
+		return r == '^' || r == '~' || r == '>' || r == '<' || r == '=' || r == '!' || r == ' ' || r == '*'
+	})
+
+	v = strings.TrimSpace(v)
+	if v == "" || v == "*" {
+		return ""
+	}
+
+	return v
+}

--- a/extractor/filesystem/language/php/composerjson/composer_json_test.go
+++ b/extractor/filesystem/language/php/composerjson/composer_json_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package composerjson_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerjson"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+	"github.com/google/osv-scalibr/testing/testcollector"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+		wantResultMetric stats.FileRequiredResult
+	}{
+		{
+			name:             "composer.json at root",
+			path:             "composer.json",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "composer.json in subpath",
+			path:             "path/to/composer.json",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:         "not composer.json",
+			path:         "package.json",
+			wantRequired: false,
+		},
+		{
+			name:             "size under limit",
+			path:             "composer.json",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "size over limit",
+			path:             "composer.json",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 100 * units.KiB,
+			wantRequired:     false,
+			wantResultMetric: stats.FileRequiredResultSizeLimitExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := composerjson.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("composerjson.New: %v", err)
+			}
+			e.(*composerjson.Extractor).Stats = collector
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1000
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+
+			gotResultMetric := collector.FileRequiredResult(tt.path)
+			if tt.wantResultMetric != "" && gotResultMetric != tt.wantResultMetric {
+				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "single dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/single_dep",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "symfony/console", Version: "5.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/single_dep"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+			},
+		},
+		{
+			Name: "multiple dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/multiple_deps",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "symfony/console", Version: "5.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/multiple_deps"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+				{Name: "monolog/monolog", Version: "2.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/multiple_deps"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+			},
+		},
+		{
+			Name: "require dev",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/require_dev",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "phpunit/phpunit", Version: "9.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/require_dev"), Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"dev"}}},
+			},
+		},
+		{
+			Name: "mixed require and require dev",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/mixed",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "symfony/console", Version: "5.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/mixed"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+				{Name: "phpunit/phpunit", Version: "9.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/mixed"), Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"dev"}}},
+			},
+		},
+		{
+			Name: "version constraints",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/version_constraints",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "symfony/console", Version: "5.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/version_constraints"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+				{Name: "monolog/monolog", Version: "2.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/version_constraints"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+				{Name: "doctrine/orm", Version: "2.8.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/version_constraints"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+				{Name: "twig/twig", Version: "3.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/version_constraints"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+			},
+		},
+		{
+			Name: "or constraint",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/or_constraint",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "symfony/console", Version: "5.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/or_constraint"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+			},
+		},
+		{
+			Name: "platform packages skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/platform_skipped",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "symfony/console", Version: "5.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/platform_skipped"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+			},
+		},
+		{
+			Name: "wildcard and branch skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/wildcard_skipped",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "symfony/console", Version: "5.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/wildcard_skipped"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+			},
+		},
+		{
+			Name: "extra sections ignored",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/extra_sections",
+			},
+			WantPackages: []*extractor.Package{
+				{Name: "symfony/console", Version: "5.0.0", PURLType: purl.TypeComposer, Location: extractor.LocationFromPath("testdata/extra_sections"), Metadata: &osv.DepGroupMetadata{DepGroupVals: nil}},
+			},
+		},
+		{
+			Name: "invalid json",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid_json",
+			},
+			WantErr: cmpopts.AnyError,
+		},
+		{
+			Name: "no dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no_deps",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty",
+			},
+			WantErr: cmpopts.AnyError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := composerjson.New(&cpb.PluginConfig{MaxFileSizeBytes: 100})
+			if err != nil {
+				t.Fatalf("composerjson.New: %v", err)
+			}
+			e.(*composerjson.Extractor).Stats = collector
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/extra_sections
+++ b/extractor/filesystem/language/php/composerjson/testdata/extra_sections
@@ -1,0 +1,21 @@
+{
+    "name": "vendor/project",
+    "require": {
+        "symfony/console": "5.0.0"
+    },
+    "require-dev": {},
+    "scripts": {
+        "test": "phpunit"
+    },
+    "autoload": {
+        "psr-4": {
+            "Vendor\\Project\\": "src/"
+        }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/vendor/project"
+        }
+    ]
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/invalid_json
+++ b/extractor/filesystem/language/php/composerjson/testdata/invalid_json
@@ -1,0 +1,6 @@
+{
+    "name": "vendor/project",
+    "require": {
+        "symfony/console": "5.0.0",
+    }
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/mixed
+++ b/extractor/filesystem/language/php/composerjson/testdata/mixed
@@ -1,0 +1,9 @@
+{
+    "name": "vendor/project",
+    "require": {
+        "symfony/console": "5.0.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "9.0.0"
+    }
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/multiple_deps
+++ b/extractor/filesystem/language/php/composerjson/testdata/multiple_deps
@@ -1,0 +1,7 @@
+{
+    "name": "vendor/project",
+    "require": {
+        "symfony/console": "5.0.0",
+        "monolog/monolog": "2.0.0"
+    }
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/no_deps
+++ b/extractor/filesystem/language/php/composerjson/testdata/no_deps
@@ -1,0 +1,5 @@
+{
+    "name": "vendor/project",
+    "require": {},
+    "require-dev": {}
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/or_constraint
+++ b/extractor/filesystem/language/php/composerjson/testdata/or_constraint
@@ -1,0 +1,6 @@
+{
+    "name": "vendor/project",
+    "require": {
+        "symfony/console": "5.0.0 || 6.0.0"
+    }
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/platform_skipped
+++ b/extractor/filesystem/language/php/composerjson/testdata/platform_skipped
@@ -1,0 +1,9 @@
+{
+    "name": "vendor/project",
+    "require": {
+        "symfony/console": "5.0.0",
+        "php": ">=7.4",
+        "ext-json": "*",
+        "lib-openssl": "*"
+    }
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/require_dev
+++ b/extractor/filesystem/language/php/composerjson/testdata/require_dev
@@ -1,0 +1,6 @@
+{
+    "name": "vendor/project",
+    "require-dev": {
+        "phpunit/phpunit": "9.0.0"
+    }
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/single_dep
+++ b/extractor/filesystem/language/php/composerjson/testdata/single_dep
@@ -1,0 +1,6 @@
+{
+    "name": "vendor/project",
+    "require": {
+        "symfony/console": "5.0.0"
+    }
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/version_constraints
+++ b/extractor/filesystem/language/php/composerjson/testdata/version_constraints
@@ -1,0 +1,9 @@
+{
+    "name": "vendor/project",
+    "require": {
+        "symfony/console": "^5.0.0",
+        "monolog/monolog": "~2.0.0",
+        "doctrine/orm": ">=2.8.0",
+        "twig/twig": "3.0.0"
+    }
+}

--- a/extractor/filesystem/language/php/composerjson/testdata/wildcard_skipped
+++ b/extractor/filesystem/language/php/composerjson/testdata/wildcard_skipped
@@ -1,0 +1,9 @@
+{
+    "name": "vendor/project",
+    "require": {
+        "symfony/console": "5.0.0",
+        "monolog/monolog": "*",
+        "doctrine/orm": "dev-master",
+        "twig/twig": "dev-feature/foo"
+    }
+}

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -67,6 +67,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/nim/nimble"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ocaml/opam"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cpan"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condameta"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
@@ -316,7 +317,10 @@ var (
 		dotnetpe.Name: {dotnetpe.New},
 	}
 	// PHPSource extractors for PHP Source extractors.
-	PHPSource = InitMap{composerlock.Name: {composerlock.New}}
+	PHPSource = InitMap{
+		composerjson.Name: {composerjson.New},
+		composerlock.Name: {composerlock.New},
+	}
 	// SwiftSource extractors for Swift.
 	SwiftSource = InitMap{
 		packageresolved.Name: {packageresolved.New},


### PR DESCRIPTION
This PR adds a new filesystem extractor `php/composerjson` that parses `composer.json` manifest files to discover declared PHP Composer dependencies.

What it does:
- Matches files named `composer.json`
- Extracts dependencies from `require` and `require-dev`
- Emits packages with PURL type `composer`
- Marks `require-dev` dependencies with dependency group metadata
- Skips Composer platform requirements such as `php`, `ext-*`, `lib-*`, and `php-*`
- Skips wildcard-only and branch-only constraints such as `*`, `dev-master`, and `feature/*`
- Conservatively simplifies version constraints such as `^1.2.3`, `~1.2`, `>=1.0`, and OR constraints

Why:
`composer.lock` captures resolved dependencies when present. `composer.json` captures the declared dependency graph and is useful for inventory generation and vulnerability analysis in PHP repositories that do not commit a lockfile or before dependency resolution has run.

Validation run locally:
- `go test ./extractor/filesystem/language/php/composerjson/ -v`
- `go test ./extractor/filesystem/language/php/...`
- `go test ./extractor/filesystem/list/...`
- `go build ./extractor/filesystem/...`
- `go build ./...`
- `git diff --check`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(cat .golangci-lint-version) run ./extractor/filesystem/language/php/composerjson/...` returned 0 issues