### PR TITLE
feat: add Cartfile.resolved extractor for Swift projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -113,6 +113,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Rust binaries                                     | `rust/cargoauditable`                |
 | Swift      | Podfile.lock                                      | `swift/podfilelock`                  |
 |            | Package.resolved                                  | `swift/packageresolved`              |
+|            | Cartfile.resolved                                 | `swift/carthagecartfileresolved`     |
 | Nim        | Nimble packages                                   | `nim/nimble`                         |
 | Perl       | Perl CPAN packages                                | `perl/cpan`                          |
 

--- a/extractor/filesystem/language/swift/carthagecartfileresolved/carthagecartfileresolved.go
+++ b/extractor/filesystem/language/swift/carthagecartfileresolved/carthagecartfileresolved.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package carthagecartfileresolved extracts Carthage Cartfile.resolved dependencies.
+package carthagecartfileresolved
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "swift/carthagecartfileresolved"
+
+	// defaultMaxFileSizeBytes is the maximum file size this extractor will process.
+	defaultMaxFileSizeBytes = 10 * units.MiB
+)
+
+// Extractor extracts packages from a Carthage Cartfile.resolved file.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New returns a Cartfile.resolved extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired checks if the file is named "Cartfile.resolved".
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	if filepath.Base(path) != "Cartfile.resolved" {
+		return false
+	}
+
+	fileinfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract parses and extracts dependency data from a Cartfile.resolved file.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := e.extractFromInput(input)
+	if e.Stats != nil {
+		var fileSizeBytes int64
+		if input.Info != nil {
+			fileSizeBytes = input.Info.Size()
+		}
+		e.Stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+			Path:          input.Path,
+			Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+			FileSizeBytes: fileSizeBytes,
+		})
+	}
+	return inventory.Inventory{Packages: pkgs}, err
+}
+
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Package, error) {
+	packages, err := parse(input.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*extractor.Package, 0, len(packages))
+	for _, pkg := range packages {
+		result = append(result, &extractor.Package{
+			Name:     pkg.Name,
+			Version:  pkg.Version,
+			PURLType: pkg.PURLType,
+			Location: extractor.LocationFromPathAndLine(input.Path, pkg.Line),
+		})
+	}
+
+	return result, nil
+}
+
+// pkg represents a parsed package entry from the Cartfile.resolved file.
+type pkg struct {
+	Name     string
+	Version  string
+	PURLType string
+	Line     int
+}
+
+// parse reads and parses a Cartfile.resolved file for package details.
+// Format: <origin> "<identifier>" "<version>"
+// Origins: github, git, binary (binary entries are skipped).
+func parse(r io.Reader) ([]pkg, error) {
+	packages := []pkg{}
+	scanner := bufio.NewScanner(r)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments.
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.Fields(line)
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("invalid line %d: expected at least 3 fields, got %d", lineNum, len(parts))
+		}
+
+		origin := parts[0]
+		identifier, err := unquote(parts[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid line %d: %w", lineNum, err)
+		}
+		version, err := unquote(parts[2])
+		if err != nil {
+			return nil, fmt.Errorf("invalid line %d: %w", lineNum, err)
+		}
+
+		if identifier == "" || version == "" {
+			return nil, fmt.Errorf("invalid line %d: empty identifier or version", lineNum)
+		}
+
+		switch origin {
+		case "github":
+			packages = append(packages, pkg{
+				Name:     normalizeSwiftURL(identifier),
+				Version:  version,
+				PURLType: purl.TypeSwift,
+				Line:     lineNum,
+			})
+		case "git":
+			name := normalizeGitURL(identifier)
+			packages = append(packages, pkg{
+				Name:     name,
+				Version:  version,
+				PURLType: purl.TypeSwift,
+				Line:     lineNum,
+			})
+		case "binary":
+			// Skip binary entries: they don't map to standard PURL types.
+			continue
+		default:
+			return nil, fmt.Errorf("invalid line %d: unknown origin %q", lineNum, origin)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read Cartfile.resolved: %w", err)
+	}
+
+	return packages, nil
+}
+
+// unquote removes leading and trailing quotes from a Cartfile.resolved field.
+func unquote(s string) (string, error) {
+	u, err := strconv.Unquote(s)
+	if err != nil {
+		return "", err
+	}
+	return u, nil
+}
+
+// normalizeGitURL extracts the path from a Git URL to use as the package name.
+// It strips the scheme and .git suffix if present.
+func normalizeGitURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+
+	u, err := url.Parse(rawURL)
+	if err == nil && u.Host != "" && u.Path != "" {
+		path := strings.TrimPrefix(u.Path, "/")
+		return normalizeSwiftURL(u.Host + "/" + path)
+	}
+
+	// Fallback: manual stripping if URL parsing fails.
+	loc := strings.TrimPrefix(rawURL, "https://")
+	loc = strings.TrimPrefix(loc, "http://")
+	loc = strings.TrimPrefix(loc, "git://")
+	loc = strings.TrimPrefix(loc, "ssh://")
+
+	// Remove user@host:path syntax.
+	if idx := strings.Index(loc, ":"); idx != -1 {
+		loc = loc[idx+1:]
+	}
+	loc = strings.TrimPrefix(loc, "/")
+	return normalizeSwiftURL(loc)
+}
+
+func normalizeSwiftURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimSuffix(raw, ".git")
+	raw = strings.TrimPrefix(raw, "https://")
+	raw = strings.TrimPrefix(raw, "http://")
+	raw = strings.TrimPrefix(raw, "git://")
+	raw = strings.TrimPrefix(raw, "ssh://git@")
+	raw = strings.TrimPrefix(raw, "git@")
+	raw = strings.TrimPrefix(raw, "github.com:")
+	if strings.Count(raw, "/") == 1 {
+		raw = "github.com/" + raw
+	}
+	return raw
+}

