### PR TITLE
feat: add stack.yaml extractor for Haskell projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -79,6 +79,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Go         | Go binaries                                       | `go/binary`                          |
 |            | go.mod (OSV)                                      | `go/gomod`                           |
 | Haskell    | stack.yaml.lock                                   | `haskell/stacklock`                  |
+|            | stack.yaml                                        | `haskell/stackyaml`                  |
 |            | cabal.project.freeze                              | `haskell/cabal`                      |
 | Java       | Java archives                                     | `java/archive`                       |
 |            | pom.xml                                           | `java/pomxml`                        |

--- a/extractor/filesystem/language/haskell/stackyaml/stackyaml.go
+++ b/extractor/filesystem/language/haskell/stackyaml/stackyaml.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stackyaml extracts Stack dependency declarations from stack.yaml manifests.
+package stackyaml
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"gopkg.in/yaml.v3"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "haskell/stackyaml"
+)
+
+// stackYAML is the top-level structure of a stack.yaml file.
+type stackYAML struct {
+	ExtraDeps []any `yaml:"extra-deps"`
+}
+
+// Extractor extracts Stack dependency declarations from stack.yaml files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file matches a stack.yaml.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "stack.yaml"
+}
+
+// Extract extracts Stack dependency declarations from stack.yaml files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	var parsed stackYAML
+	if err := yaml.NewDecoder(input.Reader).Decode(&parsed); err != nil {
+		// Empty files are valid YAML files with no content.
+		if errors.Is(err, io.EOF) {
+			return inventory.Inventory{Packages: make([]*extractor.Package, 0)}, nil
+		}
+		return inventory.Inventory{}, fmt.Errorf("could not extract from %s: %w", input.Path, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
+	}
+
+	packages := make([]*extractor.Package, 0)
+	for _, entry := range parsed.ExtraDeps {
+		pkg := parseEntry(entry, input.Path)
+		if pkg != nil {
+			packages = append(packages, pkg)
+		}
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+func parseEntry(entry any, path string) *extractor.Package {
+	str, ok := entry.(string)
+	if !ok {
+		return nil
+	}
+
+	name, version := splitNameVersion(str)
+	if name == "" {
+		return nil
+	}
+
+	pkg := &extractor.Package{
+		Name:     name,
+		PURLType: purl.TypeHaskell,
+		Location: extractor.LocationFromPath(path),
+	}
+	if version != "" {
+		pkg.Version = version
+	}
+	return pkg
+}
+
+// splitNameVersion splits a stack.yaml extra-deps string into package name and version.
+// The version starts at the first hyphen where the part after it begins with a digit.
+// Examples:
+//
+//	"foo-1.0"        -> name="foo", version="1.0"
+//	"foo-bar-1.2.3"  -> name="foo-bar", version="1.2.3"
+//	"foo-bar"        -> name="foo-bar", version="" (no version present)
+//	"foo-1.0.0-beta" -> name="foo", version="1.0.0-beta"
+//	"my-prerelease-1.0.0-alpha" -> name="my-prerelease", version="1.0.0-alpha"
+func splitNameVersion(s string) (string, string) {
+	for i := range len(s) {
+		if s[i] == '-' && i+1 < len(s) && s[i+1] >= '0' && s[i+1] <= '9' {
+			name := s[:i]
+			version := s[i+1:]
+			if name == "" || version == "" {
+				return s, ""
+			}
+			return name, version
+		}
+	}
+	return s, ""
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/haskell/stackyaml/stackyaml_test.go
+++ b/extractor/filesystem/language/haskell/stackyaml/stackyaml_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stackyaml_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/stackyaml"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantRequired bool
+	}{
+		{
+			name:         "stack.yaml in root",
+			path:         "stack.yaml",
+			wantRequired: true,
+		},
+		{
+			name:         "stack.yaml in project",
+			path:         "myproject/stack.yaml",
+			wantRequired: true,
+		},
+		{
+			name:         "not stack.yaml",
+			path:         "myproject/stack.yaml.lock",
+			wantRequired: false,
+		},
+		{
+			name:         "stack.yaml.lock",
+			path:         "myproject/stack.yaml.lock",
+			wantRequired: false,
+		},
+		{
+			name:         "invalid nested path",
+			path:         "myproject/stack.yaml/foo",
+			wantRequired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := stackyaml.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("stackyaml.New() error: %v", err)
+			}
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: 1000,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "basic extra-deps",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/basic",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "acme-missiles",
+					Version:  "0.3",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/basic"),
+				},
+				{
+					Name:     "github",
+					Version:  "0.15",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/basic"),
+				},
+			},
+		},
+		{
+			Name: "multiple versions",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/multiple_versions",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "lens",
+					Version:  "4.19.2",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/multiple_versions"),
+				},
+				{
+					Name:     "aeson",
+					Version:  "1.5.6.0",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/multiple_versions"),
+				},
+				{
+					Name:     "text",
+					Version:  "1.2.5.0",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/multiple_versions"),
+				},
+			},
+		},
+		{
+			Name: "no version",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no_version",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "some-package",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/no_version"),
+				},
+			},
+		},
+		{
+			Name: "github and git deps skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/github_git_skipped",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "github",
+					Version:  "0.15",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/github_git_skipped"),
+				},
+				{
+					Name:     "normal-pkg",
+					Version:  "1.0.0",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/github_git_skipped"),
+				},
+			},
+		},
+		{
+			Name: "empty list",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty_list",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "no extra-deps field",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no_extra_deps",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "comments",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/comments",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "acme-missiles",
+					Version:  "0.3",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/comments"),
+				},
+			},
+		},
+		{
+			Name: "prerelease versions",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/prerelease_versions",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "my-prerelease",
+					Version:  "1.0.0-beta",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/prerelease_versions"),
+				},
+				{
+					Name:     "my-prerelease",
+					Version:  "1.0.0-alpha",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/prerelease_versions"),
+				},
+			},
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty_file",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "invalid yaml",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid_yaml",
+			},
+			WantErr: cmpopts.AnyError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			e, err := stackyaml.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("stackyaml.New() error: %v", err)
+			}
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/haskell/stackyaml/testdata/basic
+++ b/extractor/filesystem/language/haskell/stackyaml/testdata/basic
@@ -1,0 +1,6 @@
+resolver: lts-18.0
+packages:
+  - .
+extra-deps:
+  - acme-missiles-0.3
+  - github-0.15

