### PR TITLE
feat: add package.yaml extractor for Haskell projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -79,6 +79,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Go         | Go binaries                                       | `go/binary`                          |
 |            | go.mod (OSV)                                      | `go/gomod`                           |
 | Haskell    | stack.yaml.lock                                   | `haskell/stacklock`                  |
+|            | package.yaml                                      | `haskell/packageyaml`                |
 |            | cabal.project.freeze                              | `haskell/cabal`                      |
 | Java       | Java archives                                     | `java/archive`                       |
 |            | pom.xml                                           | `java/pomxml`                        |

--- a/extractor/filesystem/language/haskell/packageyaml/packageyaml.go
+++ b/extractor/filesystem/language/haskell/packageyaml/packageyaml.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package packageyaml extracts inventory from package.yaml Haskell manifests.
+package packageyaml
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	"gopkg.in/yaml.v3"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "haskell/packageyaml"
+)
+
+// Extractor extracts Haskell packages from package.yaml files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the specified file is a package.yaml file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "package.yaml"
+}
+
+// Extract extracts dependencies from a package.yaml file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	content, err := io.ReadAll(input.Reader)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("could not read file: %w", err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("yaml.Unmarshal(%s): %w", input.Path, err)
+	}
+
+	packages := make([]*extractor.Package, 0)
+	seen := map[string]bool{}
+	collectDependencies(&doc, input.Path, seen, &packages)
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+func collectDependencies(node *yaml.Node, path string, seen map[string]bool, packages *[]*extractor.Package) {
+	if node == nil {
+		return
+	}
+	if node.Kind != yaml.MappingNode {
+		for _, child := range node.Content {
+			collectDependencies(child, path, seen, packages)
+		}
+		return
+	}
+
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+		if key.Value == "dependencies" {
+			parseDependencyNode(value, path, seen, packages)
+			continue
+		}
+		collectDependencies(value, path, seen, packages)
+	}
+}
+
+func parseDependencyNode(node *yaml.Node, path string, seen map[string]bool, packages *[]*extractor.Package) {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			if item.Kind == yaml.ScalarNode {
+				name, version := parseDependencyString(item.Value)
+				addPackage(name, version, path, seen, packages)
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			name := node.Content[i].Value
+			version := ""
+			if node.Content[i+1].Kind == yaml.ScalarNode {
+				version = strings.TrimSpace(node.Content[i+1].Value)
+			}
+			addPackage(name, version, path, seen, packages)
+		}
+	}
+}
+
+func addPackage(name, version, path string, seen map[string]bool, packages *[]*extractor.Package) {
+	name = strings.TrimSpace(name)
+	version = strings.TrimSpace(version)
+	if name == "" {
+		return
+	}
+	key := name + "\x00" + version
+	if seen[key] {
+		return
+	}
+	seen[key] = true
+	*packages = append(*packages, &extractor.Package{
+		Name:     name,
+		Version:  version,
+		PURLType: purl.TypeHaskell,
+		Location: extractor.LocationFromPath(path),
+	})
+}
+
+// parseDependencyString parses a dependency string like "base >= 4.14" or "aeson".
+// Returns the package name and version constraint.
+func parseDependencyString(s string) (string, string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+
+	// Split on first space to separate name from version constraint.
+	idx := strings.IndexFunc(s, func(r rune) bool {
+		return r == ' ' || r == '\t'
+	})
+	if idx == -1 {
+		return s, ""
+	}
+
+	name := strings.TrimSpace(s[:idx])
+	version := strings.TrimSpace(s[idx:])
+
+	return name, version
+}

