### PR TITLE
feat: add pubspec.yaml extractor for Dart projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -73,6 +73,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | project.assets.json                               | `dotnet/projectassetsjson`           |
 | C++        | Conan packages                                    | `cpp/conanlock`                      |
 | Dart       | pubspec.lock                                      | `dart/pubspec`                       |
+|            | pubspec.yaml                                      | `dart/pubspecyaml`                   |
 | Erlang     | mix.lock                                          | `erlang/mixlock`                     |
 | Elixir     | mix.lock                                          | `elixir/mixlock`                     |
 | Gleam      | gleam.toml                                        | `gleam/gleamtoml`                    |

--- a/extractor/filesystem/language/dart/pubspecyaml/pubspec_yaml.go
+++ b/extractor/filesystem/language/dart/pubspecyaml/pubspec_yaml.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pubspecyaml extracts Dart pubspec.yaml manifest files.
+package pubspecyaml
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"gopkg.in/yaml.v3"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "dart/pubspecyaml"
+)
+
+// Extractor extracts Dart packages from pubspec.yaml manifest files.
+type Extractor struct{}
+
+// New returns a new instance of this Extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the specified file is a pubspec.yaml
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "pubspec.yaml"
+}
+
+// Extract extracts Dart packages from pubspec.yaml files passed through the input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	var parsedFile pubspecYAML
+	if err := yaml.NewDecoder(input.Reader).Decode(&parsedFile); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
+	}
+
+	packages := make([]*extractor.Package, 0)
+
+	// Extract dependencies
+	for name, val := range parsedFile.Dependencies {
+		pkg := parsePackage(name, val, false)
+		if pkg != nil {
+			pkg.Location = extractor.LocationFromPath(input.Path)
+			packages = append(packages, pkg)
+		}
+	}
+
+	// Extract dev_dependencies
+	for name, val := range parsedFile.DevDependencies {
+		pkg := parsePackage(name, val, true)
+		if pkg != nil {
+			pkg.Location = extractor.LocationFromPath(input.Path)
+			packages = append(packages, pkg)
+		}
+	}
+
+	// Extract dependency_overrides (not dev dependencies)
+	for name, val := range parsedFile.DependencyOverrides {
+		pkg := parsePackage(name, val, false)
+		if pkg != nil {
+			pkg.Location = extractor.LocationFromPath(input.Path)
+			packages = append(packages, pkg)
+		}
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+// pubspecYAML represents the structure of a pubspec.yaml file.
+type pubspecYAML struct {
+	Dependencies        map[string]any `yaml:"dependencies"`
+	DevDependencies     map[string]any `yaml:"dev_dependencies"`
+	DependencyOverrides map[string]any `yaml:"dependency_overrides"`
+}
+
+// parsePackage converts a pubspec.yaml dependency entry into an extractor.Package.
+// It returns nil if the entry is an SDK dependency (e.g. flutter: sdk: flutter) or
+// a local/git dependency without a version.
+func parsePackage(name string, val any, isDev bool) *extractor.Package {
+	if name == "flutter" {
+		return nil
+	}
+
+	var version string
+	switch v := val.(type) {
+	case string:
+		version = v
+	case map[string]any:
+		if vv, ok := v["version"].(string); ok {
+			version = vv
+		}
+	}
+
+	if version == "" {
+		return nil
+	}
+
+	pkg := &extractor.Package{
+		Name:     name,
+		Version:  version,
+		PURLType: purl.TypePub,
+		Metadata: &osv.DepGroupMetadata{},
+	}
+	if isDev {
+		pkg.Metadata = &osv.DepGroupMetadata{DepGroupVals: []string{"dev"}}
+	}
+	return pkg
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/dart/pubspecyaml/pubspec_yaml_test.go
+++ b/extractor/filesystem/language/dart/pubspecyaml/pubspec_yaml_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubspecyaml_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspecyaml"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "empty path",
+			inputPath: "",
+			want:      false,
+		},
+		{
+			name:      "pubspec.yaml at root",
+			inputPath: "pubspec.yaml",
+			want:      true,
+		},
+		{
+			name:      "pubspec.yaml in nested directory",
+			inputPath: "path/to/my/pubspec.yaml",
+			want:      true,
+		},
+		{
+			name:      "wrong file name",
+			inputPath: "path/to/my/pubspec.yml",
+			want:      false,
+		},
+		{
+			name:      "lockfile not manifest",
+			inputPath: "path/to/my/pubspec.lock",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := pubspecyaml.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("pubspecyaml.New() error: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%s) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "invalid yaml",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/not-yaml.txt",
+			},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
+		},
+		{
+			Name: "empty",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.yaml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "no packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/source-sdk.yaml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "one package",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/one-package.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "http",
+					Version:  "^0.13.5",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/one-package.yaml"),
+					Metadata: &osv.DepGroupMetadata{},
+				},
+			},
+		},
+		{
+			Name: "one package dev",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/one-package-dev.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "build_runner",
+					Version:  "^2.3.0",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/one-package-dev.yaml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+			},
+		},
+		{
+			Name: "mixed packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/mixed-packages.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "analyzer",
+					Version:  "5.0.0",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/mixed-packages.yaml"),
+					Metadata: &osv.DepGroupMetadata{},
+				},
+				{
+					Name:     "build_runner",
+					Version:  "^2.3.0",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/mixed-packages.yaml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				{
+					Name:     "dio",
+					Version:  "5.0.0",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/mixed-packages.yaml"),
+					Metadata: &osv.DepGroupMetadata{},
+				},
+				{
+					Name:     "http",
+					Version:  "^0.13.5",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/mixed-packages.yaml"),
+					Metadata: &osv.DepGroupMetadata{},
+				},
+				{
+					Name:     "mockito",
+					Version:  ">=5.0.0 <6.0.0",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/mixed-packages.yaml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				{
+					Name:     "path_provider",
+					Version:  "2.0.15",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/mixed-packages.yaml"),
+					Metadata: &osv.DepGroupMetadata{},
+				},
+			},
+		},
+		{
+			Name: "package with git source",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/source-git.yaml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := pubspecyaml.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("pubspecyaml.New() error: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/dart/pubspecyaml/testdata/empty.yaml
+++ b/extractor/filesystem/language/dart/pubspecyaml/testdata/empty.yaml
@@ -1,0 +1,2 @@
+name: my_app
+version: 1.0.0

--- a/extractor/filesystem/language/dart/pubspecyaml/testdata/mixed-packages.yaml
+++ b/extractor/filesystem/language/dart/pubspecyaml/testdata/mixed-packages.yaml
@@ -1,0 +1,17 @@
+name: my_app
+version: 1.0.0
+dependencies:
+  http: ^0.13.5
+  path_provider: "2.0.15"
+  dio:
+    version: "5.0.0"
+    hosted:
+      name: dio
+      url: "https://pub.dev"
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  build_runner: ^2.3.0
+  mockito: ">=5.0.0 <6.0.0"
+dependency_overrides:
+  analyzer: "5.0.0"

--- a/extractor/filesystem/language/dart/pubspecyaml/testdata/not-yaml.txt
+++ b/extractor/filesystem/language/dart/pubspecyaml/testdata/not-yaml.txt
@@ -1,0 +1,1 @@
+not a yaml file

--- a/extractor/filesystem/language/dart/pubspecyaml/testdata/one-package-dev.yaml
+++ b/extractor/filesystem/language/dart/pubspecyaml/testdata/one-package-dev.yaml
@@ -1,0 +1,4 @@
+name: my_app
+version: 1.0.0
+dev_dependencies:
+  build_runner: ^2.3.0

--- a/extractor/filesystem/language/dart/pubspecyaml/testdata/one-package.yaml
+++ b/extractor/filesystem/language/dart/pubspecyaml/testdata/one-package.yaml
@@ -1,0 +1,4 @@
+name: my_app
+version: 1.0.0
+dependencies:
+  http: ^0.13.5

--- a/extractor/filesystem/language/dart/pubspecyaml/testdata/source-git.yaml
+++ b/extractor/filesystem/language/dart/pubspecyaml/testdata/source-git.yaml
@@ -1,0 +1,5 @@
+name: my_app
+version: 1.0.0
+dependencies:
+  my_git_dep:
+    git: https://github.com/example/repo.git

--- a/extractor/filesystem/language/dart/pubspecyaml/testdata/source-sdk.yaml
+++ b/extractor/filesystem/language/dart/pubspecyaml/testdata/source-sdk.yaml
@@ -1,0 +1,5 @@
+name: my_app
+version: 1.0.0
+dependencies:
+  flutter:
+    sdk: flutter

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/ffa/unknownbinariesextr"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspec"
+	pubspecyaml "github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspecyaml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/csproj"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/depsjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/dotnetpe"
@@ -250,7 +251,7 @@ var (
 		gobinary.Name: {gobinary.New},
 	}
 	// DartSource extractors for Dart.
-	DartSource = InitMap{pubspec.Name: {pubspec.New}}
+	DartSource = InitMap{pubspec.Name: {pubspec.New}, pubspecyaml.Name: {pubspecyaml.New}}
 	// ErlangSource extractors for Erlang.
 	ErlangSource = InitMap{mixlock.Name: {mixlock.New}}
 	// GleamSource extractors for Gleam.


### PR DESCRIPTION
## Summary

Adds a new OSV-SCALIBR filesystem extractor for Dart `pubspec.yaml` manifest files.

The extractor inventories Dart/Flutter dependencies declared in:

- `dependencies`
- `dev_dependencies`
- `dependency_overrides`

It emits Pub packages using `purl.TypePub`, marks dev dependencies with dependency group metadata, skips SDK/local/git entries without a concrete version string, and registers the extractor in the filesystem extractor list. The supported inventory types documentation is updated as well.

## Validation

- `gofmt -w extractor/filesystem/language/dart/pubspecyaml/pubspec_yaml.go extractor/filesystem/language/dart/pubspecyaml/pubspec_yaml_test.go`
- `git diff --check`
- `go test ./extractor/filesystem/language/dart/pubspecyaml/ -v`
- `go test ./extractor/filesystem/language/dart/...`
- `go test ./extractor/filesystem/list/...`
- `go build ./extractor/filesystem/...`
- `go build ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(Get-Content .golangci-lint-version) run ./extractor/filesystem/language/dart/pubspecyaml/...`