--- a/extractor/filesystem/language/haskell/stackyaml/testdata/comments
+++ b/extractor/filesystem/language/haskell/stackyaml/testdata/comments
@@ -1,0 +1,5 @@
+resolver: lts-18.0
+# This is a comment
+extra-deps:
+  - acme-missiles-0.3
+  # Another comment

--- a/extractor/filesystem/language/haskell/stackyaml/testdata/empty_list
+++ b/extractor/filesystem/language/haskell/stackyaml/testdata/empty_list
@@ -1,0 +1,2 @@
+resolver: lts-18.0
+extra-deps: []

--- a/extractor/filesystem/language/haskell/stackyaml/testdata/github_git_skipped
+++ b/extractor/filesystem/language/haskell/stackyaml/testdata/github_git_skipped
@@ -1,0 +1,10 @@
+resolver: lts-18.0
+extra-deps:
+  - github-0.15
+  - github: commercialhaskell/stack
+    commit: abc123def
+  - git: https://github.com/user/repo
+    commit: def456abc
+  - archive: https://example.com/pkg.tar.gz
+    sha256: abc123
+  - normal-pkg-1.0.0

--- a/extractor/filesystem/language/haskell/stackyaml/testdata/invalid_yaml
+++ b/extractor/filesystem/language/haskell/stackyaml/testdata/invalid_yaml
@@ -1,0 +1,1 @@
+extra-deps: [

--- a/extractor/filesystem/language/haskell/stackyaml/testdata/multiple_versions
+++ b/extractor/filesystem/language/haskell/stackyaml/testdata/multiple_versions
@@ -1,0 +1,5 @@
+resolver: lts-18.0
+extra-deps:
+  - lens-4.19.2
+  - aeson-1.5.6.0
+  - text-1.2.5.0

--- a/extractor/filesystem/language/haskell/stackyaml/testdata/no_extra_deps
+++ b/extractor/filesystem/language/haskell/stackyaml/testdata/no_extra_deps
@@ -1,0 +1,1 @@
+resolver: lts-18.0

--- a/extractor/filesystem/language/haskell/stackyaml/testdata/no_version
+++ b/extractor/filesystem/language/haskell/stackyaml/testdata/no_version
@@ -1,0 +1,3 @@
+resolver: lts-18.0
+extra-deps:
+  - some-package

--- a/extractor/filesystem/language/haskell/stackyaml/testdata/prerelease_versions
+++ b/extractor/filesystem/language/haskell/stackyaml/testdata/prerelease_versions
@@ -1,0 +1,4 @@
+resolver: lts-18.0
+extra-deps:
+  - my-prerelease-1.0.0-beta
+  - my-prerelease-1.0.0-alpha

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -49,6 +49,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/cabal"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/stacklock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/stackyaml"
 	javaarchive "github.com/google/osv-scalibr/extractor/filesystem/language/java/archive"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradlelockfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradleverificationmetadataxml"
@@ -267,6 +268,7 @@ var (
 	HaskellSource = InitMap{
 		stacklock.Name: {stacklock.New},
 		cabal.Name:     {cabal.New},
+		stackyaml.Name: {stackyaml.New},
 	}
 	// RSource extractors for R source extractors
 	RSource = InitMap{renvlock.Name: {renvlock.New}}

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -55,6 +55,11 @@ func TestExtractorsFromName(t *testing.T) {
 			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
+			desc:     "Find_all_Haskell_extractors",
+			name:     "haskell",
+			wantExts: []string{"haskell/stacklock", "haskell/cabal", "haskell/stackyaml"},
+		},
+		{
 			desc:     "Nonexistent_plugin",
 			name:     "nonexistent",
 			wantErr:  cmpopts.AnyError,


### PR DESCRIPTION
## Summary
- add a haskell/stackyaml extractor for Stack stack.yaml manifests
- parse string entries from extra-deps and emit Haskell PURLs
- skip map-based GitHub/Git/archive entries to avoid non-deterministic dependencies
- register the extractor and document the new supported inventory type

## Validation
- go test ./extractor/filesystem/language/haskell/stackyaml/...
- go test ./extractor/filesystem/language/haskell/...
- go test ./extractor/filesystem/list/...
- go test ./plugin/list/...
- go build ./extractor/filesystem/...
- go build ./...
- go vet ./extractor/filesystem/language/haskell/stackyaml/... ./extractor/filesystem/list/...
- git diff --check