### PR TITLE
feat: add Conda explicit lockfile extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -103,6 +103,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Pipfile.lock                                      | `python/pipfilelock`                 |
 |            | pdm.lock                                          | `python/pdmlock`                     |
 |            | Conda packages                                    | `python/condameta`                   |
+|            | Conda explicit lockfile                           | `python/condalock`                   |
 |            | setup.py                                          | `python/setup`                       |
 |            | uv.lock                                           | `python/uvlock`                      |
 | R          | renv.lock                                         | `r/renvlock`                         |

--- a/extractor/filesystem/language/python/condalock/condalock.go
+++ b/extractor/filesystem/language/python/condalock/condalock.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package condalock extracts Conda explicit lockfiles (conda-*.lock).
+package condalock
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "python/condalock"
+	// MaxFileSize is the maximum size of a Conda explicit lockfile we will parse (10 MiB).
+	MaxFileSize = 10 * 1024 * 1024
+)
+
+var knownExtensions = []string{
+	".tar.bz2",
+	".conda",
+	".tar.gz",
+	".tar.xz",
+	".zip",
+}
+
+// Extractor extracts Conda packages from explicit lockfiles.
+type Extractor struct{}
+
+var _ filesystem.Extractor = Extractor{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the specified file matches Conda explicit lockfile patterns.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	p := path.Clean(filepath.ToSlash(api.Path()))
+	base := path.Base(p)
+
+	// Skip files inside node_modules or .git directories.
+	for _, segment := range strings.Split(path.Dir(p), "/") {
+		if segment == "node_modules" || segment == ".git" {
+			return false
+		}
+	}
+
+	if base == "conda.lock" {
+		return true
+	}
+	matched, _ := path.Match("conda-*.lock", base)
+	return matched
+}
+
+// Extract extracts packages from Conda explicit lockfiles passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	if input.Info != nil && input.Info.Size() > MaxFileSize {
+		return inventory.Inventory{}, fmt.Errorf("%s: file size %d exceeds maximum %d", Name, input.Info.Size(), MaxFileSize)
+	}
+
+	scanner := bufio.NewScanner(input.Reader)
+	lineNum := 0
+	packages := make([]*extractor.Package, 0)
+
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return inventory.Inventory{}, fmt.Errorf("%s halted due to context error: %w", Name, err)
+		}
+
+		lineNum++
+		pkg, err := parsePackageLine(scanner.Text(), input.Path, lineNum)
+		if err != nil {
+			return inventory.Inventory{}, err
+		}
+		if pkg != nil {
+			packages = append(packages, pkg)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+// parsePackageLine parses a single line from a Conda explicit lockfile.
+// It returns nil, nil for lines that do not contain a package (comments, blanks, @EXPLICIT).
+func parsePackageLine(line, filePath string, lineNum int) (*extractor.Package, error) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") || line == "@EXPLICIT" {
+		return nil, nil
+	}
+
+	u, err := url.Parse(line)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL on line %d: %w", lineNum, err)
+	}
+
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("invalid URL on line %d: missing scheme", lineNum)
+	}
+
+	filename := path.Base(u.Path)
+	if filename == "" {
+		return nil, fmt.Errorf("empty filename on line %d", lineNum)
+	}
+
+	name, version, err := parseCondaFilename(filename)
+	if err != nil {
+		return nil, fmt.Errorf("line %d: %w", lineNum, err)
+	}
+
+	return &extractor.Package{
+		Name:     name,
+		Version:  version,
+		PURLType: purl.TypeConda,
+		Location: extractor.LocationFromPathAndLine(filePath, lineNum),
+	}, nil
+}
+
+// parseCondaFilename extracts the package name and version from a Conda package filename.
+// The filename format is: name-version-build.ext or name-version.ext
+func parseCondaFilename(filename string) (name, version string, err error) {
+	stem := filename
+	for _, ext := range knownExtensions {
+		if strings.HasSuffix(stem, ext) {
+			stem = strings.TrimSuffix(stem, ext)
+			break
+		}
+	}
+
+	parts := strings.Split(stem, "-")
+	for i, part := range parts {
+		if isVersionSegment(part) {
+			name = strings.Join(parts[:i], "-")
+			version = part
+			if name == "" {
+				return "", "", fmt.Errorf("empty package name in filename %q", filename)
+			}
+			return name, version, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("could not find version in filename %q", filename)
+}
+
+// isVersionSegment reports whether a string segment looks like a Conda version number.
+// A segment is considered a version if it starts with a digit and either contains a dot
+// or consists entirely of digits.
+func isVersionSegment(s string) bool {
+	if s == "" {
+		return false
+	}
+	if s[0] < '0' || s[0] > '9' {
+		return false
+	}
+	hasDot := strings.Contains(s, ".")
+	isNumeric := true
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			isNumeric = false
+			break
+		}
+	}
+	return hasDot || isNumeric
+}

