### PR TITLE
feat: add Carton cpanfile.snapshot extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -115,6 +115,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Package.resolved                                  | `swift/packageresolved`              |
 | Nim        | Nimble packages                                   | `nim/nimble`                         |
 | Perl       | Perl CPAN packages                                | `perl/cpan`                          |
+|            | Carton snapshot                                   | `perl/cartonlock`                    |
 
 ### Language runtime managers
 

--- a/extractor/filesystem/language/perl/cartonlock/cartonlock.go
+++ b/extractor/filesystem/language/perl/cartonlock/cartonlock.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cartonlock extracts Perl CPAN dependencies from Carton cpanfile.snapshot lockfiles.
+package cartonlock
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "perl/cartonlock"
+
+	// defaultMaxFileSizeBytes is the maximum file size this extractor will process.
+	defaultMaxFileSizeBytes = 10 * units.MiB
+)
+
+// Extractor extracts Perl CPAN dependencies from Carton cpanfile.snapshot files.
+type Extractor struct {
+	maxFileSizeBytes int64
+}
+
+// New returns a new instance of the extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file matches a cpanfile.snapshot.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	if filepath.Base(api.Path()) != "cpanfile.snapshot" {
+		return false
+	}
+	fileinfo, err := api.Stat()
+	return err == nil && (e.maxFileSizeBytes <= 0 || fileinfo.Size() <= e.maxFileSizeBytes)
+}
+
+// Extract extracts Perl CPAN dependencies from cpanfile.snapshot files.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	s := bufio.NewScanner(input.Reader)
+	packages := make([]*extractor.Package, 0)
+
+	inProvides := false
+	for lineNumber := 1; s.Scan(); lineNumber++ {
+		if err := ctx.Err(); err != nil {
+			return inventory.Inventory{}, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
+		}
+
+		line := s.Text()
+		// Skip blank lines and comment lines.
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+
+		// Indentation-based parsing.
+		indent := countLeadingSpaces(line)
+		trimmed := strings.TrimSpace(line)
+
+		if indent == 4 && trimmed == "provides:" {
+			inProvides = true
+			continue
+		}
+
+		if indent <= 4 {
+			// Exited the provides section (new sub-header or distribution).
+			inProvides = false
+			continue
+		}
+
+		if inProvides && indent >= 6 {
+			pkg := parseProvidesEntry(trimmed, input.Path, lineNumber)
+			if pkg != nil {
+				packages = append(packages, pkg)
+			}
+		}
+	}
+
+	if err := s.Err(); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("error while scanning cpanfile.snapshot: %w", err)
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+func countLeadingSpaces(s string) int {
+	count := 0
+	for _, c := range s {
+		if c == ' ' {
+			count++
+		} else {
+			break
+		}
+	}
+	return count
+}
+
+func parseProvidesEntry(line, path string, lineNumber int) *extractor.Package {
+	// Format: "Module::Name version" or "Module::Name undef"
+	// The module name is everything before the last space.
+	// The version is the last token.
+	idx := strings.LastIndex(line, " ")
+	if idx < 0 {
+		return nil
+	}
+	name := strings.TrimSpace(line[:idx])
+	version := strings.TrimSpace(line[idx+1:])
+	if name == "" {
+		return nil
+	}
+	// Skip placeholder versions (undef, 0) that indicate core modules or missing info.
+	if version == "undef" || version == "0" {
+		return nil
+	}
+	return &extractor.Package{
+		Name:     name,
+		Version:  version,
+		PURLType: purl.TypeCPAN,
+		Location: extractor.LocationFromPathAndLine(path, lineNumber),
+	}
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/perl/cartonlock/cartonlock_test.go
+++ b/extractor/filesystem/language/perl/cartonlock/cartonlock_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cartonlock_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cartonlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantRequired bool
+	}{
+		{
+			name:         "cpanfile.snapshot in root",
+			path:         "cpanfile.snapshot",
+			wantRequired: true,
+		},
+		{
+			name:         "cpanfile.snapshot in project",
+			path:         "myproject/cpanfile.snapshot",
+			wantRequired: true,
+		},
+		{
+			name:         "not cpanfile.snapshot",
+			path:         "myproject/cpanfile.snapshot.txt",
+			wantRequired: false,
+		},
+		{
+			name:         "cpanfile",
+			path:         "myproject/cpanfile",
+			wantRequired: false,
+		},
+		{
+			name:         "invalid nested path",
+			path:         "myproject/cpanfile.snapshot/foo",
+			wantRequired: false,
+		},
+		{
+			name:         "too large",
+			path:         "myproject/cpanfile.snapshot",
+			wantRequired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := cartonlock.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("cartonlock.New() error: %v", err)
+			}
+			fileSize := int64(1000)
+			if tt.name == "too large" {
+				fileSize = 11 * 1024 * 1024
+			}
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSize,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "basic snapshot",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/basic",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "CPAN::Meta::Requirements",
+					Version:  "2.143",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 6),
+				},
+				{
+					Name:     "CPAN::Meta::Requirements::Range",
+					Version:  "2.143",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 7),
+				},
+				{
+					Name:     "File::Slurp",
+					Version:  "9999.32",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 19),
+				},
+				{
+					Name:     "JSON::PP::Boolean",
+					Version:  "1.01",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 37),
+				},
+				{
+					Name:     "TOML",
+					Version:  "0.96",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 28),
+				},
+				{
+					Name:     "Types::Serialiser",
+					Version:  "1.01",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 38),
+				},
+				{
+					Name:     "Types::Serialiser::BooleanBase",
+					Version:  "1.01",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 39),
+				},
+				{
+					Name:     "Types::Serialiser::Error",
+					Version:  "1.01",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/basic", 40),
+				},
+			},
+		},
+		{
+			Name: "empty distributions",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty_distributions",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "undef versions skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/undef_versions",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "TOML::Parser",
+					Version:  "0.91",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/undef_versions", 12),
+				},
+				{
+					Name:     "common::sense",
+					Version:  "3.75",
+					PURLType: purl.TypeCPAN,
+					Location: extractor.LocationFromPathAndLine("testdata/undef_versions", 6),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			e, err := cartonlock.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("cartonlock.New() error: %v", err)
+			}
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/perl/cartonlock/testdata/basic
+++ b/extractor/filesystem/language/perl/cartonlock/testdata/basic
@@ -1,0 +1,43 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  CPAN-Meta-Requirements-2.143
+    pathname: R/RJ/RJBS/CPAN-Meta-Requirements-2.143.tar.gz
+    provides:
+      CPAN::Meta::Requirements 2.143
+      CPAN::Meta::Requirements::Range 2.143
+    requirements:
+      B 0
+      Carp 0
+      ExtUtils::MakeMaker 6.17
+      perl 5.010000
+      strict 0
+      version 0.88
+      warnings 0
+  File-Slurp-9999.32
+    pathname: C/CA/CAPOEIRAB/File-Slurp-9999.32.tar.gz
+    provides:
+      File::Slurp 9999.32
+    requirements:
+      B 0
+      Carp 0
+      strict 0
+      warnings 0
+  TOML-0.96
+    pathname: K/KA/KARUPA/TOML-0.96.tar.gz
+    provides:
+      TOML 0.96
+    requirements:
+      Exporter 5.57
+      Module::Build::Tiny 0.035
+      TOML::Parser 0.04
+      perl 5.008005
+  Types-Serialiser-1.01
+    pathname: M/ML/MLEHMANN/Types-Serialiser-1.01.tar.gz
+    provides:
+      JSON::PP::Boolean 1.01
+      Types::Serialiser 1.01
+      Types::Serialiser::BooleanBase 1.01
+      Types::Serialiser::Error 1.01
+    requirements:
+      ExtUtils::MakeMaker 0
+      common::sense 0

