### PR TITLE
feat: add cpanfile extractor for Perl projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -115,6 +115,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Package.resolved                                  | `swift/packageresolved`              |
 | Nim        | Nimble packages                                   | `nim/nimble`                         |
 | Perl       | Perl CPAN packages                                | `perl/cpan`                          |
+|            | cpanfile                                         | `perl/cpanfile`                      |
 
 ### Language runtime managers
 

--- a/extractor/filesystem/language/perl/cpanfile/cpanfile.go
+++ b/extractor/filesystem/language/perl/cpanfile/cpanfile.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cpanfile extracts CPAN dependency declarations from cpanfile manifests.
+package cpanfile
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "perl/cpanfile"
+)
+
+var (
+	// reSingleQuoteDep matches dependency declarations using single quotes.
+	reSingleQuoteDep = regexp.MustCompile(`^\s*(requires|test_requires|configure_requires|build_requires|recommends|suggests)\s+'([^']+)'(?:\s*,\s*'([^']+)')?\s*;`)
+	// reDoubleQuoteDep matches dependency declarations using double quotes.
+	reDoubleQuoteDep = regexp.MustCompile(`^\s*(requires|test_requires|configure_requires|build_requires|recommends|suggests)\s+"([^"]+)"(?:\s*,\s*"([^"]+)")?\s*;`)
+)
+
+// Extractor extracts CPAN dependency declarations from cpanfile manifests.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file matches a cpanfile.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "cpanfile"
+}
+
+// Extract extracts CPAN dependency declarations from cpanfile files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	s := bufio.NewScanner(input.Reader)
+	packages := make([]*extractor.Package, 0)
+	lineNumber := 0
+	blockDepth := 0
+
+	for s.Scan() {
+		lineNumber++
+		if err := ctx.Err(); err != nil {
+			return inventory.Inventory{}, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
+		}
+
+		rawLine := s.Text()
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Strip comments for brace counting.
+		stripped := stripComment(rawLine)
+		// Track block depth to skip dynamic blocks (sub, on, if, feature, etc.).
+		blockDepth += countBraces(stripped, '{')
+		blockDepth -= countBraces(stripped, '}')
+		if blockDepth < 0 {
+			blockDepth = 0
+		}
+		if blockDepth > 0 {
+			continue
+		}
+		// Skip lines that start with block keywords.
+		if isBlockStart(line) {
+			continue
+		}
+
+		pkg := parseLine(line, input.Path, lineNumber)
+		if pkg != nil {
+			packages = append(packages, pkg)
+		}
+	}
+
+	if err := s.Err(); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("error while scanning cpanfile: %w", err)
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+func stripComment(line string) string {
+	if before, _, ok := strings.Cut(line, "#"); ok {
+		return before
+	}
+	return line
+}
+
+func countBraces(s string, ch byte) int {
+	inSingleQuote := false
+	inDoubleQuote := false
+	count := 0
+	for i := range len(s) {
+		c := s[i]
+		if c == '\'' && !inDoubleQuote {
+			inSingleQuote = !inSingleQuote
+		} else if c == '"' && !inSingleQuote {
+			inDoubleQuote = !inDoubleQuote
+		} else if c == ch && !inSingleQuote && !inDoubleQuote {
+			count++
+		}
+	}
+	return count
+}
+
+func isBlockStart(line string) bool {
+	keywords := []string{"sub", "on", "if", "unless", "while", "for", "foreach", "feature"}
+	lower := strings.ToLower(line)
+	for _, kw := range keywords {
+		if strings.HasPrefix(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseLine(line, path string, lineNumber int) *extractor.Package {
+	var match []string
+	if m := reSingleQuoteDep.FindStringSubmatch(line); m != nil {
+		match = m
+	} else if m := reDoubleQuoteDep.FindStringSubmatch(line); m != nil {
+		match = m
+	} else {
+		return nil
+	}
+
+	depType := match[1]
+	moduleName := match[2]
+	version := ""
+	if len(match) > 3 && match[3] != "" {
+		version = match[3]
+	}
+
+	pkg := &extractor.Package{
+		Name:     moduleName,
+		Version:  version,
+		PURLType: purl.TypeCPAN,
+		Location: extractor.LocationFromPathAndLine(path, lineNumber),
+	}
+
+	switch depType {
+	case "test_requires":
+		pkg.Metadata = &osv.DepGroupMetadata{DepGroupVals: []string{"test"}}
+	case "configure_requires":
+		pkg.Metadata = &osv.DepGroupMetadata{DepGroupVals: []string{"configure"}}
+	case "build_requires":
+		pkg.Metadata = &osv.DepGroupMetadata{DepGroupVals: []string{"build"}}
+	case "recommends":
+		pkg.Metadata = &osv.DepGroupMetadata{DepGroupVals: []string{"recommends"}}
+	case "suggests":
+		pkg.Metadata = &osv.DepGroupMetadata{DepGroupVals: []string{"suggests"}}
+	}
+
+	return pkg
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/perl/cpanfile/cpanfile_test.go
+++ b/extractor/filesystem/language/perl/cpanfile/cpanfile_test.go
@@ -1,0 +1,289 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpanfile_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cpanfile"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantRequired bool
+	}{
+		{
+			name:         "cpanfile in root",
+			path:         "cpanfile",
+			wantRequired: true,
+		},
+		{
+			name:         "cpanfile in project",
+			path:         "myproject/cpanfile",
+			wantRequired: true,
+		},
+		{
+			name:         "not cpanfile",
+			path:         "myproject/cpanfile.txt",
+			wantRequired: false,
+		},
+		{
+			name:         "META.json",
+			path:         "myproject/META.json",
+			wantRequired: false,
+		},
+		{
+			name:         "invalid nested path",
+			path:         "myproject/cpanfile/foo",
+			wantRequired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := cpanfile.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("cpanfile.New() error: %v", err)
+			}
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: 1000,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "basic requires",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/basic",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "Moose",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 1),
+				},
+				{
+					Name:     "DBI",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 2),
+				},
+			},
+		},
+		{
+			Name: "requires with versions",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/with_versions",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "Moose",
+					Version:  ">= 2.00",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/with_versions", 1),
+				},
+				{
+					Name:     "DBI",
+					Version:  "== 1.643",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/with_versions", 2),
+				},
+				{
+					Name:     "Try::Tiny",
+					Version:  "~> 0.30",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/with_versions", 3),
+				},
+			},
+		},
+		{
+			Name: "dependency groups",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/dependency_groups",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "Moose",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/dependency_groups", 1),
+				},
+				{
+					Name:     "Test::More",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/dependency_groups", 2),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"test"}},
+				},
+				{
+					Name:     "Module::Build",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/dependency_groups", 3),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"configure"}},
+				},
+				{
+					Name:     "ExtUtils::MakeMaker",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/dependency_groups", 4),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"build"}},
+				},
+			},
+		},
+		{
+			Name: "recommends and suggests",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/recommends_suggests",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "Moose",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/recommends_suggests", 1),
+				},
+				{
+					Name:     "Class::Load",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/recommends_suggests", 2),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"recommends"}},
+				},
+				{
+					Name:     "Data::Dumper",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/recommends_suggests", 3),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"suggests"}},
+				},
+			},
+		},
+		{
+			Name: "blocks skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/blocks_skipped",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "Moose",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/blocks_skipped", 1),
+				},
+				{
+					Name:     "DBI",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/blocks_skipped", 11),
+				},
+			},
+		},
+		{
+			Name: "comments",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/comments",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "Moose",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/comments", 4),
+				},
+				{
+					Name:     "DBI",
+					Version:  ">= 1.643",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/comments", 5),
+				},
+			},
+		},
+		{
+			Name: "double quotes",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/double_quotes",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "Moose",
+					Version:  ">= 2.00",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/double_quotes", 1),
+				},
+				{
+					Name:     "DBI",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/double_quotes", 2),
+				},
+			},
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "dynamic constructs skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/dynamic_skipped",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "Moose",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/dynamic_skipped", 1),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			e, err := cpanfile.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("cpanfile.New() error: %v", err)
+			}
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/perl/cpanfile/testdata/basic
+++ b/extractor/filesystem/language/perl/cpanfile/testdata/basic
@@ -1,0 +1,2 @@
+requires 'Moose';
+requires 'DBI';

