### PR TITLE
Add Veles secret detector and validator for Cohere API keys

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -141,6 +141,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | CircleCI Project Token                      | `secrets/circleciproject`              |
 | Cloudflare API Token                        | `secrets/cloudflareapitoken`           |
 | Crates.io API Token                         | `secrets/cratesioapitoken`             |
+| Cohere API key                              | `secrets/cohereapikey`                 |
 | Cursor API key                              | `secrets/cursorapikey`                 |
 | DigitalOcean API key                        | `secrets/digitaloceanapikey`           |
 | Docker hub PAT                              | `secrets/dockerhubpat`                 |

--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -44,6 +44,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/bitwardenoauth2access"
 	"github.com/google/osv-scalibr/veles/secrets/circleci"
 	"github.com/google/osv-scalibr/veles/secrets/cloudflareapitoken"
+	"github.com/google/osv-scalibr/veles/secrets/cohereapikey"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
@@ -183,6 +184,7 @@ var (
 		fromVeles(salesforceoauth2client.NewValidator(), "secrets/salesforceoauth2clientvalidate", 0),
 		fromVeles(salesforceoauth2refresh.NewValidator(), "secrets/salesforceoauth2refreshvalidate", 0),
 		fromVeles(salesforceoauth2jwt.NewValidator(), "secrets/salesforceoauth2jwtvalidate", 0),
+		fromVeles(cohereapikey.NewValidator(), "secrets/cohereapikeyvalidate", 0),
 		fromVeles(cursorapikey.NewValidator(), "secrets/cursorapikeyvalidate", 0),
 	})
 

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -133,6 +133,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/azurestorageaccountaccesskey"
 	"github.com/google/osv-scalibr/veles/secrets/azuretoken"
 	"github.com/google/osv-scalibr/veles/secrets/circleci"
+	"github.com/google/osv-scalibr/veles/secrets/cohereapikey"
 	"github.com/google/osv-scalibr/veles/secrets/cratesioapitoken"
 	"github.com/google/osv-scalibr/veles/secrets/cursorapikey"
 	"github.com/google/osv-scalibr/veles/secrets/denopat"
@@ -375,6 +376,7 @@ var (
 		{azurestorageaccountaccesskey.NewDetector(), "secrets/azurestorageaccountaccesskey", 0},
 		{circleci.NewPersonalAccessTokenDetector(), "secrets/circlecipat", 0},
 		{circleci.NewProjectTokenDetector(), "secrets/circleciproject", 0},
+		{cohereapikey.NewDetector(), "secrets/cohereapikey", 0},
 		{cursorapikey.NewDetector(), "secrets/cursorapikey", 0},
 		{digitaloceanapikey.NewDetector(), "secrets/digitaloceanapikey", 0},
 		{pypiapitoken.NewDetector(), "secrets/pypiapitoken", 0},

--- a/veles/secrets/cohereapikey/cohereapikey.go
+++ b/veles/secrets/cohereapikey/cohereapikey.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cohereapikey contains Veles Secret types and Detectors for
+// Cohere API keys.
+package cohereapikey
+
+// APIKey is a Veles Secret that holds relevant information for a
+// Cohere API key.
+type APIKey struct {
+	Key string
+}

--- a/veles/secrets/cohereapikey/detector.go
+++ b/veles/secrets/cohereapikey/detector.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohereapikey
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+// maxTokenLength is the maximum size of a Cohere API key.
+const maxTokenLength = 100
+
+// keyRe is a regular expression that matches Cohere API keys.
+// Cohere production and trial API keys follow the pattern of alphanumeric
+// strings of 40 characters. V2 keys may use the "sk-co-" prefix.
+var keyRe = regexp.MustCompile(`\bsk-co-[A-Za-z0-9_-]{20,80}\b`)
+
+// NewDetector returns a new simpletoken.Detector that matches Cohere API keys.
+func NewDetector() veles.Detector {
+	return simpletoken.Detector{
+		MaxLen: maxTokenLength,
+		Re:     keyRe,
+		FromMatch: func(b []byte) (veles.Secret, bool) {
+			return APIKey{Key: string(b)}, true
+		},
+	}
+}

--- a/veles/secrets/cohereapikey/detector_test.go
+++ b/veles/secrets/cohereapikey/detector_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohereapikey
+
+import (
+	"testing"
+
+	"github.com/google/osv-scalibr/veles/secrets/common/simpletoken"
+)
+
+func TestDetector(t *testing.T) {
+	d := NewDetector().(simpletoken.Detector)
+
+	tests := []struct {
+		name    string
+		input   string
+		want    bool
+		wantKey string
+	}{
+		{
+			name:    "valid cohere v2 key",
+			input:   `COHERE_API_KEY=sk-co-abcdefghijklmnopqrstuvwxyz1234567890abcd`,
+			want:    true,
+			wantKey: "sk-co-abcdefghijklmnopqrstuvwxyz1234567890abcd",
+		},
+		{
+			name:    "valid cohere key in code",
+			input:   `cohere_key = "sk-co-AbCdEfGhIjKlMnOpQrStUvWx0123456789"`,
+			want:    true,
+			wantKey: "sk-co-AbCdEfGhIjKlMnOpQrStUvWx0123456789",
+		},
+		{
+			name:    "valid key with underscores and hyphens",
+			input:   `key: sk-co-abc_def-ghi_jkl-mno_pqr-stu_vwx`,
+			want:    true,
+			wantKey: "sk-co-abc_def-ghi_jkl-mno_pqr-stu_vwx",
+		},
+		{
+			name:  "no match - wrong prefix",
+			input: `API_KEY=sk-ant-abcdefghijklmnopqrstuvwxyz`,
+			want:  false,
+		},
+		{
+			name:  "no match - too short",
+			input: `key=sk-co-abc`,
+			want:  false,
+		},
+		{
+			name:  "no match - no key present",
+			input: `This is just regular text without any API keys.`,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := d.Re.FindAll([]byte(tt.input), -1)
+			got := len(matches) > 0
+			if got != tt.want {
+				t.Errorf("Detector match = %v, want %v", got, tt.want)
+			}
+			if tt.want && got {
+				if string(matches[0]) != tt.wantKey {
+					t.Errorf("Detector matched %q, want %q", string(matches[0]), tt.wantKey)
+				}
+			}
+		})
+	}
+}

