### PR TITLE
feat: add conanfile.txt extractor for C++ projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -72,6 +72,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Microsoft Build Engine (MSBuild) project files    | `dotnet/csproj`                      |
 |            | project.assets.json                               | `dotnet/projectassetsjson`           |
 | C++        | Conan packages                                    | `cpp/conanlock`                      |
+|            | conanfile.txt                                     | `cpp/conanfiletxt`                   |
 | Dart       | pubspec.lock                                      | `dart/pubspec`                       |
 | Erlang     | mix.lock                                          | `erlang/mixlock`                     |
 | Elixir     | mix.lock                                          | `elixir/mixlock`                     |

--- a/extractor/filesystem/language/cpp/conanfiletxt/conanfile_txt.go
+++ b/extractor/filesystem/language/cpp/conanfiletxt/conanfile_txt.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package conanfiletxt extracts inventory from conanfile.txt Conan manifests.
+package conanfiletxt
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "cpp/conanfiletxt"
+)
+
+// conanReference represents a parsed Conan package reference.
+// Format: name/version[@username[/channel]][#rrev]
+type conanReference struct {
+	Name    string
+	Version string
+}
+
+// Extractor extracts Conan packages from conanfile.txt files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the specified file is a conanfile.txt file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "conanfile.txt"
+}
+
+// Extract extracts dependencies from a conanfile.txt file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	packages := make([]*extractor.Package, 0)
+
+	scanner := bufio.NewScanner(input.Reader)
+	currentSection := ""
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments.
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+
+		// Section headers.
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			currentSection = strings.ToLower(line[1 : len(line)-1])
+			continue
+		}
+
+		// Parse dependencies from relevant sections.
+		if currentSection == "requires" || currentSection == "tool_requires" {
+			ref := parseConanReference(line)
+			if ref.Name != "" {
+				group := "requires"
+				if currentSection == "tool_requires" {
+					group = "tool-requires"
+				}
+				packages = append(packages, &extractor.Package{
+					Name:     ref.Name,
+					Version:  ref.Version,
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath(input.Path),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{group},
+					},
+				})
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("could not read file: %w", err)
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+// parseConanReference parses a Conan reference string into a conanReference.
+// Format: name/version[@username[/channel]][#rrev][:pkgid[#prev]][%timestamp]
+// We extract name and version only. References with no name are skipped.
+func parseConanReference(ref string) conanReference {
+	var result conanReference
+
+	// Strip timestamp.
+	if idx := strings.Index(ref, "%"); idx != -1 {
+		ref = ref[:idx]
+	}
+
+	// Strip package ID and package revision.
+	if idx := strings.Index(ref, ":"); idx != -1 {
+		ref = ref[:idx]
+	}
+
+	// Strip recipe revision.
+	if idx := strings.Index(ref, "#"); idx != -1 {
+		ref = ref[:idx]
+	}
+
+	// Strip user/channel.
+	if idx := strings.Index(ref, "@"); idx != -1 {
+		ref = ref[:idx]
+	}
+
+	// Split name and version.
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) == 2 {
+		result.Name = parts[0]
+		result.Version = parts[1]
+	} else {
+		// If no slash, treat the whole thing as a name with no version.
+		result.Name = ref
+	}
+
+	return result
+}

