### PR TITLE
feat: add pixi.toml extractor for Python projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -103,6 +103,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | Pipfile.lock                                      | `python/pipfilelock`                 |
 |            | pdm.lock                                          | `python/pdmlock`                     |
 |            | Conda packages                                    | `python/condameta`                   |
+|            | pixi.toml                                         | `python/pixitoml`                    |
 |            | setup.py                                          | `python/setup`                       |
 |            | uv.lock                                           | `python/uvlock`                      |
 | R          | renv.lock                                         | `r/renvlock`                         |

--- a/extractor/filesystem/language/python/pixitoml/pixitoml.go
+++ b/extractor/filesystem/language/python/pixitoml/pixitoml.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pixitoml extracts Pixi package dependencies from pixi.toml files.
+package pixitoml
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "python/pixitoml"
+)
+
+type pixiTomlFile struct {
+	Dependencies     map[string]toml.Primitive    `toml:"dependencies"`
+	PypiDependencies map[string]toml.Primitive    `toml:"pypi-dependencies"`
+	Feature          map[string]pixiDependencySet `toml:"feature"`
+	Target           map[string]pixiDependencySet `toml:"target"`
+}
+
+type pixiDepTable struct {
+	Version string `toml:"version"`
+}
+
+type pixiDependencySet struct {
+	Dependencies     map[string]toml.Primitive `toml:"dependencies"`
+	PypiDependencies map[string]toml.Primitive `toml:"pypi-dependencies"`
+}
+
+// Extractor extracts Pixi packages from pixi.toml files.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file is a pixi.toml file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "pixi.toml"
+}
+
+// Extract extracts packages from pixi.toml files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	var f pixiTomlFile
+	md, err := toml.NewDecoder(input.Reader).Decode(&f)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
+	}
+
+	loc := extractor.LocationFromPath(input.Path)
+	packages := make([]*extractor.Package, 0, len(f.Dependencies)+len(f.PypiDependencies))
+	packages = appendPackages(packages, f.Dependencies, md, purl.TypeConda, loc)
+	packages = appendPackages(packages, f.PypiDependencies, md, purl.TypePyPi, loc)
+	for _, feature := range f.Feature {
+		packages = appendPackages(packages, feature.Dependencies, md, purl.TypeConda, loc)
+		packages = appendPackages(packages, feature.PypiDependencies, md, purl.TypePyPi, loc)
+	}
+	for _, target := range f.Target {
+		packages = appendPackages(packages, target.Dependencies, md, purl.TypeConda, loc)
+		packages = appendPackages(packages, target.PypiDependencies, md, purl.TypePyPi, loc)
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}
+
+func appendPackages(
+	packages []*extractor.Package,
+	deps map[string]toml.Primitive,
+	md toml.MetaData,
+	purlType string,
+	loc extractor.PackageLocation,
+) []*extractor.Package {
+	for name, prim := range deps {
+		var version string
+		// Try string first (e.g., python = ">=3.9")
+		if err := md.PrimitiveDecode(prim, &version); err == nil {
+			packages = append(packages, &extractor.Package{
+				Name:     name,
+				Version:  version,
+				PURLType: purlType,
+				Location: loc,
+			})
+			continue
+		}
+
+		// Try table with version field (e.g., numpy = { version = ">=1.24" })
+		var dep pixiDepTable
+		if err := md.PrimitiveDecode(prim, &dep); err == nil {
+			packages = append(packages, &extractor.Package{
+				Name:     name,
+				Version:  dep.Version,
+				PURLType: purlType,
+				Location: loc,
+			})
+			continue
+		}
+		// Skip unparseable entries (e.g., git references, local paths)
+	}
+	return packages
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/python/pixitoml/pixitoml_test.go
+++ b/extractor/filesystem/language/python/pixitoml/pixitoml_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pixitoml_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pixitoml"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "pixi_toml",
+			inputPath: "pixi.toml",
+			want:      true,
+		},
+		{
+			name:      "path_to_pixi_toml",
+			inputPath: "path/to/pixi.toml",
+			want:      true,
+		},
+		{
+			name:      "not_pixi_toml",
+			inputPath: "not-pixi.toml",
+			want:      false,
+		},
+		{
+			name:      "pixi_toml_bak",
+			inputPath: "pixi.toml.bak",
+			want:      false,
+		},
+		{
+			name:      "Cargo_toml",
+			inputPath: "Cargo.toml",
+			want:      false,
+		},
+		{
+			name:      "empty_path",
+			inputPath: "",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := pixitoml.Extractor{}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%q) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "invalid_toml",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/not-toml.txt",
+			},
+			WantErr:      extracttest.ContainsErrStr{Str: "could not extract"},
+			WantPackages: nil,
+		},
+		{
+			Name: "empty",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.toml",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "valid",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/valid.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "flask",
+					Version:  "*",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/valid.toml"),
+				},
+				{
+					Name:     "numpy",
+					Version:  ">=1.24",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPath("testdata/valid.toml"),
+				},
+				{
+					Name:     "python",
+					Version:  ">=3.9",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPath("testdata/valid.toml"),
+				},
+				{
+					Name:     "pytest",
+					Version:  ">=8",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPath("testdata/valid.toml"),
+				},
+				{
+					Name:     "openssl",
+					Version:  ">=3",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPath("testdata/valid.toml"),
+				},
+				{
+					Name:     "pyobjc",
+					Version:  ">=10",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/valid.toml"),
+				},
+				{
+					Name:     "requests",
+					Version:  ">=2.26.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/valid.toml"),
+				},
+				{
+					Name:     "sphinx",
+					Version:  ">=7",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/valid.toml"),
+				},
+			},
+		},
+		{
+			Name: "only_conda",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/only-conda.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "numpy",
+					Version:  ">=1.24",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPath("testdata/only-conda.toml"),
+				},
+				{
+					Name:     "python",
+					Version:  ">=3.9",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPath("testdata/only-conda.toml"),
+				},
+			},
+		},
+		{
+			Name: "only_pypi",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/only-pypi.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "flask",
+					Version:  "*",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/only-pypi.toml"),
+				},
+				{
+					Name:     "requests",
+					Version:  ">=2.26.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPath("testdata/only-pypi.toml"),
+				},
+			},
+		},
+		{
+			Name: "table_dependencies",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/table-deps.toml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "numpy",
+					Version:  ">=1.24",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPath("testdata/table-deps.toml"),
+				},
+				{
+					Name:     "python",
+					Version:  ">=3.9",
+					PURLType: purl.TypeConda,
+					Location: extractor.LocationFromPath("testdata/table-deps.toml"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr := pixitoml.Extractor{}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/python/pixitoml/testdata/empty.toml
+++ b/extractor/filesystem/language/python/pixitoml/testdata/empty.toml
@@ -1,0 +1,4 @@
+[project]
+name = "my_project"
+channels = ["conda-forge"]
+platforms = ["linux-64"]

--- a/extractor/filesystem/language/python/pixitoml/testdata/not-toml.txt
+++ b/extractor/filesystem/language/python/pixitoml/testdata/not-toml.txt
@@ -1,0 +1,1 @@
+this is not valid toml [[[

--- a/extractor/filesystem/language/python/pixitoml/testdata/only-conda.toml
+++ b/extractor/filesystem/language/python/pixitoml/testdata/only-conda.toml
@@ -1,0 +1,8 @@
+[project]
+name = "my_project"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[dependencies]
+python = ">=3.9"
+numpy = ">=1.24"

--- a/extractor/filesystem/language/python/pixitoml/testdata/only-pypi.toml
+++ b/extractor/filesystem/language/python/pixitoml/testdata/only-pypi.toml
@@ -1,0 +1,8 @@
+[project]
+name = "my_project"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[pypi-dependencies]
+requests = ">=2.26.0"
+flask = "*"

--- a/extractor/filesystem/language/python/pixitoml/testdata/table-deps.toml
+++ b/extractor/filesystem/language/python/pixitoml/testdata/table-deps.toml
@@ -1,0 +1,8 @@
+[project]
+name = "my_project"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[dependencies]
+python = ">=3.9"
+numpy = { version = ">=1.24", build = "py311*" }

--- a/extractor/filesystem/language/python/pixitoml/testdata/valid.toml
+++ b/extractor/filesystem/language/python/pixitoml/testdata/valid.toml
@@ -1,0 +1,24 @@
+[project]
+name = "my_project"
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64"]
+
+[dependencies]
+python = ">=3.9"
+numpy = ">=1.24"
+
+[pypi-dependencies]
+requests = ">=2.26.0"
+flask = "*"
+
+[feature.test.dependencies]
+pytest = ">=8"
+
+[feature.docs.pypi-dependencies]
+sphinx = ">=7"
+
+[target.linux-64.dependencies]
+openssl = { version = ">=3" }
+
+[target.osx-64.pypi-dependencies]
+pyobjc = ">=10"

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -71,6 +71,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condameta"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfilelock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pixitoml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/poetrylock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pylock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
@@ -236,6 +237,7 @@ var (
 		pylock.Name:       {pylock.New},
 		condameta.Name:    {condameta.New},
 		uvlock.Name:       {uvlock.New},
+		pixitoml.Name:     {pixitoml.New},
 	}
 	// PythonArtifact extractors for Python.
 	PythonArtifact = InitMap{

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -52,7 +52,7 @@ func TestExtractorsFromName(t *testing.T) {
 		{
 			desc:     "Find_all_extractors_of_a_type",
 			name:     "python",
-			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/pixitoml", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:     "Nonexistent_plugin",

--- a/plugin/list/list_test.go
+++ b/plugin/list/list_test.go
@@ -131,12 +131,12 @@ func TestFromNames(t *testing.T) {
 		{
 			desc:      "Find_all_Plugins_of_a_type",
 			names:     []string{"python", "windows", "cis", "layerdetails"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/pixitoml", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
 		},
 		{
 			desc:      "Remove_duplicates",
 			names:     []string{"python", "python"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/pixitoml", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
 		},
 		{
 			desc:      "Nonexistent_plugin",


### PR DESCRIPTION
## Summary

Add a Python `pixi.toml` filesystem extractor for Pixi project manifests.

The extractor parses static Conda and PyPI dependency tables from top-level, feature, and target sections, emits packages with `purl.TypeConda` and `purl.TypePyPi`, registers the extractor, updates list/plugin coverage, and documents the supported inventory type.

## Validation

- `go test ./extractor/filesystem/language/python/pixitoml/...`
- `go test ./extractor/filesystem/language/python/...`
- `go test ./extractor/filesystem/list/...`
- `go test ./plugin/list/...`
- `go build ./...`
- `go vet ./extractor/filesystem/language/python/pixitoml/... ./extractor/filesystem/list/... ./plugin/list/...`
- `git diff --check`
- `golangci-lint v2.10.1` on `./extractor/filesystem/language/python/pixitoml/...`