### PR TITLE
feat: add dotnet-tools.json extractor for .NET projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -71,6 +71,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | NuGet Central Package Management                  | `dotnet/nugetcpm`                    |
 |            | Microsoft Build Engine (MSBuild) project files    | `dotnet/csproj`                      |
 |            | project.assets.json                               | `dotnet/projectassetsjson`           |
+|            | .config/dotnet-tools.json                         | `dotnet/dotnettoolsjson`             |
 | C++        | Conan packages                                    | `cpp/conanlock`                      |
 | Dart       | pubspec.lock                                      | `dart/pubspec`                       |
 | Erlang     | mix.lock                                          | `erlang/mixlock`                     |

--- a/extractor/filesystem/language/dotnet/dotnettoolsjson/dotnettoolsjson.go
+++ b/extractor/filesystem/language/dotnet/dotnettoolsjson/dotnettoolsjson.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dotnettoolsjson extracts .NET local tools from dotnet-tools.json manifests.
+package dotnettoolsjson
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "dotnet/dotnettoolsjson"
+	// MaxFileSize is the maximum size of a dotnet-tools.json we will parse (1 MB).
+	MaxFileSize = 1024 * 1024
+)
+
+// toolsManifest is the root structure of a dotnet-tools.json file.
+type toolsManifest struct {
+	Version int                `json:"version"`
+	IsRoot  bool               `json:"isRoot"`
+	Tools   map[string]toolDef `json:"tools"`
+}
+
+type toolDef struct {
+	Version  string   `json:"version"`
+	Commands []string `json:"commands"`
+}
+
+// Extractor extracts .NET local tools from dotnet-tools.json manifests.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the file is a dotnet-tools.json.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "dotnet-tools.json"
+}
+
+// Extract extracts .NET local tools from the dotnet-tools.json file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	if input.Info != nil && input.Info.Size() > MaxFileSize {
+		return inventory.Inventory{}, fmt.Errorf("%s: file size %d exceeds maximum %d", Name, input.Info.Size(), MaxFileSize)
+	}
+
+	var manifest toolsManifest
+	decoder := json.NewDecoder(input.Reader)
+	if err := decoder.Decode(&manifest); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("%s: failed to decode JSON: %w", Name, err)
+	}
+
+	toolNames := make([]string, 0, len(manifest.Tools))
+	for toolName := range manifest.Tools {
+		toolNames = append(toolNames, toolName)
+	}
+	sort.Strings(toolNames)
+
+	var packages []*extractor.Package
+	if len(toolNames) > 0 {
+		packages = make([]*extractor.Package, 0, len(toolNames))
+	}
+	for _, toolName := range toolNames {
+		if err := ctx.Err(); err != nil {
+			return inventory.Inventory{}, fmt.Errorf("%s halted due to context error: %w", Name, err)
+		}
+		tool := manifest.Tools[toolName]
+		packages = append(packages, &extractor.Package{
+			Name:     toolName,
+			Version:  tool.Version,
+			PURLType: purl.TypeNuget,
+			Location: extractor.LocationFromPath(input.Path),
+		})
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/dotnet/dotnettoolsjson/dotnettoolsjson_test.go
+++ b/extractor/filesystem/language/dotnet/dotnettoolsjson/dotnettoolsjson_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnettoolsjson_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/dotnettoolsjson"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		inputPath string
+		want      bool
+	}{
+		{
+			inputPath: "dotnet-tools.json",
+			want:      true,
+		},
+		{
+			inputPath: "path/to/.config/dotnet-tools.json",
+			want:      true,
+		},
+		{
+			inputPath: "dotnet-tools.json.bak",
+			want:      false,
+		},
+		{
+			inputPath: "tools.json",
+			want:      false,
+		},
+		{
+			inputPath: "",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.inputPath, func(t *testing.T) {
+			e, err := dotnettoolsjson.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("dotnettoolsjson.New: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%s) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "empty tools",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "basic tools",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/basic",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "cake.tool",
+					Version:  "5.0.0",
+					PURLType: purl.TypeNuget,
+					Location: extractor.LocationFromPath("testdata/basic"),
+				},
+				{
+					Name:     "powershell",
+					Version:  "7.1.2",
+					PURLType: purl.TypeNuget,
+					Location: extractor.LocationFromPath("testdata/basic"),
+				},
+			},
+		},
+		{
+			Name: "malformed json",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/malformed",
+			},
+			WantPackages: nil,
+			WantErr:      extracttest.ContainsErrStr{Str: "failed to decode JSON"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := dotnettoolsjson.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("dotnettoolsjson.New: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/dotnet/dotnettoolsjson/testdata/basic
+++ b/extractor/filesystem/language/dotnet/dotnettoolsjson/testdata/basic
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "cake.tool": {
+      "version": "5.0.0",
+      "commands": [
+        "dotnet-cake"
+      ]
+    },
+    "powershell": {
+      "version": "7.1.2",
+      "commands": [
+        "pwsh"
+      ]
+    }
+  }
+}

--- a/extractor/filesystem/language/dotnet/dotnettoolsjson/testdata/empty
+++ b/extractor/filesystem/language/dotnet/dotnettoolsjson/testdata/empty
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {}
+}

--- a/extractor/filesystem/language/dotnet/dotnettoolsjson/testdata/malformed
+++ b/extractor/filesystem/language/dotnet/dotnettoolsjson/testdata/malformed
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "cake.tool": {
+      "version": "5.0.0",

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/csproj"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/depsjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/dotnetpe"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/dotnettoolsjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/nugetcpm"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packagesconfig"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packageslockjson"
@@ -310,6 +311,7 @@ var (
 		paketdependencies.Name: {paketdependencies.New},
 		paketlock.Name:         {paketlock.New},
 		projectassetsjson.Name: {projectassetsjson.New},
+		dotnettoolsjson.Name:   {dotnettoolsjson.New},
 	}
 	// DotnetArtifact extractors for Dotnet (.NET).
 	DotnetArtifact = InitMap{

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -55,6 +55,11 @@ func TestExtractorsFromName(t *testing.T) {
 			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
+			desc:     "Find_all_dotnet_extractors",
+			name:     "dotnet",
+			wantExts: []string{"dotnet/csproj", "dotnet/depsjson", "dotnet/dotnettoolsjson", "dotnet/nugetcpm", "dotnet/packagesconfig", "dotnet/packageslockjson", "dotnet/paketdependencies", "dotnet/paketlock", "dotnet/pe", "dotnet/projectassetsjson"},
+		},
+		{
 			desc:     "Nonexistent_plugin",
 			name:     "nonexistent",
 			wantErr:  cmpopts.AnyError,


### PR DESCRIPTION
## Summary

Add a filesystem extractor for .NET local tool manifests stored in `dotnet-tools.json`.

The extractor inventories package IDs and versions from the manifest `tools` map and emits NuGet package records.

## Details

- matches files named `dotnet-tools.json`
- parses JSON manifest entries under `tools`
- extracts deterministic NuGet package names and versions
- emits packages with PURL type `nuget`
- enforces a 1 MiB file size guard
- registers the extractor in the filesystem extractor list
- adds list coverage and supported inventory documentation

## Tests

- `go test ./extractor/filesystem/language/dotnet/dotnettoolsjson/...`
- `go test ./extractor/filesystem/language/dotnet/...`
- `go test ./extractor/filesystem/list/...`
- `go test ./plugin/...`
- `go build ./...`
- `go vet ./extractor/filesystem/language/dotnet/dotnettoolsjson/... ./extractor/filesystem/list/...`
- `git diff --check`