--- a/extractor/filesystem/language/cpp/conanfiletxt/conanfile_txt_test.go
+++ b/extractor/filesystem/language/cpp/conanfiletxt/conanfile_txt_test.go
@@ -1,0 +1,343 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conanfiletxt_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanfiletxt"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "empty",
+			inputPath: "",
+			want:      false,
+		},
+		{
+			name:      "conanfile.txt",
+			inputPath: "conanfile.txt",
+			want:      true,
+		},
+		{
+			name:      "path/to/conanfile.txt",
+			inputPath: "path/to/my/conanfile.txt",
+			want:      true,
+		},
+		{
+			name:      "conanfile.txt/file",
+			inputPath: "path/to/my/conanfile.txt/file",
+			want:      false,
+		},
+		{
+			name:      "conanfile.txt.file",
+			inputPath: "path/to/my/conanfile.txt.file",
+			want:      false,
+		},
+		{
+			name:      "not conanfile.txt",
+			inputPath: "path/to/my/package.json",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := conanfiletxt.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("conanfiletxt.New: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%q) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.txt",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "no dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no-deps.txt",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "one dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/one-dep.txt",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "zlib",
+					Version:  "1.2.11",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/one-dep.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+			},
+		},
+		{
+			Name: "multiple dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/multi-deps.txt",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "poco",
+					Version:  "1.9.4",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/multi-deps.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "zlib",
+					Version:  "1.2.11",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/multi-deps.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "boost",
+					Version:  "1.70.0",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/multi-deps.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+			},
+		},
+		{
+			Name: "comments skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/comments.txt",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "zlib",
+					Version:  "1.2.11",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/comments.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "poco",
+					Version:  "1.9.4",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/comments.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "boost",
+					Version:  "1.70.0",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/comments.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+			},
+		},
+		{
+			Name: "with channels stripped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/with-channels.txt",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "zlib",
+					Version:  "1.2.11",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/with-channels.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "poco",
+					Version:  "1.9.4",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/with-channels.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "boost",
+					Version:  "1.70.0",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/with-channels.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+			},
+		},
+		{
+			Name: "mixed sections",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/mixed-sections.txt",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "zlib",
+					Version:  "1.2.11",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/mixed-sections.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "cmake",
+					Version:  "3.23.0",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/mixed-sections.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"tool-requires"},
+					},
+				},
+				{
+					Name:     "7zip",
+					Version:  "16.00",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/mixed-sections.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"tool-requires"},
+					},
+				},
+			},
+		},
+		{
+			Name: "with revisions stripped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/with-revisions.txt",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "zlib",
+					Version:  "1.2.11",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/with-revisions.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "boost",
+					Version:  "1.70.0",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/with-revisions.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "poco",
+					Version:  "1.9.4",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/with-revisions.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+			},
+		},
+		{
+			Name: "version ranges preserved",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/version-ranges.txt",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "poco",
+					Version:  "[>1.0 <1.9]",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/version-ranges.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+				{
+					Name:     "zlib",
+					Version:  "1.2.11",
+					PURLType: purl.TypeConan,
+					Location: extractor.LocationFromPath("testdata/version-ranges.txt"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"requires"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := conanfiletxt.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("conanfiletxt.New: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/cpp/conanfiletxt/testdata/comments.txt
+++ b/extractor/filesystem/language/cpp/conanfiletxt/testdata/comments.txt
@@ -1,0 +1,8 @@
+[requires]
+# This is a comment
+zlib/1.2.11
+
+; This is also a comment
+poco/1.9.4
+
+boost/1.70.0

--- a/extractor/filesystem/language/cpp/conanfiletxt/testdata/empty.txt
+++ b/extractor/filesystem/language/cpp/conanfiletxt/testdata/empty.txt
@@ -1,0 +1,1 @@
+[requires]

--- a/extractor/filesystem/language/cpp/conanfiletxt/testdata/mixed-sections.txt
+++ b/extractor/filesystem/language/cpp/conanfiletxt/testdata/mixed-sections.txt
@@ -1,0 +1,6 @@
+[requires]
+zlib/1.2.11
+
+[tool_requires]
+cmake/3.23.0
+7zip/16.00

--- a/extractor/filesystem/language/cpp/conanfiletxt/testdata/multi-deps.txt
+++ b/extractor/filesystem/language/cpp/conanfiletxt/testdata/multi-deps.txt
@@ -1,0 +1,4 @@
+[requires]
+poco/1.9.4
+zlib/1.2.11
+boost/1.70.0

--- a/extractor/filesystem/language/cpp/conanfiletxt/testdata/no-deps.txt
+++ b/extractor/filesystem/language/cpp/conanfiletxt/testdata/no-deps.txt
@@ -1,0 +1,6 @@
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[options]
+openssl/*:shared=True

--- a/extractor/filesystem/language/cpp/conanfiletxt/testdata/one-dep.txt
+++ b/extractor/filesystem/language/cpp/conanfiletxt/testdata/one-dep.txt
@@ -1,0 +1,2 @@
+[requires]
+zlib/1.2.11

--- a/extractor/filesystem/language/cpp/conanfiletxt/testdata/version-ranges.txt
+++ b/extractor/filesystem/language/cpp/conanfiletxt/testdata/version-ranges.txt
@@ -1,0 +1,3 @@
+[requires]
+poco/[>1.0 <1.9]
+zlib/1.2.11

--- a/extractor/filesystem/language/cpp/conanfiletxt/testdata/with-channels.txt
+++ b/extractor/filesystem/language/cpp/conanfiletxt/testdata/with-channels.txt
@@ -1,0 +1,5 @@
+[requires]
+
+zlib/1.2.11@conan/stable
+poco/1.9.4@user/channel
+boost/1.70.0

--- a/extractor/filesystem/language/cpp/conanfiletxt/testdata/with-revisions.txt
+++ b/extractor/filesystem/language/cpp/conanfiletxt/testdata/with-revisions.txt
@@ -1,0 +1,4 @@
+[requires]
+zlib/1.2.11#revision1
+boost/1.70.0#revision2
+poco/1.9.4

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/vdi"
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/vmdk"
 	"github.com/google/osv-scalibr/extractor/filesystem/ffa/unknownbinariesextr"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanfiletxt"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspec"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/csproj"
@@ -198,7 +199,10 @@ var (
 	// Language extractors.
 
 	// CppSource extractors for C++.
-	CppSource = InitMap{conanlock.Name: {conanlock.New}}
+	CppSource = InitMap{
+		conanlock.Name:    {conanlock.New},
+		conanfiletxt.Name: {conanfiletxt.New},
+	}
 	// JavaSource extractors for Java.
 	JavaSource = InitMap{
 		gradlelockfile.Name:                {gradlelockfile.New},


### PR DESCRIPTION
## Summary
- add a `cpp/conanfiletxt` inventory extractor for Conan `conanfile.txt` manifests
- parse `[requires]` and `[tool_requires]` package references into Conan PURLs
- register the extractor and document the supported inventory type

## Tests
- `go test ./extractor/filesystem/language/cpp/conanfiletxt/ -v`
- `go test ./extractor/filesystem/language/cpp/...`
- `go test ./extractor/filesystem/list/...`
- `go test ./plugin/list/...`
- `go build ./extractor/filesystem/...`
- `go build ./...`
- `go vet ./extractor/filesystem/language/cpp/conanfiletxt/`
- `git diff --check`