### PR TITLE
feat: add R DESCRIPTION extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -105,7 +105,8 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Conda packages                                    | `python/condameta`                   |
 |            | setup.py                                          | `python/setup`                       |
 |            | uv.lock                                           | `python/uvlock`                      |
-| R          | renv.lock                                         | `r/renvlock`                         |
+| R          | DESCRIPTION                                       | `r/description`                      |
+|            | renv.lock                                         | `r/renvlock`                         |
 | Ruby       | Installed Gem packages                            | `ruby/gemspec`                       |
 |            | Gemfile.lock, gems.locked                         | `ruby/gemfilelock`                   |
 | Rust       | Cargo.lock                                        | `rust/cargolock`                     |

--- a/extractor/filesystem/language/r/description/description.go
+++ b/extractor/filesystem/language/r/description/description.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package description extracts R dependency declarations from DESCRIPTION manifests.
+package description
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "r/description"
+)
+
+var depFields = map[string]bool{
+	"Depends":   true,
+	"Imports":   true,
+	"Suggests":  true,
+	"Enhances":  true,
+	"LinkingTo": true,
+}
+
+var depGroups = map[string]string{
+	"Depends":   "depends",
+	"Imports":   "imports",
+	"Suggests":  "suggests",
+	"Enhances":  "enhances",
+	"LinkingTo": "linkingto",
+}
+
+// Extractor extracts R dependency declarations from DESCRIPTION files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file matches a DESCRIPTION file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "DESCRIPTION"
+}
+
+// Extract extracts R dependency declarations from DESCRIPTION files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	s := bufio.NewScanner(input.Reader)
+	packages := make([]*extractor.Package, 0)
+	var currentField string
+	var currentValue strings.Builder
+
+	flushField := func() {
+		if currentField == "" {
+			return
+		}
+		if depFields[currentField] {
+			value := strings.TrimSpace(currentValue.String())
+			group := depGroups[currentField]
+			for _, pkg := range parseDepField(value, input.Path, group) {
+				if pkg != nil {
+					packages = append(packages, pkg)
+				}
+			}
+		}
+		currentField = ""
+		currentValue.Reset()
+	}
+
+	for s.Scan() {
+		if err := ctx.Err(); err != nil {
+			return inventory.Inventory{}, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
+		}
+
+		line := s.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		// Check if this is a new field line (starts with non-whitespace, contains a colon).
+		if !isContinuationLine(line) {
+			flushField()
+			if colonIdx := strings.Index(line, ":"); colonIdx > 0 {
+				fieldName := strings.TrimSpace(line[:colonIdx])
+				fieldValue := strings.TrimSpace(line[colonIdx+1:])
+				currentField = fieldName
+				currentValue.WriteString(fieldValue)
+			}
+		} else {
+			// Continuation line - append to current field value.
+			currentValue.WriteString(" ")
+			currentValue.WriteString(trimmed)
+		}
+	}
+	flushField()
+
+	if err := s.Err(); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("error while scanning DESCRIPTION: %w", err)
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+func isContinuationLine(line string) bool {
+	if len(line) == 0 {
+		return false
+	}
+	// DCF continuation lines start with a space or tab.
+	first := line[0]
+	return first == ' ' || first == '\t'
+}
+
+func parseDepField(value, path, group string) []*extractor.Package {
+	if value == "" {
+		return nil
+	}
+	var packages []*extractor.Package
+	entries := splitCommaEntries(value)
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		name := extractPackageName(entry)
+		if name == "" || name == "R" {
+			continue
+		}
+		pkg := &extractor.Package{
+			Name:     name,
+			PURLType: purl.TypeCran,
+			Location: extractor.LocationFromPath(path),
+			Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{group}},
+		}
+		packages = append(packages, pkg)
+	}
+	return packages
+}
+
+func splitCommaEntries(s string) []string {
+	var entries []string
+	var current strings.Builder
+	inParens := 0
+	for i := range len(s) {
+		c := s[i]
+		if c == '(' {
+			inParens++
+			current.WriteByte(c)
+		} else if c == ')' {
+			inParens--
+			current.WriteByte(c)
+		} else if c == ',' && inParens == 0 {
+			entries = append(entries, current.String())
+			current.Reset()
+		} else {
+			current.WriteByte(c)
+		}
+	}
+	if current.Len() > 0 {
+		entries = append(entries, current.String())
+	}
+	return entries
+}
+
+func extractPackageName(entry string) string {
+	// The package name is everything before the first '(' (version constraint).
+	name, _, _ := strings.Cut(entry, "(")
+	return strings.TrimSpace(name)
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/r/description/description_test.go
+++ b/extractor/filesystem/language/r/description/description_test.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package description_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/r/description"
+	"github.com/google/osv-scalibr/extractor/filesystem/osv"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantRequired bool
+	}{
+		{
+			name:         "DESCRIPTION in root",
+			path:         "DESCRIPTION",
+			wantRequired: true,
+		},
+		{
+			name:         "DESCRIPTION in project",
+			path:         "myproject/DESCRIPTION",
+			wantRequired: true,
+		},
+		{
+			name:         "not DESCRIPTION",
+			path:         "myproject/DESCRIPTION.txt",
+			wantRequired: false,
+		},
+		{
+			name:         "renv.lock",
+			path:         "myproject/renv.lock",
+			wantRequired: false,
+		},
+		{
+			name:         "invalid nested path",
+			path:         "myproject/DESCRIPTION/foo",
+			wantRequired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := description.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("description.New() error: %v", err)
+			}
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: 1000,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "basic deps",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/basic",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "ggplot2",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/basic"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"depends"}},
+				},
+				{
+					Name:     "dplyr",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/basic"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"imports"}},
+				},
+				{
+					Name:     "tidyr",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/basic"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"imports"}},
+				},
+			},
+		},
+		{
+			Name: "multiple fields",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/multiple_fields",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "ggplot2",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/multiple_fields"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"imports"}},
+				},
+				{
+					Name:     "testthat",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/multiple_fields"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"suggests"}},
+				},
+				{
+					Name:     "data.table",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/multiple_fields"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"enhances"}},
+				},
+				{
+					Name:     "Rcpp",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/multiple_fields"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"linkingto"}},
+				},
+			},
+		},
+		{
+			Name: "multiline fields",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/multiline",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "ggplot2",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/multiline"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"depends"}},
+				},
+				{
+					Name:     "dplyr",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/multiline"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"depends"}},
+				},
+				{
+					Name:     "tidyr",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/multiline"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"depends"}},
+				},
+				{
+					Name:     "stringr",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/multiline"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"imports"}},
+				},
+			},
+		},
+		{
+			Name: "version constraints",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/version_constraints",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "ggplot2",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/version_constraints"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"imports"}},
+				},
+				{
+					Name:     "dplyr",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/version_constraints"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"imports"}},
+				},
+				{
+					Name:     "testthat",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/version_constraints"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"suggests"}},
+				},
+			},
+		},
+		{
+			Name: "skip R dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/skip_r",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "ggplot2",
+					PURLType: purl.TypeCran,
+					Location: extractor.LocationFromPath("testdata/skip_r"),
+					Metadata: &osv.DepGroupMetadata{DepGroupVals: []string{"depends"}},
+				},
+			},
+		},
+		{
+			Name: "no deps",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no_deps",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			e, err := description.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("description.New() error: %v", err)
+			}
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/r/description/testdata/basic
+++ b/extractor/filesystem/language/r/description/testdata/basic
@@ -1,0 +1,5 @@
+Package: mypackage
+Version: 1.0.0
+Title: My Package
+Depends: ggplot2
+Imports: dplyr, tidyr

