### PR TITLE
Respect offline mode for Veles validators

### DIFF
--- a/binary/cli/cli_test.go
+++ b/binary/cli/cli_test.go
@@ -842,6 +842,17 @@ func TestGetScanConfig_PluginGroups(t *testing.T) {
 			},
 		},
 		{
+			desc: "offline_filters_veles_validators",
+			flags: &cli.Flags{
+				PluginsToRun:         []string{"secrets/urlcredsvalidate"},
+				Offline:              true,
+				FilterByCapabilities: true,
+			},
+			dontWantPlugins: []string{
+				"secrets/urlcredsvalidate",
+			},
+		},
+		{
 			desc: "default_plugins",
 			flags: &cli.Flags{
 				PluginsToRun: []string{"default"},

--- a/enricher/secrets/convert/convert.go
+++ b/enricher/secrets/convert/convert.go
@@ -72,8 +72,9 @@ func (v *validatorWrapper) Version() int {
 
 // Requirements of the enricher.
 func (v *validatorWrapper) Requirements() *plugin.Capabilities {
-	// Veles plugins don't have any special requirements.
-	return &plugin.Capabilities{}
+	// Veles validators are materialized into the central secrets/velesvalidate
+	// enricher, which performs live validation requests.
+	return &plugin.Capabilities{Network: plugin.NetworkOnline}
 }
 
 // RequiredPlugins returns an empty list - While it works on the results of the

--- a/scalibr.go
+++ b/scalibr.go
@@ -177,6 +177,16 @@ func (cfg *ScanConfig) ValidatePluginRequirements() error {
 	return errors.Join(errs...)
 }
 
+func validateEnricherRequirements(enrichers []enricher.Enricher, capabs *plugin.Capabilities) error {
+	errs := []error{}
+	for _, e := range enrichers {
+		if err := plugin.ValidateRequirements(e, capabs); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 // LINT.IfChange
 
 // ScanResult stores the results of a scan incl. scan status and inventory found.
@@ -304,6 +314,11 @@ func (Scanner) Scan(ctx context.Context, config *ScanConfig) (sr *ScanResult) {
 		sro.EndTime = time.Now()
 		return newScanResult(sro)
 	}
+	if err := validateEnricherRequirements(enrichers, config.Capabilities); err != nil {
+		sro.Err = multierr.Append(sro.Err, err)
+		sro.EndTime = time.Now()
+		return newScanResult(sro)
+	}
 	enricherCfg := &enricher.Config{
 		Enrichers: enrichers,
 		ScanRoot: &scalibrfs.ScanRoot{
@@ -404,6 +419,11 @@ func (s Scanner) ScanContainer(ctx context.Context, img image.Image, config *Sca
 	// Run enrichers with the updated inventory.
 	enrichers, err = ce.SetupVelesEnrichers(enrichers)
 	if err != nil {
+		scanResult.Status.Status = plugin.ScanStatusFailed
+		scanResult.Status.FailureReason = err.Error()
+		return scanResult, nil //nolint:nilerr // Errors are returned in the scanResult.
+	}
+	if err := validateEnricherRequirements(enrichers, config.Capabilities); err != nil {
 		scanResult.Status.Status = plugin.ScanStatusFailed
 		scanResult.Status.FailureReason = err.Error()
 		return scanResult, nil //nolint:nilerr // Errors are returned in the scanResult.

--- a/scalibr_test.go
+++ b/scalibr_test.go
@@ -749,6 +749,32 @@ func TestScanContainer(t *testing.T) {
 	}
 }
 
+func TestScanContainerVelesValidatorRequiresNetwork(t *testing.T) {
+	fakeChainLayers := fakelayerbuilder.BuildFakeChainLayersFromPath(t, t.TempDir(),
+		"testdata/populatelayers.yml")
+
+	scanConfig := scalibr.ScanConfig{
+		Plugins: []plugin.Plugin{
+			fakelayerbuilder.FakeTestLayersExtractor{},
+			fromVelesValidator(t, velestest.NewFakeStringSecretValidator(veles.ValidationValid, nil), "secret-validator", 1),
+		},
+		Capabilities: &plugin.Capabilities{
+			Network: plugin.NetworkOffline,
+		},
+	}
+
+	got, err := scalibr.New().ScanContainer(t.Context(), fakeimage.New([]image.ChainLayer{fakeChainLayers[0]}, nil), &scanConfig)
+	if err != nil {
+		t.Fatalf("scalibr.New().ScanContainer() error: %v", err)
+	}
+	if got.Status.Status != plugin.ScanStatusFailed {
+		t.Fatalf("scalibr.New().ScanContainer() status: %v, want %v", got.Status.Status, plugin.ScanStatusFailed)
+	}
+	if got.Status.FailureReason == "" {
+		t.Fatal("scalibr.New().ScanContainer() failure reason is empty")
+	}
+}
+
 func TestScan_ExtractorOverride(t *testing.T) {
 	tmp := t.TempDir()
 	fs := scalibrfs.DirFS(tmp)
@@ -1051,6 +1077,18 @@ func TestValidatePluginRequirements(t *testing.T) {
 				Capabilities: &plugin.Capabilities{
 					Network:  plugin.NetworkOffline,
 					DirectFS: true,
+				},
+			},
+			wantErr: cmpopts.AnyError,
+		},
+		{
+			desc: "veles_validator_requires_network",
+			cfg: scalibr.ScanConfig{
+				Plugins: []plugin.Plugin{
+					fromVelesValidator(t, velestest.NewFakeStringSecretValidator(veles.ValidationValid, nil), "secret-validator", 1),
+				},
+				Capabilities: &plugin.Capabilities{
+					Network: plugin.NetworkOffline,
 				},
 			},
 			wantErr: cmpopts.AnyError,


### PR DESCRIPTION
## Summary

- mark Veles validator wrappers as requiring online network capability
- re-check materialized enricher requirements after Veles validation setup in normal and container scans
- add regression coverage for scanner offline rejection, container-scan offline rejection, and CLI `--offline` capability filtering for a real Veles validator plugin

## Why

Veles validator wrappers are placeholders that are later materialized into the central `secrets/velesvalidate` enricher. That central enricher already declares an online network requirement, but the wrapper did not expose the same requirement during capability validation. As a result, an offline scan configuration could keep a validator enabled until after the wrapper was replaced.

This change keeps capability filtering consistent before and after Veles validator setup, and it prevents the CLI offline path from retaining Veles validation plugins such as `secrets/urlcredsvalidate`.

## Testing

- `go test . ./binary/cli ./enricher/secrets/...`
- `go test ./...`