--- a/extractor/filesystem/language/swift/carthagecartfileresolved/carthagecartfileresolved_test.go
+++ b/extractor/filesystem/language/swift/carthagecartfileresolved/carthagecartfileresolved_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package carthagecartfileresolved_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/carthagecartfileresolved"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+	"github.com/google/osv-scalibr/testing/testcollector"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+		wantResultMetric stats.FileRequiredResult
+	}{
+		{
+			name:             "Cartfile.resolved file",
+			path:             "Cartfile.resolved",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "path Cartfile.resolved file",
+			path:             "path/to/my/Cartfile.resolved",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:         "file not required",
+			path:         "test.resolved",
+			wantRequired: false,
+		},
+		{
+			name:             "Cartfile.resolved file required if file size < max file size",
+			path:             "Cartfile.resolved",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "Cartfile.resolved file required if file size == max file size",
+			path:             "Cartfile.resolved",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "Cartfile.resolved file not required if file size > max file size",
+			path:             "Cartfile.resolved",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 100 * units.KiB,
+			wantRequired:     false,
+			wantResultMetric: stats.FileRequiredResultSizeLimitExceeded,
+		},
+		{
+			name:             "Cartfile.resolved file required if max file size set to 0",
+			path:             "Cartfile.resolved",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 0,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := carthagecartfileresolved.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("carthagecartfileresolved.New: %v", err)
+			}
+			e.(*carthagecartfileresolved.Extractor).Stats = collector
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1000
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+
+			gotResultMetric := collector.FileRequiredResult(tt.path)
+			if tt.wantResultMetric != "" && gotResultMetric != tt.wantResultMetric {
+				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "valid_mixed_cartfile",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/valid",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "github.com/Alamofire/Alamofire",
+					Version:  "5.4.3",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/valid", 1),
+				},
+				{
+					Name:     "github.com/SwiftyJSON/SwiftyJSON",
+					Version:  "5.0.1",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/valid", 2),
+				},
+			},
+		},
+		{
+			Name: "valid_github_only",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/github_only",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "github.com/ReactiveX/RxSwift",
+					Version:  "6.5.0",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/github_only", 1),
+				},
+			},
+		},
+		{
+			Name: "valid_git_only",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/git_only",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "github.com/SwiftyJSON/SwiftyJSON",
+					Version:  "5.0.1",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/git_only", 1),
+				},
+			},
+		},
+		{
+			Name: "empty_cartfile",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "binary_skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/binary_only",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := carthagecartfileresolved.New(&cpb.PluginConfig{MaxFileSizeBytes: 100})
+			if err != nil {
+				t.Fatalf("carthagecartfileresolved.New: %v", err)
+			}
+			e.(*carthagecartfileresolved.Extractor).Stats = collector
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/swift/carthagecartfileresolved/testdata/binary_only
+++ b/extractor/filesystem/language/swift/carthagecartfileresolved/testdata/binary_only
@@ -1,0 +1,1 @@
+binary "https://example.com/framework.json" "1.0.0"

--- a/extractor/filesystem/language/swift/carthagecartfileresolved/testdata/git_only
+++ b/extractor/filesystem/language/swift/carthagecartfileresolved/testdata/git_only
@@ -1,0 +1,1 @@
+git "https://github.com/SwiftyJSON/SwiftyJSON.git" "5.0.1"

--- a/extractor/filesystem/language/swift/carthagecartfileresolved/testdata/github_only
+++ b/extractor/filesystem/language/swift/carthagecartfileresolved/testdata/github_only
@@ -1,0 +1,1 @@
+github "ReactiveX/RxSwift" "6.5.0"

--- a/extractor/filesystem/language/swift/carthagecartfileresolved/testdata/valid
+++ b/extractor/filesystem/language/swift/carthagecartfileresolved/testdata/valid
@@ -1,0 +1,3 @@
+github "Alamofire/Alamofire" "5.4.3"
+git "https://github.com/SwiftyJSON/SwiftyJSON.git" "5.0.1"
+binary "https://example.com/framework.json" "1.0.0"

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -83,6 +83,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargoauditable"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargolock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargotoml"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/carthagecartfileresolved"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/packageresolved"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/podfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/bazelmaven"
@@ -319,8 +320,9 @@ var (
 	PHPSource = InitMap{composerlock.Name: {composerlock.New}}
 	// SwiftSource extractors for Swift.
 	SwiftSource = InitMap{
-		packageresolved.Name: {packageresolved.New},
-		podfilelock.Name:     {podfilelock.New},
+		packageresolved.Name:          {packageresolved.New},
+		podfilelock.Name:              {podfilelock.New},
+		carthagecartfileresolved.Name: {carthagecartfileresolved.New},
 	}
 
 	// Containers extractors.


### PR DESCRIPTION
## Summary

Add a Swift Carthage `Cartfile.resolved` filesystem extractor.

The extractor parses static `github` and `git` entries, normalizes repository references to the same Swift URL package-name convention used by `swift/packageresolved`, emits packages with `purl.TypeSwift`, skips binary entries that do not map to a supported package ecosystem, records line-level locations, registers the extractor, and documents the supported inventory type.

## Validation

- `go test ./extractor/filesystem/language/swift/carthagecartfileresolved/...`
- `go test ./extractor/filesystem/language/swift/...`
- `go test ./extractor/filesystem/list/...`
- `go test ./plugin/list/...`
- `go build ./...`
- `go vet ./extractor/filesystem/language/swift/carthagecartfileresolved/... ./extractor/filesystem/list/... ./plugin/list/...`
- `git diff --check`
- `golangci-lint v2.10.1` on `./extractor/filesystem/language/swift/carthagecartfileresolved/...`