### PR TITLE
feat: add constraints.txt extractor for Python projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -100,6 +100,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | PHP        | Composer                                          | `php/composerlock`                   |
 | Python     | Installed PyPI packages (global and venv)         | `python/wheelegg`                    |
 |            | requirements.txt                                  | `python/requirements`                |
+|            | constraints.txt                                   | `python/constraints`                 |
 |            | poetry.lock                                       | `python/poetrylock`                  |
 |            | Pipfile.lock                                      | `python/pipfilelock`                 |
 |            | pdm.lock                                          | `python/pdmlock`                     |

--- a/extractor/filesystem/language/python/constraints/constraints.go
+++ b/extractor/filesystem/language/python/constraints/constraints.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package constraints extracts constraints files.
+package constraints
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "python/constraints"
+
+	// noLimitMaxFileSizeBytes is a sentinel value that indicates no limit.
+	noLimitMaxFileSizeBytes = int64(0)
+)
+
+var (
+	// Regex matching comments in constraints files.
+	reComment = regexp.MustCompile(`(^|\s+)#.*$`)
+	// Regex matching extras in package names, e.g. requests[security].
+	reExtras = regexp.MustCompile(`\[[^\[\]]*\]`)
+	// Regex matching valid Python distribution names.
+	reValidPkg = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	// Regex matching version operators, ordered longest first.
+	reVersionOperators = regexp.MustCompile(`===|==|>=|<=|~=|!=|>|<`)
+)
+
+// Extractor extracts python packages from constraints.txt files.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New returns a constraints.txt extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := noLimitMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file matches a constraints.txt file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	if filepath.Base(path) != "constraints.txt" {
+		return false
+	}
+
+	fileinfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if e.maxFileSizeBytes > noLimitMaxFileSizeBytes && fileinfo.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract extracts packages from constraints.txt files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := extractFromPath(input.Reader, input.Path)
+
+	if e.Stats != nil {
+		var fileSizeBytes int64
+		if input.Info != nil {
+			fileSizeBytes = input.Info.Size()
+		}
+		e.Stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+			Path:          input.Path,
+			Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+			FileSizeBytes: fileSizeBytes,
+		})
+	}
+	return inventory.Inventory{Packages: pkgs}, err
+}
+
+func extractFromPath(reader io.Reader, path string) ([]*extractor.Package, error) {
+	var pkgs []*extractor.Package
+	s := bufio.NewScanner(reader)
+	lineNum := 0
+	for s.Scan() {
+		lineNum++
+		l := s.Text()
+		l = removeComments(l)
+		l = strings.TrimSpace(l)
+		if len(l) == 0 {
+			continue
+		}
+		// Ignore Python environment markers.
+		l = strings.SplitN(l, ";", 2)[0]
+		l = strings.TrimSpace(l)
+		if len(l) == 0 {
+			continue
+		}
+		// Remove extras from package names.
+		l = removeExtras(l)
+
+		name, version, comp := getNameAndVersion(l)
+		if name == "" {
+			continue
+		}
+		if version == "" && comp != "" {
+			// Version should be non-empty if there is a comparator.
+			continue
+		}
+		if !isValidPackage(name) {
+			continue
+		}
+
+		pkgs = append(pkgs, &extractor.Package{
+			Name:     name,
+			Version:  version,
+			PURLType: purl.TypePyPi,
+			Location: extractor.LocationFromPathAndLine(filepath.ToSlash(path), lineNum),
+			Metadata: &requirements.Metadata{
+				HashCheckingModeValues: []string{},
+				VersionComparator:      comp,
+				Requirement:            l,
+			},
+		})
+	}
+	return pkgs, s.Err()
+}
+
+func getNameAndVersion(s string) (name, version, comparator string) {
+	match := reVersionOperators.FindStringIndex(s)
+	if match == nil {
+		return strings.TrimSpace(s), "", ""
+	}
+	comp := s[match[0]:match[1]]
+	name = strings.TrimSpace(s[:match[0]])
+	version = strings.TrimSpace(s[match[1]:])
+	return name, version, comp
+}
+
+func removeComments(s string) string {
+	return reComment.ReplaceAllString(s, "")
+}
+
+func removeExtras(s string) string {
+	return reExtras.ReplaceAllString(s, "")
+}
+
+func isValidPackage(s string) bool {
+	return reValidPkg.MatchString(s)
+}

