### PR TITLE
feat: add pyproject.toml extractor for Python projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -99,6 +99,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | PHP        | Composer                                          | `php/composerlock`                   |
 | Python     | Installed PyPI packages (global and venv)         | `python/wheelegg`                    |
 |            | requirements.txt                                  | `python/requirements`                |
+|            | pyproject.toml                                    | `python/pyprojecttoml`               |
 |            | poetry.lock                                       | `python/poetrylock`                  |
 |            | Pipfile.lock                                      | `python/pipfilelock`                 |
 |            | pdm.lock                                          | `python/pdmlock`                     |

--- a/extractor/filesystem/language/python/pyprojecttoml/pyproject_toml.go
+++ b/extractor/filesystem/language/python/pyprojecttoml/pyproject_toml.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pyprojecttoml extracts inventory from pyproject.toml Python manifests.
+// Supports PEP 621 [project] dependencies and optional-dependencies.
+package pyprojecttoml
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "python/pyprojecttoml"
+)
+
+// pyprojectTOML represents the parsed pyproject.toml structure.
+// It models the [project] table used by PEP 621 dependencies.
+type pyprojectTOML struct {
+	Project struct {
+		Dependencies         []string            `toml:"dependencies"`
+		OptionalDependencies map[string][]string `toml:"optional-dependencies"`
+	} `toml:"project"`
+}
+
+var (
+	// reStripExtras removes [extras] from package names.
+	reStripExtras = regexp.MustCompile(`\[.*\]`)
+	// reStripMarkers removes ; environment markers from requirement strings.
+	reStripMarkers = regexp.MustCompile(`;.*`)
+	// reStripWhitespace removes all whitespace.
+	reStripWhitespace = regexp.MustCompile(`\s+`)
+	// reVersionConstraint matches version constraints like >=1.0, ==2.0, etc.
+	reVersionConstraint = regexp.MustCompile(`^([a-zA-Z0-9_.-]+)(===|==|~=|>=|<=|>|<|!=)(.*)$`)
+)
+
+// Extractor extracts python packages from pyproject.toml files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the specified file is a pyproject.toml file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "pyproject.toml"
+}
+
+// Extract extracts dependencies from a pyproject.toml file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	content, err := io.ReadAll(input.Reader)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("could not read file: %w", err)
+	}
+
+	var doc pyprojectTOML
+	if err := toml.Unmarshal(content, &doc); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("toml.Unmarshal(%s): %w", input.Path, err)
+	}
+
+	packages := make([]*extractor.Package, 0)
+
+	// Extract main dependencies from [project.dependencies].
+	for _, req := range doc.Project.Dependencies {
+		pkg := parseRequirement(req, "")
+		if pkg != nil {
+			pkg.Location = extractor.LocationFromPath(input.Path)
+			pkg.PURLType = purl.TypePyPi
+			packages = append(packages, pkg)
+		}
+	}
+
+	// Extract optional dependencies from [project.optional-dependencies].
+	for group, reqs := range doc.Project.OptionalDependencies {
+		for _, req := range reqs {
+			pkg := parseRequirement(req, group)
+			if pkg != nil {
+				pkg.Location = extractor.LocationFromPath(input.Path)
+				pkg.PURLType = purl.TypePyPi
+				packages = append(packages, pkg)
+			}
+		}
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+// parseRequirement parses a single PEP 508 requirement string and returns a Package.
+// Returns nil if the requirement should be skipped (e.g., URL dependency).
+func parseRequirement(req string, depGroup string) *extractor.Package {
+	req = strings.TrimSpace(req)
+	if req == "" {
+		return nil
+	}
+
+	// Skip URL dependencies (e.g., "package @ https://...").
+	if strings.Contains(req, "@") {
+		return nil
+	}
+
+	// Strip extras (e.g., "pytest[testing]" -> "pytest").
+	req = reStripExtras.ReplaceAllString(req, "")
+
+	// Strip environment markers (e.g., "requests; python_version >= \"3.8\"").
+	req = reStripMarkers.ReplaceAllString(req, "")
+
+	req = strings.TrimSpace(req)
+
+	name, version := getLowestVersion(req)
+	if name == "" {
+		return nil
+	}
+
+	pkg := &extractor.Package{
+		Name:    name,
+		Version: version,
+	}
+
+	// Set dependency group metadata.
+	if depGroup != "" {
+		groupValue := depGroup
+		if groupValue == "dev" || groupValue == "test" {
+			groupValue = "dev"
+		}
+		pkg.Metadata = &osv.DepGroupMetadata{DepGroupVals: []string{groupValue}}
+	}
+
+	return pkg
+}
+
+// getLowestVersion extracts the package name and version from a PEP 508 requirement string.
+// It returns the name and the lowest version constraint found.
+// If no version is found, returns the name with an empty version string.
+func getLowestVersion(s string) (string, string) {
+	// Normalize: strip all whitespace.
+	s = reStripWhitespace.ReplaceAllString(s, "")
+
+	match := reVersionConstraint.FindStringSubmatch(s)
+	if match == nil {
+		// No version constraint - just a package name.
+		return s, ""
+	}
+
+	name := strings.ToLower(match[1])
+	operator := match[2]
+	version := match[3]
+
+	// Strip any trailing constraints after comma.
+	if idx := strings.Index(version, ","); idx != -1 {
+		version = version[:idx]
+	}
+
+	// For unsupported operators, return name with empty version.
+	if operator == "!=" || operator == "<" || operator == ">" {
+		return name, ""
+	}
+
+	// For ~= compatible release, return as-is.
+	if operator == "~=" {
+		return name, operator + version
+	}
+
+	// For ===, ==, >=, <=, return operator + version.
+	return name, operator + version
+}

--- a/extractor/filesystem/language/python/pyprojecttoml/pyproject_toml_test.go
+++ b/extractor/filesystem/language/python/pyprojecttoml/pyproject_toml_test.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pyprojecttoml_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pyprojecttoml"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "empty",
+			inputPath: "",
+			want:      false,
+		},
+		{
+			name:      "pyproject.toml",
+			inputPath: "pyproject.toml",
+			want:      true,
+		},
+		{
+			name:      "path/to/pyproject.toml",
+			inputPath: "path/to/my/pyproject.toml",
+			want:      true,
+		},
+		{
+			name:      "pyproject.toml/file",
+			inputPath: "path/to/my/pyproject.toml/file",
+			want:      false,
+		},
+		{
+			name:      "pyproject.toml.file",
+			inputPath: "path/to/my/pyproject.toml.file",
+			want:      false,
+		},
+		{
+			name:      "not pyproject.toml",
+			inputPath: "path/to/my/package.json",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := pyprojecttoml.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("pyprojecttoml.New: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%q) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "invalid toml",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/not-toml.txt",
+			},
+			WantErr:      extracttest.ContainsErrStr{Str: "toml.Unmarshal"},
+			WantPackages: nil,
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.toml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "no dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no-deps.toml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "one dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/one-dep.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/one-dep.toml"),
+				},
+			},
+		},
+		{
+			Name: "one optional dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/one-optional.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "pytest",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/one-optional.toml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+			},
+		},
+		{
+			Name: "mixed dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/mixed-deps.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  ">=2.28.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+				},
+				{
+					Name:     "flask",
+					Version:  "==2.3.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+				},
+				{
+					Name:     "numpy",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+				},
+				{
+					Name:     "pytest",
+					Version:  ">=7.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				{
+					Name:     "black",
+					Version:  ">=23.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				{
+					Name:     "coverage",
+					Version:  ">=7.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+			},
+		},
+		{
+			Name: "url dependency skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/url-dep.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  ">=2.28.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/url-dep.toml"),
+				},
+			},
+		},
+		{
+			Name: "extras stripped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/extras.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  ">=2.28.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/extras.toml"),
+				},
+				{
+					Name:     "pytest",
+					Version:  ">=7.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/extras.toml"),
+				},
+			},
+		},
+		{
+			Name: "markers stripped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/markers.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  ">=2.28.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/markers.toml"),
+				},
+				{
+					Name:     "platform-specific-package",
+					Version:  ">=1.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/markers.toml"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := pyprojecttoml.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("pyprojecttoml.New: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/python/pyprojecttoml/testdata/empty.toml
+++ b/extractor/filesystem/language/python/pyprojecttoml/testdata/empty.toml
@@ -1,0 +1,1 @@
+[project]

--- a/extractor/filesystem/language/python/pyprojecttoml/testdata/extras.toml
+++ b/extractor/filesystem/language/python/pyprojecttoml/testdata/extras.toml
@@ -1,0 +1,6 @@
+[project]
+name = "my-project"
+dependencies = [
+    "requests[security]>=2.28.0",
+    "pytest[testing]>=7.0",
+]

--- a/extractor/filesystem/language/python/pyprojecttoml/testdata/markers.toml
+++ b/extractor/filesystem/language/python/pyprojecttoml/testdata/markers.toml
@@ -1,0 +1,6 @@
+[project]
+name = "my-project"
+dependencies = [
+    "requests>=2.28.0 ; python_version >= \"3.8\"",
+    'platform-specific-package>=1.0 ; sys_platform == "win32"',
+]

--- a/extractor/filesystem/language/python/pyprojecttoml/testdata/mixed-deps.toml
+++ b/extractor/filesystem/language/python/pyprojecttoml/testdata/mixed-deps.toml
@@ -1,0 +1,16 @@
+[project]
+name = "my-project"
+dependencies = [
+    "requests>=2.28.0",
+    "flask==2.3.0",
+    "numpy",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "black>=23.0",
+]
+test = [
+    "coverage>=7.0",
+]

--- a/extractor/filesystem/language/python/pyprojecttoml/testdata/no-deps.toml
+++ b/extractor/filesystem/language/python/pyprojecttoml/testdata/no-deps.toml
@@ -1,0 +1,3 @@
+[project]
+name = "my-project"
+version = "1.0.0"

--- a/extractor/filesystem/language/python/pyprojecttoml/testdata/not-toml.txt
+++ b/extractor/filesystem/language/python/pyprojecttoml/testdata/not-toml.txt
@@ -1,0 +1,1 @@
+This is not a TOML file at all.

--- a/extractor/filesystem/language/python/pyprojecttoml/testdata/one-dep.toml
+++ b/extractor/filesystem/language/python/pyprojecttoml/testdata/one-dep.toml
@@ -1,0 +1,5 @@
+[project]
+name = "my-project"
+dependencies = [
+    "requests",
+]

--- a/extractor/filesystem/language/python/pyprojecttoml/testdata/one-optional.toml
+++ b/extractor/filesystem/language/python/pyprojecttoml/testdata/one-optional.toml
@@ -1,0 +1,7 @@
+[project]
+name = "my-project"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]

--- a/extractor/filesystem/language/python/pyprojecttoml/testdata/url-dep.toml
+++ b/extractor/filesystem/language/python/pyprojecttoml/testdata/url-dep.toml
@@ -1,0 +1,6 @@
+[project]
+name = "my-project"
+dependencies = [
+    "requests>=2.28.0",
+    "custom-package @ git+https://github.com/user/custom-package.git@v1.0.0",
+]

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -73,6 +73,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/poetrylock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pylock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pyprojecttoml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/setup"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/uvlock"
@@ -228,14 +229,15 @@ var (
 	// PythonSource extractors for Python.
 	PythonSource = InitMap{
 		// requirements extraction for environments with and without network access.
-		requirements.Name: {requirements.New},
-		setup.Name:        {setup.New},
-		pipfilelock.Name:  {pipfilelock.New},
-		pdmlock.Name:      {pdmlock.New},
-		poetrylock.Name:   {poetrylock.New},
-		pylock.Name:       {pylock.New},
-		condameta.Name:    {condameta.New},
-		uvlock.Name:       {uvlock.New},
+		requirements.Name:  {requirements.New},
+		setup.Name:         {setup.New},
+		pipfilelock.Name:   {pipfilelock.New},
+		pdmlock.Name:       {pdmlock.New},
+		poetrylock.Name:    {poetrylock.New},
+		pylock.Name:        {pylock.New},
+		condameta.Name:     {condameta.New},
+		uvlock.Name:        {uvlock.New},
+		pyprojecttoml.Name: {pyprojecttoml.New},
 	}
 	// PythonArtifact extractors for Python.
 	PythonArtifact = InitMap{

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -52,7 +52,7 @@ func TestExtractorsFromName(t *testing.T) {
 		{
 			desc:     "Find_all_extractors_of_a_type",
 			name:     "python",
-			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/pyprojecttoml", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:     "Nonexistent_plugin",

--- a/plugin/list/list_test.go
+++ b/plugin/list/list_test.go
@@ -131,12 +131,12 @@ func TestFromNames(t *testing.T) {
 		{
 			desc:      "Find_all_Plugins_of_a_type",
 			names:     []string{"python", "windows", "cis", "layerdetails"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/pyprojecttoml", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
 		},
 		{
 			desc:      "Remove_duplicates",
 			names:     []string{"python", "python"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/pyprojecttoml", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:      "Nonexistent_plugin",


### PR DESCRIPTION
## Summary

Adds a new OSV-SCALIBR filesystem extractor for Python `pyproject.toml` manifests.

The extractor inventories PEP 621 dependencies declared in:

- `[project] dependencies`
- `[project] optional-dependencies`

It emits PyPI packages using `purl.TypePyPi`, marks optional `dev` / `test` groups as dev dependency metadata, preserves other optional group names, and skips URL dependencies where a standard package/version cannot be represented safely.

## Validation

- `gofmt -w extractor/filesystem/language/python/pyprojecttoml/pyproject_toml.go extractor/filesystem/language/python/pyprojecttoml/pyproject_toml_test.go`
- `git diff --check`
- `go test ./extractor/filesystem/language/python/pyprojecttoml/ -v`
- `go test ./extractor/filesystem/language/python/...`
- `go test ./extractor/filesystem/list/...`
- `go build ./extractor/filesystem/...`
- `go build ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(Get-Content .golangci-lint-version) run ./extractor/filesystem/language/python/pyprojecttoml/...`
- Verified final newline on all new testdata files.