--- a/extractor/filesystem/language/r/description/testdata/multiline
+++ b/extractor/filesystem/language/r/description/testdata/multiline
@@ -1,0 +1,9 @@
+Package: mypackage
+Version: 1.0.0
+Title: My Package
+Depends:
+    ggplot2,
+    dplyr,
+    tidyr
+Imports:
+    stringr

--- a/extractor/filesystem/language/r/description/testdata/multiple_fields
+++ b/extractor/filesystem/language/r/description/testdata/multiple_fields
@@ -1,0 +1,8 @@
+Package: mypackage
+Version: 1.0.0
+Title: My Package
+Depends: R (>= 3.5.0)
+Imports: ggplot2
+Suggests: testthat
+Enhances: data.table
+LinkingTo: Rcpp

--- a/extractor/filesystem/language/r/description/testdata/no_deps
+++ b/extractor/filesystem/language/r/description/testdata/no_deps
@@ -1,0 +1,5 @@
+Package: mypackage
+Version: 1.0.0
+Title: My Package
+Author: John Doe
+License: MIT

--- a/extractor/filesystem/language/r/description/testdata/skip_r
+++ b/extractor/filesystem/language/r/description/testdata/skip_r
@@ -1,0 +1,4 @@
+Package: mypackage
+Version: 1.0.0
+Title: My Package
+Depends: R (>= 3.5.0), ggplot2

--- a/extractor/filesystem/language/r/description/testdata/version_constraints
+++ b/extractor/filesystem/language/r/description/testdata/version_constraints
@@ -1,0 +1,6 @@
+Package: mypackage
+Version: 1.0.0
+Title: My Package
+Depends: R (>= 3.5.0)
+Imports: ggplot2 (>= 3.3.0), dplyr (>= 1.0.0)
+Suggests: testthat (>= 3.0.0)

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -77,6 +77,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/setup"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/uvlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/wheelegg"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/r/description"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/r/renvlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ruby/gemfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ruby/gemspec"
@@ -269,7 +270,7 @@ var (
 		cabal.Name:     {cabal.New},
 	}
 	// RSource extractors for R source extractors
-	RSource = InitMap{renvlock.Name: {renvlock.New}}
+	RSource = InitMap{renvlock.Name: {renvlock.New}, description.Name: {description.New}}
 	// RubySource extractors for Ruby.
 	RubySource = InitMap{
 		gemspec.Name:     {gemspec.New},

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -55,6 +55,11 @@ func TestExtractorsFromName(t *testing.T) {
 			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
+			desc:     "Find_all_R_extractors",
+			name:     "r",
+			wantExts: []string{"r/renvlock", "r/description"},
+		},
+		{
 			desc:     "Nonexistent_plugin",
 			name:     "nonexistent",
 			wantErr:  cmpopts.AnyError,


### PR DESCRIPTION
## Summary
- add an r/description extractor for R DESCRIPTION manifests
- parse Depends, Imports, Suggests, Enhances, and LinkingTo dependency fields
- handle DCF continuation lines and comma splitting outside version constraints
- skip the R language dependency and emit CRAN PURLs with dependency group metadata
- register the extractor and document the new supported inventory type

## Validation
- go test ./extractor/filesystem/language/r/description/...
- go test ./extractor/filesystem/language/r/...
- go test ./extractor/filesystem/list/...
- go test ./plugin/list/...
- go build ./extractor/filesystem/...
- go build ./...
- go vet ./extractor/filesystem/language/r/description/... ./extractor/filesystem/list/...
- git diff --check