--- a/extractor/filesystem/language/perl/cartonlock/testdata/empty_distributions
+++ b/extractor/filesystem/language/perl/cartonlock/testdata/empty_distributions
@@ -1,0 +1,2 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS

--- a/extractor/filesystem/language/perl/cartonlock/testdata/undef_versions
+++ b/extractor/filesystem/language/perl/cartonlock/testdata/undef_versions
@@ -1,0 +1,17 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  Common-Sense-3.75
+    pathname: M/ML/MLEHMANN/common-sense-3.75.tar.gz
+    provides:
+      common::sense 3.75
+    requirements:
+      ExtUtils::MakeMaker 0
+  TOML-Parser-0.91
+    pathname: K/KA/KARUPA/TOML-Parser-0.91.tar.gz
+    provides:
+      TOML::Parser 0.91
+      TOML::Parser::Tokenizer undef
+      TOML::Parser::Tokenizer::Strict undef
+    requirements:
+      Encode 0
+      perl 5.010000

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -66,6 +66,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/lua/luarocks"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/nim/nimble"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ocaml/opam"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cartonlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cpan"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condameta"
@@ -281,7 +282,7 @@ var (
 		cargotoml.Name: {cargotoml.New},
 	}
 	// CPANSource extractors for Perl.
-	CPANSource = InitMap{cpan.Name: {cpan.New}}
+	CPANSource = InitMap{cpan.Name: {cpan.New}, cartonlock.Name: {cartonlock.New}}
 	// RustArtifact extractors for Rust.
 	RustArtifact = InitMap{
 		cargoauditable.Name: {cargoauditable.New},

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -55,6 +55,11 @@ func TestExtractorsFromName(t *testing.T) {
 			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
+			desc:     "Find_all_Perl_extractors",
+			name:     "perl",
+			wantExts: []string{"perl/cpan", "perl/cartonlock"},
+		},
+		{
 			desc:     "Nonexistent_plugin",
 			name:     "nonexistent",
 			wantErr:  cmpopts.AnyError,


### PR DESCRIPTION
This adds a Perl Carton lockfile extractor for cpanfile.snapshot files.

The extractor inventories pinned CPAN modules from Carton snapshot provides sections, emits pkg:cpan packages, and records line-level locations for extracted packages.

Validation:
- go test -count=1 ./extractor/filesystem/language/perl/cartonlock/...
- go test ./extractor/filesystem/language/perl/...
- go test ./extractor/filesystem/list/...
- go test ./plugin/list/...
- go build ./extractor/filesystem/...
- go build ./...
- go vet ./extractor/filesystem/language/perl/cartonlock/... ./extractor/filesystem/list/...
- git diff --check