### PR TITLE
feat: add Pipfile extractor for Python projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -99,6 +99,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | PHP        | Composer                                          | `php/composerlock`                   |
 | Python     | Installed PyPI packages (global and venv)         | `python/wheelegg`                    |
 |            | requirements.txt                                  | `python/requirements`                |
+|            | Pipfile                                           | `python/pipfile`                    |
 |            | poetry.lock                                       | `python/poetrylock`                  |
 |            | Pipfile.lock                                      | `python/pipfilelock`                 |
 |            | pdm.lock                                          | `python/pdmlock`                     |

--- a/extractor/filesystem/language/python/pipfile/pipfile.go
+++ b/extractor/filesystem/language/python/pipfile/pipfile.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pipfile extracts inventory from Pipfile Python manifests.
+package pipfile
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/log"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "python/pipfile"
+)
+
+// pipfile represents the parsed Pipfile structure.
+// We only care about the [packages] and [dev-packages] tables.
+type pipfile struct {
+	Packages    map[string]any `toml:"packages"`
+	DevPackages map[string]any `toml:"dev-packages"`
+}
+
+// Extractor extracts python packages from Pipfile files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the specified file is a Pipfile.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "Pipfile"
+}
+
+// Extract extracts dependencies from a Pipfile.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	content, err := io.ReadAll(input.Reader)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("could not read file: %w", err)
+	}
+
+	var doc pipfile
+	if err := toml.Unmarshal(content, &doc); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("toml.Unmarshal(%s): %w", input.Path, err)
+	}
+
+	packages := make([]*extractor.Package, 0)
+
+	// Extract packages from [packages].
+	for name, details := range doc.Packages {
+		pkg := parseDependency(name, details, "")
+		if pkg != nil {
+			pkg.Location = extractor.LocationFromPath(input.Path)
+			pkg.PURLType = purl.TypePyPi
+			packages = append(packages, pkg)
+		}
+	}
+
+	// Extract packages from [dev-packages].
+	for name, details := range doc.DevPackages {
+		pkg := parseDependency(name, details, "dev")
+		if pkg != nil {
+			pkg.Location = extractor.LocationFromPath(input.Path)
+			pkg.PURLType = purl.TypePyPi
+			packages = append(packages, pkg)
+		}
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+// parseDependency parses a single dependency entry from a Pipfile.
+// Returns nil if the dependency should be skipped (e.g., git, path, editable).
+func parseDependency(name string, details any, depGroup string) *extractor.Package {
+	version, ok := extractVersionConstraint(name, details)
+	if !ok {
+		return nil
+	}
+
+	// "*" means any version — treat as empty version string.
+	if version == "*" {
+		version = ""
+	} else {
+		version = normalizeVersionConstraint(version)
+	}
+
+	pkg := &extractor.Package{
+		Name:    name,
+		Version: version,
+	}
+
+	if depGroup != "" {
+		pkg.Metadata = &osv.DepGroupMetadata{
+			DepGroupVals: []string{depGroup},
+		}
+	}
+
+	return pkg
+}
+
+// extractVersionConstraint parses a single dependency entry from a Pipfile.
+// It returns the version constraint string and a boolean indicating if parsing was successful.
+// It skips over non-version dependencies like git, path, file, or editable references.
+func extractVersionConstraint(name string, details any) (string, bool) {
+	switch v := details.(type) {
+	case string:
+		return v, true
+	case map[string]any:
+		if vs, ok := v["version"].(string); ok {
+			return vs, true
+		} else if _, ok := v["git"]; ok {
+			log.Infof("Skipping git dependency in Pipfile for package %q", name)
+			return "", false
+		} else if _, ok := v["path"]; ok {
+			log.Infof("Skipping path dependency in Pipfile for package %q", name)
+			return "", false
+		} else if _, ok := v["file"]; ok {
+			log.Infof("Skipping file dependency in Pipfile for package %q", name)
+			return "", false
+		} else if _, ok := v["editable"]; ok {
+			log.Infof("Skipping editable dependency in Pipfile for package %q", name)
+			return "", false
+		}
+	default:
+		log.Warnf("Unsupported dependency format in Pipfile for package %q", name)
+		return "", false
+	}
+
+	return "", false
+}
+
+func normalizeVersionConstraint(version string) string {
+	version = strings.TrimSpace(version)
+	for _, sep := range []string{"===", "==", ">=", "<=", "~="} {
+		if v, ok := strings.CutPrefix(version, sep); ok {
+			return strings.TrimSpace(v)
+		}
+	}
+	return version
+}

--- a/extractor/filesystem/language/python/pipfile/pipfile_test.go
+++ b/extractor/filesystem/language/python/pipfile/pipfile_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipfile_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfile"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "empty",
+			inputPath: "",
+			want:      false,
+		},
+		{
+			name:      "Pipfile",
+			inputPath: "Pipfile",
+			want:      true,
+		},
+		{
+			name:      "path/to/Pipfile",
+			inputPath: "path/to/my/Pipfile",
+			want:      true,
+		},
+		{
+			name:      "Pipfile/file",
+			inputPath: "path/to/my/Pipfile/file",
+			want:      false,
+		},
+		{
+			name:      "Pipfile.lock",
+			inputPath: "path/to/my/Pipfile.lock",
+			want:      false,
+		},
+		{
+			name:      "not Pipfile",
+			inputPath: "path/to/my/package.json",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := pipfile.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("pipfile.New: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%q) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "invalid toml",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/not-toml.txt",
+			},
+			WantErr:      extracttest.ContainsErrStr{Str: "toml.Unmarshal"},
+			WantPackages: nil,
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.toml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "no dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no-deps.toml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "one dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/one-dep.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/one-dep.toml"),
+				},
+			},
+		},
+		{
+			Name: "multiple dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/multi-deps.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/multi-deps.toml"),
+				},
+				{
+					Name:     "flask",
+					Version:  "2.3.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/multi-deps.toml"),
+				},
+				{
+					Name:     "django",
+					Version:  "4.2",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/multi-deps.toml"),
+				},
+			},
+		},
+		{
+			Name: "dev packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/dev-packages.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "pytest",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/dev-packages.toml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				{
+					Name:     "black",
+					Version:  "23.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/dev-packages.toml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+			},
+		},
+		{
+			Name: "mixed deps and dev packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/mixed-deps.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+				},
+				{
+					Name:     "flask",
+					Version:  "2.3.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+				},
+				{
+					Name:     "pytest",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				{
+					Name:     "black",
+					Version:  "23.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/mixed-deps.toml"),
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+			},
+		},
+		{
+			Name: "skip git dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/skip-git.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/skip-git.toml"),
+				},
+			},
+		},
+		{
+			Name: "skip path dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/skip-path.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/skip-path.toml"),
+				},
+			},
+		},
+		{
+			Name: "table version specification",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/table-version.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "2.31.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/table-version.toml"),
+				},
+				{
+					Name:     "flask",
+					Version:  "2.3.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/table-version.toml"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := pipfile.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("pipfile.New: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/python/pipfile/testdata/dev-packages.toml
+++ b/extractor/filesystem/language/python/pipfile/testdata/dev-packages.toml
@@ -1,0 +1,3 @@
+[dev-packages]
+pytest = "*"
+black = ">=23.0"

--- a/extractor/filesystem/language/python/pipfile/testdata/empty.toml
+++ b/extractor/filesystem/language/python/pipfile/testdata/empty.toml
@@ -1,0 +1,4 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"

--- a/extractor/filesystem/language/python/pipfile/testdata/mixed-deps.toml
+++ b/extractor/filesystem/language/python/pipfile/testdata/mixed-deps.toml
@@ -1,0 +1,7 @@
+[packages]
+requests = "*"
+flask = "==2.3.0"
+
+[dev-packages]
+pytest = "*"
+black = ">=23.0"

--- a/extractor/filesystem/language/python/pipfile/testdata/multi-deps.toml
+++ b/extractor/filesystem/language/python/pipfile/testdata/multi-deps.toml
@@ -1,0 +1,4 @@
+[packages]
+requests = "*"
+flask = "==2.3.0"
+django = ">=4.2"

--- a/extractor/filesystem/language/python/pipfile/testdata/no-deps.toml
+++ b/extractor/filesystem/language/python/pipfile/testdata/no-deps.toml
@@ -1,0 +1,2 @@
+[requires]
+python_version = "3.8"

--- a/extractor/filesystem/language/python/pipfile/testdata/not-toml.txt
+++ b/extractor/filesystem/language/python/pipfile/testdata/not-toml.txt
@@ -1,0 +1,1 @@
+This is not a TOML file at all.

--- a/extractor/filesystem/language/python/pipfile/testdata/one-dep.toml
+++ b/extractor/filesystem/language/python/pipfile/testdata/one-dep.toml
@@ -1,0 +1,2 @@
+[packages]
+requests = "*"

--- a/extractor/filesystem/language/python/pipfile/testdata/skip-git.toml
+++ b/extractor/filesystem/language/python/pipfile/testdata/skip-git.toml
@@ -1,0 +1,3 @@
+[packages]
+requests = "*"
+private = {git = "https://github.com/user/private.git", ref = "main"}

--- a/extractor/filesystem/language/python/pipfile/testdata/skip-path.toml
+++ b/extractor/filesystem/language/python/pipfile/testdata/skip-path.toml
@@ -1,0 +1,3 @@
+[packages]
+requests = "*"
+my-lib = {path = "../my-lib"}

--- a/extractor/filesystem/language/python/pipfile/testdata/table-version.toml
+++ b/extractor/filesystem/language/python/pipfile/testdata/table-version.toml
@@ -1,0 +1,3 @@
+[packages]
+requests = {version = ">=2.31.0", extras = ["security"]}
+flask = "==2.3.0"

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -70,6 +70,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condameta"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/poetrylock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pylock"
@@ -230,6 +231,7 @@ var (
 		// requirements extraction for environments with and without network access.
 		requirements.Name: {requirements.New},
 		setup.Name:        {setup.New},
+		pipfile.Name:      {pipfile.New},
 		pipfilelock.Name:  {pipfilelock.New},
 		pdmlock.Name:      {pdmlock.New},
 		poetrylock.Name:   {poetrylock.New},

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -52,7 +52,7 @@ func TestExtractorsFromName(t *testing.T) {
 		{
 			desc:     "Find_all_extractors_of_a_type",
 			name:     "python",
-			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantExts: []string{"python/pdmlock", "python/pipfile", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:     "Nonexistent_plugin",

--- a/plugin/list/list_test.go
+++ b/plugin/list/list_test.go
@@ -131,12 +131,12 @@ func TestFromNames(t *testing.T) {
 		{
 			desc:      "Find_all_Plugins_of_a_type",
 			names:     []string{"python", "windows", "cis", "layerdetails"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
+			wantNames: []string{"python/pdmlock", "python/pipfile", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
 		},
 		{
 			desc:      "Remove_duplicates",
 			names:     []string{"python", "python"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantNames: []string{"python/pdmlock", "python/pipfile", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:      "Nonexistent_plugin",


### PR DESCRIPTION
## Summary
- add a `python/pipfile` inventory extractor for Pipenv `Pipfile` manifests
- parse `[packages]` and `[dev-packages]`, including string and table dependency forms
- register the extractor, update plugin/list expectations, and document the supported inventory type

## Tests
- `go test ./extractor/filesystem/language/python/pipfile/ -v`
- `go test ./extractor/filesystem/language/python/...`
- `go test ./extractor/filesystem/list/...`
- `go test ./plugin/list/...`
- `go build ./extractor/filesystem/...`
- `go build ./...`
- `go vet ./extractor/filesystem/language/python/pipfile/`
- `git diff --check`

Local `golangci-lint` was not installed in this workspace.