--- a/veles/secrets/cohereapikey/validator.go
+++ b/veles/secrets/cohereapikey/validator.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohereapikey
+
+import (
+	"net/http"
+	"time"
+
+	sv "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+const (
+	// Cohere API base URL.
+	cohereAPIBaseURL = "https://api.cohere.com"
+	// Timeout for API validation requests.
+	validationTimeout = 10 * time.Second
+	// ModelsEndpoint is the Cohere API models endpoint.
+	ModelsEndpoint = "/v2/models"
+)
+
+// NewValidator creates a new Validator that validates API keys by making a
+// test request to the Cohere API /v2/models endpoint.
+// Cohere API keys use Bearer token authentication.
+func NewValidator() *sv.Validator[APIKey] {
+	return &sv.Validator[APIKey]{
+		Endpoint:   cohereAPIBaseURL + ModelsEndpoint,
+		HTTPMethod: http.MethodGet,
+		HTTPHeaders: func(k APIKey) map[string]string {
+			return map[string]string{
+				"Authorization": "Bearer " + k.Key,
+			}
+		},
+		ValidResponseCodes:   []int{http.StatusOK, http.StatusTooManyRequests},
+		InvalidResponseCodes: []int{http.StatusUnauthorized, http.StatusForbidden},
+		HTTPC: &http.Client{
+			Timeout: validationTimeout,
+		},
+	}
+}

--- a/veles/secrets/cohereapikey/validator_test.go
+++ b/veles/secrets/cohereapikey/validator_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohereapikey_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/cohereapikey"
+)
+
+const (
+	validatorTestKey = "sk-co-abcdefghijklmnopqrstuvwxyz1234567890abcd"
+)
+
+// mockCohereServer creates a mock Cohere API server for testing.
+func mockCohereServer(t *testing.T, expectedKey string, statusCode int) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		modelsEndpoint := cohereapikey.ModelsEndpoint
+		if r.Method != http.MethodGet || r.URL.Path != modelsEndpoint {
+			t.Errorf("unexpected request: %s %s, expected: GET %s",
+				r.Method, r.URL.Path, modelsEndpoint)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		// Check Bearer token authentication.
+		auth := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + expectedKey
+		if auth != expectedAuth {
+			t.Errorf("expected Authorization: %s, got: %s",
+				expectedAuth, auth)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+	}))
+
+	return server
+}
+
+func TestValidator(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		want       veles.ValidationStatus
+		wantErr    error
+	}{
+		{
+			name:       "valid_key",
+			statusCode: http.StatusOK,
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "invalid_key_unauthorized",
+			statusCode: http.StatusUnauthorized,
+			want:       veles.ValidationInvalid,
+		},
+		{
+			name:       "invalid_key_forbidden",
+			statusCode: http.StatusForbidden,
+			want:       veles.ValidationInvalid,
+		},
+		{
+			name:       "rate_limited_but_likely_valid",
+			statusCode: http.StatusTooManyRequests,
+			want:       veles.ValidationValid,
+		},
+		{
+			name:       "server_error",
+			statusCode: http.StatusInternalServerError,
+			want:       veles.ValidationFailed,
+			wantErr:    cmpopts.AnyError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := mockCohereServer(t, validatorTestKey, tc.statusCode)
+			defer server.Close()
+
+			validator := cohereapikey.NewValidator()
+			validator.HTTPC = server.Client()
+			validator.Endpoint = server.URL + cohereapikey.ModelsEndpoint
+
+			key := cohereapikey.APIKey{Key: validatorTestKey}
+
+			got, err := validator.Validate(t.Context(), key)
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Validate() error mismatch (-want +got):\n%s", diff)
+			}
+
+			if got != tc.want {
+				t.Errorf("Validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds a new Veles secret-scanning plugin for Cohere API keys (prefix `sk-co-` followed by 20-80 alphanumeric characters including underscores and hyphens).

**Detector** (`veles/secrets/cohereapikey`): uses the shared `simpletoken` helper to match `sk-co-[A-Za-z0-9_-]{20,80}`.

**Validator**: confirms liveness via `GET https://api.cohere.com/v2/models` with the key in the `Authorization: Bearer` header - HTTP 200 -> valid, 401/403 -> invalid.

## Changes
- New package `veles/secrets/cohereapikey` (Secret type, detector, validator) with detector and validator unit tests.
- Registered the detector in `extractor/filesystem/list/list.go`.
- Registered the validator in `enricher/enricherlist/list.go`.
- Documented the new type in `docs/supported_inventory_types.md`.

## Testing
- `go build ./...` - passes.
- `go test ./veles/secrets/cohereapikey/...` - all tests pass.
- `gofmt` and `go vet` clean.