--- a/extractor/filesystem/language/python/condalock/condalock.go
+++ b/extractor/filesystem/language/python/condalock/condalock.go
@@ -73,7 +73,7 @@ func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	base := path.Base(p)
 
 	// Skip files inside node_modules or .git directories.
-	for _, segment := range strings.Split(path.Dir(p), "/") {
+	for segment := range strings.SplitSeq(path.Dir(p), "/") {
 		if segment == "node_modules" || segment == ".git" {
 			return false
 		}
@@ -158,8 +158,8 @@ func parsePackageLine(line, filePath string, lineNum int) (*extractor.Package, e
 func parseCondaFilename(filename string) (name, version string, err error) {
 	stem := filename
 	for _, ext := range knownExtensions {
-		if strings.HasSuffix(stem, ext) {
-			stem = strings.TrimSuffix(stem, ext)
+		if cutStem, ok := strings.CutSuffix(stem, ext); ok {
+			stem = cutStem
 			break
 		}
 	}

--- a/extractor/filesystem/language/python/condalock/condalock_test.go
+++ b/extractor/filesystem/language/python/condalock/condalock_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package condalock_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condalock"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "empty path",
+			inputPath: "",
+			want:      false,
+		},
+		{
+			name:      "conda.lock",
+			inputPath: "conda.lock",
+			want:      true,
+		},
+		{
+			name:      "conda-linux-64.lock",
+			inputPath: "conda-linux-64.lock",
+			want:      true,
+		},
+		{
+			name:      "conda-osx-arm64.lock",
+			inputPath: "conda-osx-arm64.lock",
+			want:      true,
+		},
+		{
+			name:      "path/to/conda.lock",
+			inputPath: "path/to/conda.lock",
+			want:      true,
+		},
+		{
+			name:      "path/to/conda-win-64.lock",
+			inputPath: "path/to/conda-win-64.lock",
+			want:      true,
+		},
+		{
+			name:      "not a lockfile",
+			inputPath: "notconda.lock",
+			want:      false,
+		},
+		{
+			name:      "conda.lock as directory",
+			inputPath: "path/to/conda.lock/file",
+			want:      false,
+		},
+		{
+			name:      "conda.lock with extra suffix",
+			inputPath: "path/to/conda.lock.backup",
+			want:      false,
+		},
+		{
+			name:      "inside node_modules",
+			inputPath: "node_modules/conda.lock",
+			want:      false,
+		},
+		{
+			name:      "nested inside node_modules",
+			inputPath: "foo/node_modules/bar/conda.lock",
+			want:      false,
+		},
+		{
+			name:      "inside .git",
+			inputPath: ".git/conda.lock",
+			want:      false,
+		},
+		{
+			name:      "nested inside .git",
+			inputPath: "foo/.git/conda.lock",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := condalock.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("condalock.New: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%q) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "valid lockfile with three packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/conda-linux-64.lock",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "python",
+					Version:  "3.9.7",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPathAndLine("testdata/conda-linux-64.lock", 3),
+				},
+				{
+					Name:     "numpy",
+					Version:  "1.21.0",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPathAndLine("testdata/conda-linux-64.lock", 4),
+				},
+				{
+					Name:     "libgcc-ng",
+					Version:  "11.2.0",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPathAndLine("testdata/conda-linux-64.lock", 5),
+				},
+			},
+		},
+		{
+			Name: "empty file",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.lock",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "comments only",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/comments_only.lock",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "invalid URL",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/invalid-url.lock",
+			},
+			WantErr:      extracttest.ContainsErrStr{Str: "invalid URL"},
+			WantPackages: nil,
+		},
+		{
+			Name: "no version in filename",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no-version.lock",
+			},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not find version"},
+			WantPackages: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := condalock.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("condalock.New: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract_conda_lock(t *testing.T) {
+	extr, err := condalock.New(&cpb.PluginConfig{})
+	if err != nil {
+		t.Fatalf("condalock.New: %v", err)
+	}
+
+	scanInput := extracttest.GenerateScanInputMock(t, extracttest.ScanInputMockConfig{
+		Path: "testdata/conda.lock",
+	})
+	defer extracttest.CloseTestScanInput(t, scanInput)
+
+	got, err := extr.Extract(t.Context(), &scanInput)
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+
+	want := inventory.Inventory{Packages: []*extractor.Package{
+		{
+			Name:     "six",
+			Version:  "1.16.0",
+			PURLType: purl.TypeConda,
+			Location: extractor.LocationFromPathAndLine("testdata/conda.lock", 2),
+		},
+	}}
+
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+		t.Errorf("Extract diff (-want +got):\n%s", diff)
+	}
+}

--- a/extractor/filesystem/language/python/condalock/testdata/comments_only.lock
+++ b/extractor/filesystem/language/python/condalock/testdata/comments_only.lock
@@ -1,0 +1,3 @@
+# This is a comment
+# Another comment line
+# No packages here

--- a/extractor/filesystem/language/python/condalock/testdata/conda-linux-64.lock
+++ b/extractor/filesystem/language/python/condalock/testdata/conda-linux-64.lock
@@ -1,0 +1,5 @@
+# platform: linux-64
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/linux-64/python-3.9.7-h12debd9_1.tar.bz2#1234abcd
+https://conda.anaconda.org/conda-forge/linux-64/numpy-1.21.0-py39hdbf815f_0.tar.bz2#5678efgh
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-11.2.0-h12345_0.tar.bz2#9abcdef0

--- a/extractor/filesystem/language/python/condalock/testdata/conda.lock
+++ b/extractor/filesystem/language/python/condalock/testdata/conda.lock
@@ -1,0 +1,2 @@
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#abcd1234

--- a/extractor/filesystem/language/python/condalock/testdata/invalid-url.lock
+++ b/extractor/filesystem/language/python/condalock/testdata/invalid-url.lock
@@ -1,0 +1,2 @@
+@EXPLICIT
+not-a-valid-url-at-all

--- a/extractor/filesystem/language/python/condalock/testdata/no-version.lock
+++ b/extractor/filesystem/language/python/condalock/testdata/no-version.lock
@@ -1,0 +1,2 @@
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/linux-64/not-a-version.tar.bz2#1234

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -68,6 +68,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ocaml/opam"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cpan"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condalock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condameta"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfilelock"
@@ -234,6 +235,7 @@ var (
 		pdmlock.Name:      {pdmlock.New},
 		poetrylock.Name:   {poetrylock.New},
 		pylock.Name:       {pylock.New},
+		condalock.Name:    {condalock.New},
 		condameta.Name:    {condameta.New},
 		uvlock.Name:       {uvlock.New},
 	}

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -52,7 +52,7 @@ func TestExtractorsFromName(t *testing.T) {
 		{
 			desc:     "Find_all_extractors_of_a_type",
 			name:     "python",
-			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condalock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:     "Nonexistent_plugin",

--- a/plugin/list/list_test.go
+++ b/plugin/list/list_test.go
@@ -131,12 +131,12 @@ func TestFromNames(t *testing.T) {
 		{
 			desc:      "Find_all_Plugins_of_a_type",
 			names:     []string{"python", "windows", "cis", "layerdetails"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condalock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
 		},
 		{
 			desc:      "Remove_duplicates",
 			names:     []string{"python", "python"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condalock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:      "Nonexistent_plugin",


### PR DESCRIPTION
This adds a Python Conda explicit lockfile extractor for conda.lock and conda-*.lock files. The extractor inventories package URLs from static Conda explicit lockfiles, parses package names and versions from artifact filenames, emits pkg:conda packages, registers the extractor, updates list/plugin test coverage, and documents the supported inventory type.

Validation performed:

- go test ./extractor/filesystem/language/python/condalock/...
- go test ./extractor/filesystem/language/python/...
- go test ./extractor/filesystem/list/...
- go test ./plugin/...
- go build ./...
- go vet ./extractor/filesystem/language/python/condalock/... ./extractor/filesystem/list/... ./plugin/list/...
- git diff --check