### PR TITLE
feat: add Mintfile extractor for Swift projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -113,6 +113,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Rust binaries                                     | `rust/cargoauditable`                |
 | Swift      | Podfile.lock                                      | `swift/podfilelock`                  |
 |            | Package.resolved                                  | `swift/packageresolved`              |
+|            | Mintfile                                          | `swift/mintfile`                     |
 | Nim        | Nimble packages                                   | `nim/nimble`                         |
 | Perl       | Perl CPAN packages                                | `perl/cpan`                          |
 

--- a/extractor/filesystem/language/swift/mintfile/mintfile.go
+++ b/extractor/filesystem/language/swift/mintfile/mintfile.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mintfile extracts dependencies from Mintfile files.
+package mintfile
+
+import (
+	"bufio"
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "swift/mintfile"
+
+	// defaultMaxFileSizeBytes is the maximum file size this extractor will process.
+	defaultMaxFileSizeBytes = 10 * units.MiB
+)
+
+// Extractor extracts dependencies from Mintfile files.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New creates a new instance of the Mintfile extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name returns the extractor's name.
+func (e Extractor) Name() string { return Name }
+
+// Version returns the extractor's version.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements defines the extractor's capabilities.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired checks if a file is named Mintfile and meets size constraints.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	if filepath.Base(path) != "Mintfile" {
+		return false
+	}
+
+	fileInfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+
+	if e.maxFileSizeBytes > 0 && fileInfo.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fileInfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fileInfo.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract processes and extracts dependency information from a Mintfile file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := e.extractFromInput(input)
+	if e.Stats != nil {
+		var fileSizeBytes int64
+		if input.Info != nil {
+			fileSizeBytes = input.Info.Size()
+		}
+		e.Stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+			Path:          input.Path,
+			Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+			FileSizeBytes: fileSizeBytes,
+		})
+	}
+	return inventory.Inventory{Packages: pkgs}, err
+}
+
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Package, error) {
+	scanner := bufio.NewScanner(input.Reader)
+	var packages []*extractor.Package
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(stripComment(scanner.Text()))
+		// Skip empty lines and comments.
+		if line == "" {
+			continue
+		}
+
+		name, version := parseLine(line)
+		if name == "" {
+			continue
+		}
+
+		packages = append(packages, &extractor.Package{
+			Name:     name,
+			Version:  version,
+			PURLType: purl.TypeSwift,
+			Location: extractor.LocationFromPathAndLine(input.Path, lineNum),
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return packages, nil
+}
+
+func stripComment(line string) string {
+	before, _, _ := strings.Cut(line, "#")
+	return before
+}
+
+// parseLine parses a single Mintfile line into package name and version.
+// Format: owner/repo@version or owner/repo
+func parseLine(line string) (name, version string) {
+	if strings.Contains(line, "@") {
+		parts := strings.SplitN(line, "@", 2)
+		name = strings.TrimSpace(parts[0])
+		version = strings.TrimSpace(parts[1])
+	} else {
+		name = strings.TrimSpace(line)
+	}
+	return normalizeSwiftPackageName(name), version
+}
+
+func normalizeSwiftPackageName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.TrimSuffix(name, ".git")
+	name = strings.TrimPrefix(name, "https://")
+	name = strings.TrimPrefix(name, "http://")
+	name = strings.TrimPrefix(name, "git://")
+	name = strings.TrimPrefix(name, "ssh://git@")
+	name = strings.TrimPrefix(name, "git@")
+	name = strings.TrimPrefix(name, "github.com:")
+	if strings.Count(name, "/") == 1 {
+		name = "github.com/" + name
+	}
+	if strings.Count(name, "/") < 2 {
+		return ""
+	}
+	return name
+}

--- a/extractor/filesystem/language/swift/mintfile/mintfile_test.go
+++ b/extractor/filesystem/language/swift/mintfile/mintfile_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mintfile_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/mintfile"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+	"github.com/google/osv-scalibr/testing/testcollector"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+		wantResultMetric stats.FileRequiredResult
+	}{
+		{
+			name:             "Mintfile file",
+			path:             "Mintfile",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "path Mintfile file",
+			path:             "path/to/my/Mintfile",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:         "file not required",
+			path:         "test.mint",
+			wantRequired: false,
+		},
+		{
+			name:             "Mintfile file required if file size < max file size",
+			path:             "Mintfile",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "Mintfile file required if file size == max file size",
+			path:             "Mintfile",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "Mintfile file not required if file size > max file size",
+			path:             "Mintfile",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 100 * units.KiB,
+			wantRequired:     false,
+			wantResultMetric: stats.FileRequiredResultSizeLimitExceeded,
+		},
+		{
+			name:             "Mintfile file required if max file size set to 0",
+			path:             "Mintfile",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 0,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := mintfile.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("mintfile.New: %v", err)
+			}
+			e.(*mintfile.Extractor).Stats = collector
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1000
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+
+			gotResultMetric := collector.FileRequiredResult(tt.path)
+			if tt.wantResultMetric != "" && gotResultMetric != tt.wantResultMetric {
+				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "valid Mintfile",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/valid",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "github.com/yonaskolb/xcodegen",
+					Version:  "2.18.0",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/valid", 1),
+				},
+				{
+					Name:     "github.com/realm/SwiftLint",
+					Version:  "0.40.3",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/valid", 2),
+				},
+				{
+					Name:     "github.com/yonaskolb/genesis",
+					Version:  "0.4.0",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/valid", 3),
+				},
+			},
+		},
+		{
+			Name: "empty Mintfile",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "comments only Mintfile",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/comments",
+			},
+			WantPackages: nil,
+		},
+		{
+			Name: "Mintfile without versions",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no_version",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "github.com/yonaskolb/xcodegen",
+					Version:  "",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/no_version", 1),
+				},
+				{
+					Name:     "github.com/realm/SwiftLint",
+					Version:  "",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/no_version", 2),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := mintfile.New(&cpb.PluginConfig{MaxFileSizeBytes: 100})
+			if err != nil {
+				t.Fatalf("mintfile.New: %v", err)
+			}
+			e.(*mintfile.Extractor).Stats = collector
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/swift/mintfile/testdata/comments
+++ b/extractor/filesystem/language/swift/mintfile/testdata/comments
@@ -1,0 +1,3 @@
+# This is a comment
+
+# Another comment

--- a/extractor/filesystem/language/swift/mintfile/testdata/no_version
+++ b/extractor/filesystem/language/swift/mintfile/testdata/no_version
@@ -1,0 +1,2 @@
+yonaskolb/xcodegen
+realm/SwiftLint

--- a/extractor/filesystem/language/swift/mintfile/testdata/valid
+++ b/extractor/filesystem/language/swift/mintfile/testdata/valid
@@ -1,0 +1,3 @@
+yonaskolb/xcodegen@2.18.0
+realm/SwiftLint@0.40.3
+yonaskolb/genesis@0.4.0

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -83,6 +83,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargoauditable"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargolock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargotoml"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/mintfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/packageresolved"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/podfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/bazelmaven"
@@ -321,6 +322,7 @@ var (
 	SwiftSource = InitMap{
 		packageresolved.Name: {packageresolved.New},
 		podfilelock.Name:     {podfilelock.New},
+		mintfile.Name:        {mintfile.New},
 	}
 
 	// Containers extractors.


### PR DESCRIPTION
## Summary

Add a Swift Mintfile filesystem extractor that inventories Mint package declarations from files named `Mintfile`.

The extractor parses static `owner/repo@version` and `owner/repo` entries, normalizes GitHub-style entries to Swift URL package names such as `github.com/owner/repo`, emits packages with `purl.TypeSwift`, records line-level locations, registers the extractor, and documents the supported inventory type.

## Validation

- `go test ./extractor/filesystem/language/swift/mintfile/...`
- `go test ./extractor/filesystem/language/swift/...`
- `go test ./extractor/filesystem/list/...`
- `go test ./plugin/list/...`
- `go build ./...`
- `go vet ./extractor/filesystem/language/swift/mintfile/... ./extractor/filesystem/list/... ./plugin/list/...`
- `git diff --check`
- `golangci-lint v2.10.1` on `./extractor/filesystem/language/swift/mintfile/...`