--- a/extractor/filesystem/language/python/constraints/constraints_test.go
+++ b/extractor/filesystem/language/python/constraints/constraints_test.go
@@ -1,0 +1,318 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constraints_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/constraints"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	scalibrfs "github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/testing/fakefs"
+	"github.com/google/osv-scalibr/testing/testcollector"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+		wantResultMetric stats.FileRequiredResult
+	}{
+		{
+			name:             "constraints.txt",
+			path:             "project/constraints.txt",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:         "requirements.txt should not match",
+			path:         "project/requirements.txt",
+			wantRequired: false,
+		},
+		{
+			name:         "other txt file should not match",
+			path:         "project/other.txt",
+			wantRequired: false,
+		},
+		{
+			name:             "constraints.txt within size limit",
+			path:             "project/constraints.txt",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "constraints.txt at exact size limit",
+			path:             "project/constraints.txt",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "constraints.txt exceeds size limit",
+			path:             "project/constraints.txt",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 100 * units.KiB,
+			wantRequired:     false,
+			wantResultMetric: stats.FileRequiredResultSizeLimitExceeded,
+		},
+		{
+			name:             "constraints.txt required if max file size is 0",
+			path:             "project/constraints.txt",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 0,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := constraints.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("constraints.New() error: %v", err)
+			}
+			e.(*constraints.Extractor).Stats = collector
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 100 * units.KiB
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+
+			gotResultMetric := collector.FileRequiredResult(tt.path)
+			if gotResultMetric != tt.wantResultMetric {
+				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		wantPackages     []*extractor.Package
+		wantResultMetric stats.FileExtractedResult
+	}{
+		{
+			name: "valid",
+			path: "testdata/valid.txt",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "2.28.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid.txt", 1),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: "==", Requirement: "requests==2.28.0"},
+				},
+				{
+					Name:     "flask",
+					Version:  "2.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid.txt", 2),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: ">=", Requirement: "flask>=2.0.0"},
+				},
+				{
+					Name:     "numpy",
+					Version:  "1.24.0,<2.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid.txt", 3),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: ">=", Requirement: "numpy>=1.24.0,<2.0.0"},
+				},
+				{
+					Name:     "django",
+					Version:  "3.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid.txt", 4),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: ">", Requirement: "django>3.0"},
+				},
+				{
+					Name:     "pillow",
+					Version:  "10.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid.txt", 5),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: "<", Requirement: "pillow<10.0"},
+				},
+				{
+					Name:     "pytest",
+					Version:  "7.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid.txt", 6),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: "!=", Requirement: "pytest!=7.0.0"},
+				},
+				{
+					Name:     "scipy",
+					Version:  "1.9.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid.txt", 7),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: "~=", Requirement: "scipy~=1.9.0"},
+				},
+				{
+					Name:     "a",
+					Version:  "1.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid.txt", 8),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: "==", Requirement: "a==1.0.0"},
+				},
+				{
+					Name:     "zope.interface",
+					Version:  "6.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/valid.txt", 9),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: "==", Requirement: "zope.interface==6.0"},
+				},
+			},
+			wantResultMetric: stats.FileExtractedResultSuccess,
+		},
+		{
+			name:             "empty",
+			path:             "testdata/empty.txt",
+			wantResultMetric: stats.FileExtractedResultSuccess,
+		},
+		{
+			name: "comments",
+			path: "testdata/comments.txt",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "2.28.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/comments.txt", 2),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: "==", Requirement: "requests==2.28.0"},
+				},
+				{
+					Name:     "flask",
+					Version:  "2.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/comments.txt", 4),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: ">=", Requirement: "flask>=2.0.0"},
+				},
+				{
+					Name:     "numpy",
+					Version:  "1.24.0,<2.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/comments.txt", 5),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, VersionComparator: ">=", Requirement: "numpy>=1.24.0,<2.0.0"},
+				},
+			},
+			wantResultMetric: stats.FileExtractedResultSuccess,
+		},
+		{
+			name: "no_version",
+			path: "testdata/no_version.txt",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/no_version.txt", 1),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, Requirement: "requests"},
+				},
+				{
+					Name:     "flask",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/no_version.txt", 2),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, Requirement: "flask"},
+				},
+				{
+					Name:     "numpy",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/no_version.txt", 3),
+					Metadata: &requirements.Metadata{HashCheckingModeValues: []string{}, Requirement: "numpy"},
+				},
+			},
+			wantResultMetric: stats.FileExtractedResultSuccess,
+		},
+		{
+			name:             "invalid",
+			path:             "testdata/invalid.txt",
+			wantResultMetric: stats.FileExtractedResultSuccess,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := constraints.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("constraints.New() error: %v", err)
+			}
+			e.(*constraints.Extractor).Stats = collector
+
+			fsys := scalibrfs.DirFS(".")
+			r, err := fsys.Open(tt.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err = r.Close(); err != nil {
+					t.Errorf("Close(): %v", err)
+				}
+			}()
+
+			info, err := r.Stat()
+			if err != nil {
+				t.Fatalf("Stat(): %v", err)
+			}
+
+			input := &filesystem.ScanInput{FS: scalibrfs.DirFS("."), Path: tt.path, Info: info, Reader: r}
+			got, err := e.Extract(t.Context(), input)
+			if err != nil {
+				t.Fatalf("Extract(%s): %v", tt.path, err)
+			}
+
+			want := inventory.Inventory{Packages: tt.wantPackages}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("Extract(%s) (-want +got):\n%s", tt.path, diff)
+			}
+
+			gotResultMetric := collector.FileExtractedResult(tt.path)
+			if gotResultMetric != tt.wantResultMetric {
+				t.Errorf("Extract(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			}
+
+			gotFileSizeMetric := collector.FileExtractedFileSize(tt.path)
+			if gotFileSizeMetric != info.Size() {
+				t.Errorf("Extract(%s) recorded file size %v, want file size %v", tt.path, gotFileSizeMetric, info.Size())
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/python/constraints/testdata/comments.txt
+++ b/extractor/filesystem/language/python/constraints/testdata/comments.txt
@@ -1,0 +1,5 @@
+# This is a comment
+requests==2.28.0
+# Another comment
+flask>=2.0.0
+numpy>=1.24.0,<2.0.0  # inline comment

--- a/extractor/filesystem/language/python/constraints/testdata/invalid.txt
+++ b/extractor/filesystem/language/python/constraints/testdata/invalid.txt
@@ -1,0 +1,4 @@
+asdf==
+==1.0
+asdf 1.0
+urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/==1.26.8.zip

--- a/extractor/filesystem/language/python/constraints/testdata/no_version.txt
+++ b/extractor/filesystem/language/python/constraints/testdata/no_version.txt
@@ -1,0 +1,3 @@
+requests
+flask
+numpy

--- a/extractor/filesystem/language/python/constraints/testdata/valid.txt
+++ b/extractor/filesystem/language/python/constraints/testdata/valid.txt
@@ -1,0 +1,9 @@
+requests==2.28.0
+flask>=2.0.0
+numpy>=1.24.0,<2.0.0
+django>3.0
+pillow<10.0
+pytest!=7.0.0
+scipy~=1.9.0
+a==1.0.0
+zope.interface==6.0

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -70,6 +70,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/perl/cpan"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/condameta"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/constraints"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/poetrylock"
@@ -231,6 +232,7 @@ var (
 	PythonSource = InitMap{
 		// requirements extraction for environments with and without network access.
 		requirements.Name: {requirements.New},
+		constraints.Name:  {constraints.New},
 		setup.Name:        {setup.New},
 		pipfilelock.Name:  {pipfilelock.New},
 		pdmlock.Name:      {pdmlock.New},

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -52,7 +52,7 @@ func TestExtractorsFromName(t *testing.T) {
 		{
 			desc:     "Find_all_extractors_of_a_type",
 			name:     "python",
-			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/constraints", "python/setup"},
 		},
 		{
 			desc:     "Nonexistent_plugin",

--- a/plugin/list/list_test.go
+++ b/plugin/list/list_test.go
@@ -131,12 +131,12 @@ func TestFromNames(t *testing.T) {
 		{
 			desc:      "Find_all_Plugins_of_a_type",
 			names:     []string{"python", "windows", "cis", "layerdetails"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/constraints", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
 		},
 		{
 			desc:      "Remove_duplicates",
 			names:     []string{"python", "python"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/constraints", "python/setup"},
 		},
 		{
 			desc:      "Nonexistent_plugin",


### PR DESCRIPTION
## Summary
- add python/constraints filesystem extractor for constraints.txt files
- reuse Python requirements metadata for version comparator and requirement strings
- update filesystem and plugin list tests plus supported inventory docs

## Validation
- go test ./extractor/filesystem/language/python/constraints/...
- go test ./extractor/filesystem/language/python/...
- go test ./extractor/filesystem/list/...
- go test ./plugin/list/...
- go build ./...
- go vet ./extractor/filesystem/language/python/constraints/... ./extractor/filesystem/list/... ./plugin/list/...
- git diff --check
- golangci-lint run ./extractor/filesystem/language/python/constraints/...