--- a/extractor/filesystem/language/haskell/packageyaml/packageyaml_test.go
+++ b/extractor/filesystem/language/haskell/packageyaml/packageyaml_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packageyaml_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/packageyaml"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "empty",
+			inputPath: "",
+			want:      false,
+		},
+		{
+			name:      "package.yaml",
+			inputPath: "package.yaml",
+			want:      true,
+		},
+		{
+			name:      "path/to/package.yaml",
+			inputPath: "path/to/my/package.yaml",
+			want:      true,
+		},
+		{
+			name:      "package.yaml/file",
+			inputPath: "path/to/my/package.yaml/file",
+			want:      false,
+		},
+		{
+			name:      "package.yml",
+			inputPath: "path/to/my/package.yml",
+			want:      false,
+		},
+		{
+			name:      "not package.yaml",
+			inputPath: "path/to/my/package.json",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := packageyaml.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("packageyaml.New: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%q) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "invalid yaml",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/not-yaml.txt",
+			},
+			WantErr:      extracttest.ContainsErrStr{Str: "yaml.Unmarshal"},
+			WantPackages: nil,
+		},
+		{
+			Name: "no dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no-deps.yaml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "empty list",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty-list.yaml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "empty map",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty-map.yaml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "one dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/one-dep.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "base",
+					Version:  "",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/one-dep.yaml"),
+				},
+			},
+		},
+		{
+			Name: "list dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/list-deps.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "base",
+					Version:  ">= 4.14 && < 5",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/list-deps.yaml"),
+				},
+				{
+					Name:     "aeson",
+					Version:  ">= 2.0",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/list-deps.yaml"),
+				},
+				{
+					Name:     "bytestring",
+					Version:  "",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/list-deps.yaml"),
+				},
+			},
+		},
+		{
+			Name: "map dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/map-deps.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "base",
+					Version:  ">= 4.14 && < 5",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/map-deps.yaml"),
+				},
+				{
+					Name:     "aeson",
+					Version:  ">= 2.0",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/map-deps.yaml"),
+				},
+				{
+					Name:     "bytestring",
+					Version:  "",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/map-deps.yaml"),
+				},
+			},
+		},
+		{
+			Name: "component dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/component-deps.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "base",
+					Version:  ">= 4.14 && < 5",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/component-deps.yaml"),
+				},
+				{
+					Name:     "text",
+					Version:  ">= 2.0",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/component-deps.yaml"),
+				},
+				{
+					Name:     "aeson",
+					Version:  ">= 2.0",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/component-deps.yaml"),
+				},
+				{
+					Name:     "hspec",
+					Version:  ">= 2.10",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/component-deps.yaml"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := packageyaml.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("packageyaml.New: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/haskell/packageyaml/testdata/component-deps.yaml
+++ b/extractor/filesystem/language/haskell/packageyaml/testdata/component-deps.yaml
@@ -1,0 +1,15 @@
+name: my-package
+version: 0.1.0.0
+dependencies:
+  - base >= 4.14 && < 5
+library:
+  dependencies:
+    - text >= 2.0
+executables:
+  my-tool:
+    dependencies:
+      aeson: ">= 2.0"
+tests:
+  my-test:
+    dependencies:
+      - hspec >= 2.10

--- a/extractor/filesystem/language/haskell/packageyaml/testdata/empty-list.yaml
+++ b/extractor/filesystem/language/haskell/packageyaml/testdata/empty-list.yaml
@@ -1,0 +1,3 @@
+name: my-package
+version: 0.1.0.0
+dependencies: []

--- a/extractor/filesystem/language/haskell/packageyaml/testdata/empty-map.yaml
+++ b/extractor/filesystem/language/haskell/packageyaml/testdata/empty-map.yaml
@@ -1,0 +1,3 @@
+name: my-package
+version: 0.1.0.0
+dependencies: {}

--- a/extractor/filesystem/language/haskell/packageyaml/testdata/list-deps.yaml
+++ b/extractor/filesystem/language/haskell/packageyaml/testdata/list-deps.yaml
@@ -1,0 +1,6 @@
+name: my-package
+version: 0.1.0.0
+dependencies:
+  - base >= 4.14 && < 5
+  - aeson >= 2.0
+  - bytestring

--- a/extractor/filesystem/language/haskell/packageyaml/testdata/map-deps.yaml
+++ b/extractor/filesystem/language/haskell/packageyaml/testdata/map-deps.yaml
@@ -1,0 +1,6 @@
+name: my-package
+version: 0.1.0.0
+dependencies:
+  base: ">= 4.14 && < 5"
+  aeson: ">= 2.0"
+  bytestring: ""

--- a/extractor/filesystem/language/haskell/packageyaml/testdata/no-deps.yaml
+++ b/extractor/filesystem/language/haskell/packageyaml/testdata/no-deps.yaml
@@ -1,0 +1,2 @@
+name: my-package
+version: 0.1.0.0

--- a/extractor/filesystem/language/haskell/packageyaml/testdata/not-yaml.txt
+++ b/extractor/filesystem/language/haskell/packageyaml/testdata/not-yaml.txt
@@ -1,0 +1,1 @@
+dependencies: [

--- a/extractor/filesystem/language/haskell/packageyaml/testdata/one-dep.yaml
+++ b/extractor/filesystem/language/haskell/packageyaml/testdata/one-dep.yaml
@@ -1,0 +1,4 @@
+name: my-package
+version: 0.1.0.0
+dependencies:
+  - base

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -48,6 +48,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gobinary"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/cabal"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/packageyaml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/stacklock"
 	javaarchive "github.com/google/osv-scalibr/extractor/filesystem/language/java/archive"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradlelockfile"
@@ -265,8 +266,9 @@ var (
 	ElixirSource = InitMap{elixir.Name: {elixir.New}}
 	// HaskellSource extractors for Haskell.
 	HaskellSource = InitMap{
-		stacklock.Name: {stacklock.New},
-		cabal.Name:     {cabal.New},
+		stacklock.Name:   {stacklock.New},
+		cabal.Name:       {cabal.New},
+		packageyaml.Name: {packageyaml.New},
 	}
 	// RSource extractors for R source extractors
 	RSource = InitMap{renvlock.Name: {renvlock.New}}


### PR DESCRIPTION
## Summary
- add a `haskell/packageyaml` inventory extractor for hpack `package.yaml` manifests
- collect dependencies from top-level and component-level `dependencies` sections
- register the extractor and document the supported inventory type

## Tests
- `go test ./extractor/filesystem/language/haskell/packageyaml/ -v`
- `go test ./extractor/filesystem/language/haskell/...`
- `go test ./extractor/filesystem/list/...`
- `go test ./plugin/list/...`
- `go build ./extractor/filesystem/...`
- `go build ./...`
- `go vet ./extractor/filesystem/language/haskell/packageyaml/`
- `git diff --check`

Local `golangci-lint` was not installed in this workspace.