### PR TITLE
feat: add Haskell cabalfile extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -80,6 +80,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | go.mod (OSV)                                      | `go/gomod`                           |
 | Haskell    | stack.yaml.lock                                   | `haskell/stacklock`                  |
 |            | cabal.project.freeze                              | `haskell/cabal`                      |
+|            | .cabal                                            | `haskell/cabalfile`                  |
 | Java       | Java archives                                     | `java/archive`                       |
 |            | pom.xml                                           | `java/pomxml`                        |
 |            | gradle.lockfile                                   | `java/gradlelockfile`                |

--- a/extractor/filesystem/language/haskell/cabalfile/cabalfile.go
+++ b/extractor/filesystem/language/haskell/cabalfile/cabalfile.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cabalfile extracts Haskell dependency declarations from .cabal manifests.
+package cabalfile
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "haskell/cabalfile"
+)
+
+// Extractor extracts Haskell dependency declarations from .cabal files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file matches a .cabal file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Ext(api.Path()) == ".cabal"
+}
+
+// Extract extracts Haskell dependency declarations from .cabal files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	s := bufio.NewScanner(input.Reader)
+	packages := make([]*extractor.Package, 0)
+
+	var collectingField string
+	var collectedValue strings.Builder
+
+	flush := func() {
+		if collectingField == "" {
+			return
+		}
+		if strings.EqualFold(collectingField, "build-depends") || strings.EqualFold(collectingField, "build-tool-depends") {
+			value := strings.TrimSpace(collectedValue.String())
+			for _, entry := range splitCommaEntries(value) {
+				entry = strings.TrimSpace(entry)
+				if entry == "" {
+					continue
+				}
+				name := extractPackageName(entry)
+				if name != "" {
+					packages = append(packages, &extractor.Package{
+						Name:     name,
+						PURLType: purl.TypeHaskell,
+						Location: extractor.LocationFromPath(input.Path),
+					})
+				}
+			}
+		}
+		collectingField = ""
+		collectedValue.Reset()
+	}
+
+	for s.Scan() {
+		if err := ctx.Err(); err != nil {
+			return inventory.Inventory{}, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
+		}
+
+		rawLine := s.Text()
+		trimmed := strings.TrimSpace(rawLine)
+
+		// Skip blank lines and comments.
+		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+
+		// Check if this is a continuation line (starts with whitespace).
+		isContinuation := len(rawLine) > 0 && (rawLine[0] == ' ' || rawLine[0] == '\t')
+
+		if isContinuation {
+			// Inside a section or continuing a field.
+			if strings.Contains(rawLine, ":") {
+				// New field inside a section.
+				flush()
+				fieldName, fieldValue, _ := strings.Cut(rawLine, ":")
+				fieldName = strings.TrimSpace(fieldName)
+				fieldValue = strings.TrimSpace(fieldValue)
+				collectingField = fieldName
+				collectedValue.WriteString(fieldValue)
+			} else if collectingField != "" {
+				// Continuation of current field.
+				collectedValue.WriteString(" ")
+				collectedValue.WriteString(trimmed)
+			}
+		} else {
+			// Top-level line.
+			flush()
+			if strings.Contains(rawLine, ":") {
+				// Top-level field.
+				fieldName, fieldValue, _ := strings.Cut(rawLine, ":")
+				fieldName = strings.TrimSpace(fieldName)
+				fieldValue = strings.TrimSpace(fieldValue)
+				collectingField = fieldName
+				collectedValue.WriteString(fieldValue)
+			} else {
+				// Section header (e.g., library, executable foo).
+				collectingField = ""
+			}
+		}
+	}
+	flush()
+
+	if err := s.Err(); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("error while scanning .cabal file: %w", err)
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+func splitCommaEntries(s string) []string {
+	var entries []string
+	var current strings.Builder
+	inParens := 0
+	for i := range len(s) {
+		c := s[i]
+		if c == '(' {
+			inParens++
+			current.WriteByte(c)
+		} else if c == ')' {
+			inParens--
+			current.WriteByte(c)
+		} else if c == ',' && inParens == 0 {
+			entries = append(entries, current.String())
+			current.Reset()
+		} else {
+			current.WriteByte(c)
+		}
+	}
+	if current.Len() > 0 {
+		entries = append(entries, current.String())
+	}
+	return entries
+}
+
+func extractPackageName(entry string) string {
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return ""
+	}
+	// The package name is the first token (before any whitespace or operator).
+	// Split on whitespace.
+	idx := strings.IndexFunc(entry, func(r rune) bool {
+		return r == ' ' || r == '\t'
+	})
+	if idx < 0 {
+		return entry
+	}
+	return entry[:idx]
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/haskell/cabalfile/cabalfile_test.go
+++ b/extractor/filesystem/language/haskell/cabalfile/cabalfile_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cabalfile_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/cabalfile"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantRequired bool
+	}{
+		{
+			name:         "mypackage.cabal in root",
+			path:         "mypackage.cabal",
+			wantRequired: true,
+		},
+		{
+			name:         "mypackage.cabal in project",
+			path:         "myproject/mypackage.cabal",
+			wantRequired: true,
+		},
+		{
+			name:         "not .cabal",
+			path:         "myproject/mypackage.txt",
+			wantRequired: false,
+		},
+		{
+			name:         "cabal.project.freeze",
+			path:         "myproject/cabal.project.freeze",
+			wantRequired: false,
+		},
+		{
+			name:         "invalid nested path",
+			path:         "myproject/mypackage.cabal/foo",
+			wantRequired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := cabalfile.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("cabalfile.New() error: %v", err)
+			}
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: 1000,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "basic build-depends",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/basic",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "base",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/basic"),
+				},
+				{
+					Name:     "aeson",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/basic"),
+				},
+			},
+		},
+		{
+			Name: "library section",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/library_section",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "text",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/library_section"),
+				},
+				{
+					Name:     "bytestring",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/library_section"),
+				},
+			},
+		},
+		{
+			Name: "executable and test suite",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/executable_test",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "optparse-applicative",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/executable_test"),
+				},
+				{
+					Name:     "tasty",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/executable_test"),
+				},
+				{
+					Name:     "tasty-hunit",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/executable_test"),
+				},
+			},
+		},
+		{
+			Name: "multiline build-depends",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/multiline",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "base",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/multiline"),
+				},
+				{
+					Name:     "aeson",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/multiline"),
+				},
+				{
+					Name:     "text",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/multiline"),
+				},
+			},
+		},
+		{
+			Name: "comments",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/comments",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "base",
+					PURLType: purl.TypeHaskell,
+					Location: extractor.LocationFromPath("testdata/comments"),
+				},
+			},
+		},
+		{
+			Name: "no build-depends",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no_build_depends",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			e, err := cabalfile.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("cabalfile.New() error: %v", err)
+			}
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/haskell/cabalfile/testdata/basic
+++ b/extractor/filesystem/language/haskell/cabalfile/testdata/basic
@@ -1,0 +1,3 @@
+name: mypackage
+version: 1.0.0
+build-depends: base >= 4.14, aeson >= 1.5