--- a/extractor/filesystem/language/perl/cpanfile/testdata/blocks_skipped
+++ b/extractor/filesystem/language/perl/cpanfile/testdata/blocks_skipped
@@ -1,0 +1,11 @@
+requires 'Moose';
+
+on 'test' => sub {
+    requires 'Test::More';
+};
+
+feature 'mysql', 'MySQL support' => sub {
+    requires 'DBD::mysql';
+};
+
+requires 'DBI';

--- a/extractor/filesystem/language/perl/cpanfile/testdata/comments
+++ b/extractor/filesystem/language/perl/cpanfile/testdata/comments
@@ -1,0 +1,5 @@
+# This is a cpanfile
+# Comments should be ignored
+
+requires 'Moose'; # inline comment
+requires 'DBI', '>= 1.643'; # another comment

--- a/extractor/filesystem/language/perl/cpanfile/testdata/dependency_groups
+++ b/extractor/filesystem/language/perl/cpanfile/testdata/dependency_groups
@@ -1,0 +1,4 @@
+requires 'Moose';
+test_requires 'Test::More';
+configure_requires 'Module::Build';
+build_requires 'ExtUtils::MakeMaker';

--- a/extractor/filesystem/language/perl/cpanfile/testdata/double_quotes
+++ b/extractor/filesystem/language/perl/cpanfile/testdata/double_quotes
@@ -1,0 +1,2 @@
+requires "Moose", ">= 2.00";
+requires "DBI";

