### PR TITLE
Add Kubernetes ServiceAccount token detector

### DIFF
--- a/binary/proto/secret.go
+++ b/binary/proto/secret.go
@@ -58,6 +58,7 @@ import (
 	veleshttp "github.com/google/osv-scalibr/veles/secrets/http"
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
 	"github.com/google/osv-scalibr/veles/secrets/jwt"
+	veleskubernetesserviceaccount "github.com/google/osv-scalibr/veles/secrets/kubernetesserviceaccount"
 	velesmistralapikey "github.com/google/osv-scalibr/veles/secrets/mistralapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
 	velesonepasswordkeys "github.com/google/osv-scalibr/veles/secrets/onepasswordkeys"
@@ -280,6 +281,8 @@ func velesSecretToProto(s veles.Secret) (*spb.SecretData, error) {
 		return reCaptchaKeyToProto(t), nil
 	case jwt.Token:
 		return jwtTokenToProto(t), nil
+	case veleskubernetesserviceaccount.Token:
+		return jwtTokenToProto(jwt.Token{Value: t.Value}), nil
 	case pyxkeyv1.PyxKeyV1:
 		return pyxKeyV1ToProto(t), nil
 	case pyxkeyv2.PyxKeyV2:

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -155,6 +155,7 @@ import (
 	"github.com/google/osv-scalibr/veles/secrets/http"
 	"github.com/google/osv-scalibr/veles/secrets/huggingfaceapikey"
 	"github.com/google/osv-scalibr/veles/secrets/jwt"
+	"github.com/google/osv-scalibr/veles/secrets/kubernetesserviceaccount"
 	"github.com/google/osv-scalibr/veles/secrets/mistralapikey"
 	"github.com/google/osv-scalibr/veles/secrets/npmjsaccesstoken"
 	"github.com/google/osv-scalibr/veles/secrets/onepasswordkeys"
@@ -437,6 +438,7 @@ var (
 		{vapid.NewDetector(), "secrets/vapidkey", 0},
 		{recaptchakey.NewDetector(), "secrets/recaptchakey", 0},
 		{jwt.NewDetector(), "secrets/jwttoken", 0},
+		{kubernetesserviceaccount.NewDetector(), "secrets/kubernetesserviceaccount", 0},
 		{pyxkeyv1.NewDetector(), "secrets/pyxkeyv1", 0},
 		{pyxkeyv2.NewDetector(), "secrets/pyxkeyv2", 0},
 		{urlcreds.NewDetector(), "secrets/urlcreds", 0},

--- a/veles/secrets/kubernetesserviceaccount/detector.go
+++ b/veles/secrets/kubernetesserviceaccount/detector.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kubernetesserviceaccount contains the logic to detect Kubernetes
+// ServiceAccount tokens, which are JWT tokens containing Kubernetes-specific
+// claims.
+package kubernetesserviceaccount
+
+import (
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/common/jwt"
+)
+
+type detector struct{}
+
+// NewDetector returns a new Veles Detector that finds Kubernetes ServiceAccount
+// tokens.
+func NewDetector() veles.Detector {
+	return &detector{}
+}
+
+// Detect finds Kubernetes ServiceAccount tokens.
+func (d *detector) Detect(data []byte) ([]veles.Secret, []int) {
+	tokens, positions := jwt.ExtractTokens(data)
+	var secrets []veles.Secret
+	var secretPositions []int
+	for i, t := range tokens {
+		if isKubernetesServiceAccountToken(t) {
+			secrets = append(secrets, Token{Value: t.Raw()})
+			secretPositions = append(secretPositions, positions[i])
+		}
+	}
+	return secrets, secretPositions
+}
+
+// MaxSecretLen returns the max length that a Kubernetes ServiceAccount token
+// can have. Kubernetes ServiceAccount tokens are JWTs, so we use the same
+// limit as the JWT detector.
+func (d *detector) MaxSecretLen() uint32 {
+	return jwt.MaxTokenLength
+}
+
+// isKubernetesServiceAccountToken checks whether a JWT token contains the
+// Kubernetes ServiceAccount-specific claims.
+func isKubernetesServiceAccountToken(t jwt.Token) bool {
+	payload := t.Payload()
+	if payload == nil {
+		return false
+	}
+	// Kubernetes ServiceAccount tokens contain at least one of these claims.
+	kubernetesClaims := []string{
+		"kubernetes.io/serviceaccount/namespace",
+		"kubernetes.io/serviceaccount/service-account.name",
+		"kubernetes.io/serviceaccount/service-account.uid",
+	}
+	for _, claim := range kubernetesClaims {
+		if _, ok := payload[claim]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/veles/secrets/kubernetesserviceaccount/detector_test.go
+++ b/veles/secrets/kubernetesserviceaccount/detector_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetesserviceaccount_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/kubernetesserviceaccount"
+	"github.com/google/osv-scalibr/veles/velestest"
+)
+
+// testK8sSAJWT is a synthetic JWT with a Kubernetes ServiceAccount payload claim.
+// Header: {"alg":"RS256","kid":"abc","typ":"JWT"}
+// Payload: {"iss":"kubernetes/serviceaccount","sub":"system:serviceaccount:default:default","kubernetes.io/serviceaccount/namespace":"default","kubernetes.io/serviceaccount/service-account.name":"default","kubernetes.io/serviceaccount/service-account.uid":"12345678-1234-1234-1234-123456789abc","aud":["https://kubernetes.default.svc"],"exp":4468870491}
+// Signature: synthetic (not valid cryptographically, but structurally valid)
+const testK8sSAJWT = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYyIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6ZGVmYXVsdCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvbmFtZXNwYWNlIjoiZGVmYXVsdCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQudWlkIjoiMTIzNDU2NzgtMTIzNC0xMjM0LTEyMzQtMTIzNDU2Nzg5YWJjIiwiYXVkIjpbImh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2YyJdLCJleHAiOjQ0Njg4NzA0OTF9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+// testGenericJWT is a generic JWT without Kubernetes claims.
+const testGenericJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+func TestDetectorAcceptance(t *testing.T) {
+	velestest.AcceptDetector(
+		t,
+		kubernetesserviceaccount.NewDetector(),
+		testK8sSAJWT,
+		kubernetesserviceaccount.Token{Value: testK8sSAJWT},
+	)
+}
+
+func TestKubernetesServiceAccountDetector_TruePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{kubernetesserviceaccount.NewDetector()})
+	if err != nil {
+		t.Fatalf("Failed to initialize detection engine: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "simple_matching_token",
+		input: testK8sSAJWT,
+		want: []veles.Secret{
+			kubernetesserviceaccount.Token{Value: testK8sSAJWT},
+		},
+	}, {
+		name:  "token_in_surrounding_text",
+		input: "Bearer " + testK8sSAJWT + " end",
+		want: []veles.Secret{
+			kubernetesserviceaccount.Token{Value: testK8sSAJWT},
+		},
+	}, {
+		name:  "token_in_json_config",
+		input: `{"apiVersion":"v1","kind":"Secret","data":{"token":"` + testK8sSAJWT + `"}}`,
+		want: []veles.Secret{
+			kubernetesserviceaccount.Token{Value: testK8sSAJWT},
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestKubernetesServiceAccountDetector_TrueNegatives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{kubernetesserviceaccount.NewDetector()})
+	if err != nil {
+		t.Fatalf("Failed to initialize detection engine: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		input string
+	}{{
+		name:  "empty_input",
+		input: "",
+	}, {
+		name:  "generic_jwt_without_kubernetes_claims",
+		input: testGenericJWT,
+	}, {
+		name:  "multiple_generic_jwts",
+		input: testGenericJWT + "\n" + testGenericJWT,
+	}, {
+		name:  "random_text",
+		input: "this is not a token at all",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			var want []veles.Secret
+			if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/kubernetesserviceaccount/kubernetesserviceaccount.go
+++ b/veles/secrets/kubernetesserviceaccount/kubernetesserviceaccount.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetesserviceaccount
+
+// Token contains a Kubernetes ServiceAccount JWT token.
+type Token struct {
+	Value string
+}


### PR DESCRIPTION
## Summary

This contribution adds a new Veles secret detector to OSV-SCALIBR that identifies Kubernetes ServiceAccount tokens. These are JWTs commonly mounted into Kubernetes pods at `/var/run/secrets/kubernetes.io/serviceaccount/token` and are a high-value target for secret scanning.

This PR supersedes #2222, which was closed after an initial CLA failure. The commit author email has since been corrected to my CLA-linked email, and the `cla/google` check passed on the same commit.

## What is detected

JWT tokens containing at least one Kubernetes ServiceAccount-specific claim:

- `kubernetes.io/serviceaccount/namespace`
- `kubernetes.io/serviceaccount/service-account.name`
- `kubernetes.io/serviceaccount/service-account.uid`

## Why this matters

Kubernetes ServiceAccount tokens are commonly leaked in:

- Container image layers
- CI/CD pipeline logs and artifacts
- Exported configuration files and manifests
- Source code repositories

Detecting these tokens helps organizations identify and rotate compromised credentials before they can be exploited for pod-level or cluster-level privilege escalation.

## Why the generic JWT detector is not sufficient

The existing `jwt` detector finds JWTs but cannot distinguish Kubernetes ServiceAccount tokens from non-sensitive application tokens, test JWTs, or public API tokens. A specific detector lets security teams classify and prioritize this credential type more accurately.

## Implementation details

- Reuses the existing `common/jwt` extraction infrastructure for structure validation and position tracking.
- Filters JWTs by Kubernetes-specific claims to reduce false positives versus the generic JWT detector.
- Integrates the detector into SCALIBR's `SecretDetectors` registry.
- Reuses the existing `JWTToken` proto type for protobuf mapping.

## Testing

- `TestDetectorAcceptance` via `velestest.AcceptDetector` covers chunk boundaries, overlap, padding, and position accuracy.
- `TestKubernetesServiceAccountDetector_TruePositives` covers bare token, Bearer header, and JSON config.
- `TestKubernetesServiceAccountDetector_TrueNegatives` covers empty input, generic JWTs without Kubernetes claims, multiple generic JWTs, and random text.

Local verification previously run successfully:

- `git diff --check`
- `go test ./veles/secrets/kubernetesserviceaccount/... -v`
- `go test ./extractor/filesystem/list/... ./binary/proto/... -count=1`
- `go test ./veles/... -count=1`
- `go vet ./veles/secrets/kubernetesserviceaccount/... ./extractor/filesystem/list/... ./binary/proto/...`

## Files changed

- `veles/secrets/kubernetesserviceaccount/detector.go`
- `veles/secrets/kubernetesserviceaccount/kubernetesserviceaccount.go`
- `veles/secrets/kubernetesserviceaccount/detector_test.go`
- `extractor/filesystem/list/list.go`
- `binary/proto/secret.go`