--- a/extractor/filesystem/language/haskell/cabalfile/testdata/comments
+++ b/extractor/filesystem/language/haskell/cabalfile/testdata/comments
@@ -1,0 +1,5 @@
+name: mypackage
+version: 1.0.0
+-- This is a comment
+build-depends: base >= 4.14
+-- Another comment

--- a/extractor/filesystem/language/haskell/cabalfile/testdata/executable_test
+++ b/extractor/filesystem/language/haskell/cabalfile/testdata/executable_test
@@ -1,0 +1,10 @@
+name: mypackage
+version: 1.0.0
+
+executable myexe
+  build-depends: optparse-applicative >= 0.16
+  main-is: Main.hs
+
+test-suite tests
+  build-depends: tasty, tasty-hunit
+  main-is: Test.hs

--- a/extractor/filesystem/language/haskell/cabalfile/testdata/library_section
+++ b/extractor/filesystem/language/haskell/cabalfile/testdata/library_section
@@ -1,0 +1,6 @@
+name: mypackage
+version: 1.0.0
+
+library
+  build-depends: text >= 1.2, bytestring >= 0.10
+  hs-source-dirs: src

--- a/extractor/filesystem/language/haskell/cabalfile/testdata/multiline
+++ b/extractor/filesystem/language/haskell/cabalfile/testdata/multiline
@@ -1,0 +1,6 @@
+name: mypackage
+version: 1.0.0
+build-depends:
+  base >= 4.14,
+  aeson >= 1.5,
+  text >= 1.2

--- a/extractor/filesystem/language/haskell/cabalfile/testdata/no_build_depends
+++ b/extractor/filesystem/language/haskell/cabalfile/testdata/no_build_depends
@@ -1,0 +1,4 @@
+name: mypackage
+version: 1.0.0
+author: John Doe
+license: MIT

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -48,6 +48,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gobinary"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/cabal"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/cabalfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/stacklock"
 	javaarchive "github.com/google/osv-scalibr/extractor/filesystem/language/java/archive"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradlelockfile"
@@ -267,6 +268,7 @@ var (
 	HaskellSource = InitMap{
 		stacklock.Name: {stacklock.New},
 		cabal.Name:     {cabal.New},
+		cabalfile.Name: {cabalfile.New},
 	}
 	// RSource extractors for R source extractors
 	RSource = InitMap{renvlock.Name: {renvlock.New}}

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -55,6 +55,11 @@ func TestExtractorsFromName(t *testing.T) {
 			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
+			desc:     "Find_all_Haskell_extractors",
+			name:     "haskell",
+			wantExts: []string{"haskell/stacklock", "haskell/cabal", "haskell/cabalfile"},
+		},
+		{
 			desc:     "Nonexistent_plugin",
 			name:     "nonexistent",
 			wantErr:  cmpopts.AnyError,


### PR DESCRIPTION
## Summary
- add a Haskell .cabal manifest extractor for Cabal package dependencies
- register the extractor under Haskell source inventory
- add tests and documentation for the new supported inventory type

## Testing
- go test ./extractor/filesystem/language/haskell/cabalfile/...
- go test ./extractor/filesystem/language/haskell/...
- go test ./extractor/filesystem/list/...
- go test ./plugin/list/...
- go build ./extractor/filesystem/...
- go build ./...
- go vet ./extractor/filesystem/language/haskell/cabalfile/... ./extractor/filesystem/list/...
- git diff --check