--- a/extractor/filesystem/language/perl/cpanfile/testdata/dynamic_skipped
+++ b/extractor/filesystem/language/perl/cpanfile/testdata/dynamic_skipped
@@ -1,0 +1,8 @@
+requires 'Moose';
+
+my $version = '1.0';
+requires 'Foo', $version;
+
+if ($perl_version >= 5.010) {
+    requires 'Bar';
+}

--- a/extractor/filesystem/language/perl/cpanfile/testdata/recommends_suggests
+++ b/extractor/filesystem/language/perl/cpanfile/testdata/recommends_suggests
@@ -1,0 +1,3 @@
+requires 'Moose';
+recommends 'Class::Load';
+suggests 'Data::Dumper';

--- a/extractor/filesystem/language/perl/cpanfile/testdata/with_versions
+++ b/extractor/filesystem/language/perl/cpanfile/testdata/with_versions
@@ -1,0 +1,3 @@
+requires 'Moose', '>= 2.00';
+requires 'DBI', '== 1.643';
+requires 'Try::Tiny', '~> 0.30';

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -67,6 +67,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/nim/nimble"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ocaml/opam"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cpan"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cpanfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condameta"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
@@ -281,7 +282,7 @@ var (
 		cargotoml.Name: {cargotoml.New},
 	}
 	// CPANSource extractors for Perl.
-	CPANSource = InitMap{cpan.Name: {cpan.New}}
+	CPANSource = InitMap{cpan.Name: {cpan.New}, cpanfile.Name: {cpanfile.New}}
 	// RustArtifact extractors for Rust.
 	RustArtifact = InitMap{
 		cargoauditable.Name: {cargoauditable.New},

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -55,6 +55,11 @@ func TestExtractorsFromName(t *testing.T) {
 			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
+			desc:     "Find_all_Perl_extractors",
+			name:     "perl",
+			wantExts: []string{"perl/cpan", "perl/cpanfile"},
+		},
+		{
 			desc:     "Nonexistent_plugin",
 			name:     "nonexistent",
 			wantErr:  cmpopts.AnyError,


### PR DESCRIPTION
## Summary

Adds a new `perl/cpanfile` filesystem extractor for CPAN dependency manifests.

The extractor conservatively parses deterministic cpanfile declarations such as `requires`, `test_requires`, `configure_requires`, `build_requires`, `recommends`, and `suggests` with literal string arguments. Dynamic Perl constructs and block-scoped declarations are skipped to avoid unsafe or speculative parsing.

## Changes

- Adds `extractor/filesystem/language/perl/cpanfile`.
- Emits CPAN packages with `purl.TypeCPAN`.
- Adds dependency group metadata for non-runtime groups.
- Registers the extractor in `extractor/filesystem/list/list.go`.
- Adds Perl extractor coverage in `extractor/filesystem/list/list_test.go`.
- Documents the new inventory type in `docs/supported_inventory_types.md`.
- Adds fixtures for basic dependencies, versions, groups, comments, double quotes, dynamic skips, and empty files.

## Testing

- `go test ./extractor/filesystem/language/perl/cpanfile/...`
- `go test ./extractor/filesystem/language/perl/...`
- `go test ./extractor/filesystem/list/...`
- `go test ./plugin/list/...`
- `go build ./extractor/filesystem/...`
- `go build ./...`
- `go vet ./extractor/filesystem/language/perl/cpanfile/... ./extractor/filesystem/list/...`
- `git diff --check`
