### PR TITLE
extractor/os/rpm: trim AlmaLinux ecosystem suffix to major version

### DIFF
--- a/extractor/filesystem/os/ecosystem/ecosystem.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem.go
@@ -84,7 +84,12 @@ func MakeEcosystem(metadata any) osvecosystem.Parsed {
 			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemOpenEuler, Suffix: m.OpenEulerEcosystemSuffix()}
 		}
 		if m.OSID == "almalinux" {
-			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemAlmaLinux, Suffix: m.OSVersionID}
+			// OSV.dev keys ALSA advisories by major version only (e.g. "AlmaLinux:9").
+			// VERSION_ID in /etc/os-release is a full point release (e.g. "9.0" or "9.8"),
+			// so trim to the major version only. A bare major such as "9" is returned
+			// unchanged by strings.Cut (found=false, before=full string).
+			majorVersion, _, _ := strings.Cut(m.OSVersionID, ".")
+			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemAlmaLinux, Suffix: majorVersion}
 		}
 
 	case *snapmeta.Metadata:

--- a/extractor/filesystem/os/ecosystem/ecosystem_test.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem_test.go
@@ -326,10 +326,36 @@ func TestEcosystemRPM(t *testing.T) {
 			want: "AlmaLinux:9",
 		},
 		{
+			// Real VERSION_ID from almalinux:9.0 docker image is "9.0" not "9".
+			// OSV.dev ALSA advisories use "AlmaLinux:9" (major only).
+			desc: "AlmaLinux_9_point_release",
+			metadata: &rpmmeta.Metadata{
+				OSID:        "almalinux",
+				OSVersionID: "9.0",
+			},
+			want: "AlmaLinux:9",
+		},
+		{
+			desc: "AlmaLinux_9_point_release_late",
+			metadata: &rpmmeta.Metadata{
+				OSID:        "almalinux",
+				OSVersionID: "9.8",
+			},
+			want: "AlmaLinux:9",
+		},
+		{
 			desc: "AlmaLinux_8",
 			metadata: &rpmmeta.Metadata{
 				OSID:        "almalinux",
 				OSVersionID: "8",
+			},
+			want: "AlmaLinux:8",
+		},
+		{
+			desc: "AlmaLinux_8_point_release",
+			metadata: &rpmmeta.Metadata{
+				OSID:        "almalinux",
+				OSVersionID: "8.9",
 			},
 			want: "AlmaLinux:8",
 		},


### PR DESCRIPTION
PR #2148 mapped `ID=almalinux` to `EcosystemAlmaLinux` using the full `os-release` `VERSION_ID` as the suffix. On a real host or container, `VERSION_ID` is a point release (e.g. `"9.0"`, `"9.8"`), producing the ecosystem `"AlmaLinux:9.0"`.

OSV.dev keys AlmaLinux (ALSA) advisories by **major version only** (`"AlmaLinux:9"`), so the point-release suffix matches **zero advisories**.

### Empirical check

Using `almalinux:9.0` docker image (`curl-minimal-7.76.1-14.el9_0.5`):

| Ecosystem queried | Packages with vulns | Vuln refs |
|---|---|---|
| `AlmaLinux:9` | matches ALSA-2022:8299 | curl vulnerable |
| `AlmaLinux:9.0` |  0 packages | 0 vulns |

### Fix

Trim `VERSION_ID` to the part before the first `"."` so:
- `"9.0"` → `"9"`
- `"9.8"` → `"9"`  
- `"8.9"` → `"8"`

A bare major such as `"9"` is returned unchanged by `strings.Cut`.

### Testing

- Added test cases for point releases (`9.0`, `9.8`, `8.9`) in `ecosystem_test.go`
- All existing tests continue to pass

Fixes #2091
Related to: google/osv-scanner#2870