### PR TITLE
feat: add Cartfile extractor for Swift projects

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -112,7 +112,8 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Rust       | Cargo.lock                                        | `rust/cargolock`                     |
 |            | Cargo.toml                                        | `rust/cargotoml`                     |
 |            | Rust binaries                                     | `rust/cargoauditable`                |
-| Swift      | Podfile.lock                                      | `swift/podfilelock`                  |
+| Swift      | Cartfile                                          | `swift/cartfile`                     |
+|            | Podfile.lock                                      | `swift/podfilelock`                  |
 |            | Package.resolved                                  | `swift/packageresolved`              |
 | Nim        | Nimble packages                                   | `nim/nimble`                         |
 | Perl       | Perl CPAN packages                                | `perl/cpan`                          |

--- a/extractor/filesystem/language/swift/cartfile/cartfile.go
+++ b/extractor/filesystem/language/swift/cartfile/cartfile.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cartfile extracts Cartfile dependencies.
+package cartfile
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "swift/cartfile"
+
+	// defaultMaxFileSizeBytes is the maximum file size this extractor will process.
+	defaultMaxFileSizeBytes = 10 * units.MiB
+)
+
+var (
+	// cartfileLineRegexp matches lines in the format: <origin> "<identifier>" <version>
+	cartfileLineRegexp = regexp.MustCompile(`^(github|git|binary)\s+"([^"]+)"(?:\s+(.+))?$`)
+)
+
+// Extractor extracts packages from Cartfile files.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New returns a Cartfile extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired checks if the file is named "Cartfile".
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	if filepath.Base(path) != "Cartfile" {
+		return false
+	}
+
+	fileinfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract parses and extracts dependency data from a Cartfile.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := e.extractFromInput(input)
+	if e.Stats != nil {
+		var fileSizeBytes int64
+		if input.Info != nil {
+			fileSizeBytes = input.Info.Size()
+		}
+		e.Stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+			Path:          input.Path,
+			Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+			FileSizeBytes: fileSizeBytes,
+		})
+	}
+	return inventory.Inventory{Packages: pkgs}, err
+}
+
+func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Package, error) {
+	return parse(input.Reader, input.Path)
+}
+
+// parse reads and parses a Cartfile for package details.
+func parse(r io.Reader, path string) ([]*extractor.Package, error) {
+	packages := make([]*extractor.Package, 0)
+	scanner := bufio.NewScanner(r)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and full-line comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Strip inline comments
+		if idx := strings.Index(line, "#"); idx != -1 {
+			line = strings.TrimSpace(line[:idx])
+		}
+
+		if line == "" {
+			continue
+		}
+
+		matches := cartfileLineRegexp.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+
+		origin := matches[1]
+		identifier := matches[2]
+		version := strings.TrimSpace(matches[3])
+		// Strip surrounding quotes from version if present
+		version = strings.Trim(version, `"`)
+
+		if version == "" {
+			continue
+		}
+
+		var name, purlType string
+
+		switch origin {
+		case "github":
+			name = normalizeSwiftURL(identifier)
+			purlType = purl.TypeSwift
+		case "git":
+			name = normalizeGitURL(identifier)
+			purlType = purl.TypeSwift
+		case "binary":
+			// Skip binary dependencies - no standard PURL mapping
+			continue
+		}
+
+		packages = append(packages, &extractor.Package{
+			Name:     name,
+			Version:  version,
+			PURLType: purlType,
+			Location: extractor.LocationFromPathAndLine(filepath.ToSlash(path), lineNum),
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read Cartfile: %w", err)
+	}
+
+	return packages, nil
+}
+
+// normalizeGitURL extracts the package URL-style name from a Git URL.
+func normalizeGitURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+
+	u, err := url.Parse(rawURL)
+	if err == nil && u.Host != "" && u.Path != "" {
+		path := strings.TrimPrefix(u.Path, "/")
+		return normalizeSwiftURL(u.Host + "/" + path)
+	}
+
+	loc := strings.TrimPrefix(rawURL, "https://")
+	loc = strings.TrimPrefix(loc, "http://")
+	loc = strings.TrimPrefix(loc, "git://")
+	loc = strings.TrimPrefix(loc, "ssh://")
+
+	if idx := strings.Index(loc, ":"); idx != -1 {
+		loc = loc[idx+1:]
+	}
+	loc = strings.TrimPrefix(loc, "/")
+	return normalizeSwiftURL(loc)
+}
+
+func normalizeSwiftURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimSuffix(raw, ".git")
+	raw = strings.TrimPrefix(raw, "https://")
+	raw = strings.TrimPrefix(raw, "http://")
+	raw = strings.TrimPrefix(raw, "git://")
+	raw = strings.TrimPrefix(raw, "ssh://git@")
+	raw = strings.TrimPrefix(raw, "git@")
+	raw = strings.TrimPrefix(raw, "github.com:")
+	if strings.Count(raw, "/") == 1 {
+		raw = "github.com/" + raw
+	}
+	return raw
+}

--- a/extractor/filesystem/language/swift/cartfile/cartfile_test.go
+++ b/extractor/filesystem/language/swift/cartfile/cartfile_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cartfile_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/cartfile"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+	"github.com/google/osv-scalibr/testing/testcollector"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+		wantResultMetric stats.FileRequiredResult
+	}{
+		{
+			name:             "Cartfile",
+			path:             "Cartfile",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "path/to/Cartfile",
+			path:             "path/to/Cartfile",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:         "Cartfile.resolved not required",
+			path:         "Cartfile.resolved",
+			wantRequired: false,
+		},
+		{
+			name:         "other file not required",
+			path:         "Package.resolved",
+			wantRequired: false,
+		},
+		{
+			name:             "Cartfile required if file size < max file size",
+			path:             "Cartfile",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "Cartfile required if file size == max file size",
+			path:             "Cartfile",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "Cartfile not required if file size > max file size",
+			path:             "Cartfile",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 100 * units.KiB,
+			wantRequired:     false,
+			wantResultMetric: stats.FileRequiredResultSizeLimitExceeded,
+		},
+		{
+			name:             "Cartfile required if max file size set to 0",
+			path:             "Cartfile",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 0,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := cartfile.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("cartfile.New: %v", err)
+			}
+			e.(*cartfile.Extractor).Stats = collector
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1000
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+
+			gotResultMetric := collector.FileRequiredResult(tt.path)
+			if tt.wantResultMetric != "" && gotResultMetric != tt.wantResultMetric {
+				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "valid github",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/valid-github",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "github.com/Alamofire/Alamofire",
+					Version:  "~> 5.4",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/valid-github", 1),
+				},
+				{
+					Name:     "github.com/ReactiveX/RxSwift",
+					Version:  "6.5.0",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/valid-github", 2),
+				},
+			},
+		},
+		{
+			Name: "valid git",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/valid-git",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "github.com/SwiftyJSON/SwiftyJSON",
+					Version:  "~> 5.0",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/valid-git", 1),
+				},
+				{
+					Name:     "github.com/ReactiveX/RxSwift",
+					Version:  "6.0.0",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/valid-git", 2),
+				},
+			},
+		},
+		{
+			Name: "empty",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "binary skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/binary-skipped",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "comments",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/comments",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "github.com/Alamofire/Alamofire",
+					Version:  "~> 5.4",
+					PURLType: purl.TypeSwift,
+					Location: extractor.LocationFromPathAndLine("testdata/comments", 3),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := cartfile.New(&cpb.PluginConfig{MaxFileSizeBytes: 100})
+			if err != nil {
+				t.Fatalf("cartfile.New: %v", err)
+			}
+			e.(*cartfile.Extractor).Stats = collector
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/swift/cartfile/testdata/binary-skipped
+++ b/extractor/filesystem/language/swift/cartfile/testdata/binary-skipped
@@ -1,0 +1,1 @@
+binary "https://example.com/framework.json" ~> 1.0

--- a/extractor/filesystem/language/swift/cartfile/testdata/comments
+++ b/extractor/filesystem/language/swift/cartfile/testdata/comments
@@ -1,0 +1,3 @@
+# This is a comment
+# Another comment
+github "Alamofire/Alamofire" ~> 5.4 # inline comment

--- a/extractor/filesystem/language/swift/cartfile/testdata/valid-git
+++ b/extractor/filesystem/language/swift/cartfile/testdata/valid-git
@@ -1,0 +1,2 @@
+git "https://github.com/SwiftyJSON/SwiftyJSON.git" ~> 5.0
+git "git@github.com:ReactiveX/RxSwift.git" "6.0.0"

--- a/extractor/filesystem/language/swift/cartfile/testdata/valid-github
+++ b/extractor/filesystem/language/swift/cartfile/testdata/valid-github
@@ -1,0 +1,2 @@
+github "Alamofire/Alamofire" ~> 5.4
+github "ReactiveX/RxSwift" "6.5.0"

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -84,6 +84,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargoauditable"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargolock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargotoml"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/cartfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/packageresolved"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/podfilelock"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/bazelmaven"
@@ -321,6 +322,7 @@ var (
 	PHPSource = InitMap{composerlock.Name: {composerlock.New}}
 	// SwiftSource extractors for Swift.
 	SwiftSource = InitMap{
+		cartfile.Name:        {cartfile.New},
 		packageresolved.Name: {packageresolved.New},
 		podfilelock.Name:     {podfilelock.New},
 	}


### PR DESCRIPTION
## Summary
- add swift/cartfile filesystem extractor for Carthage Cartfile dependency declarations
- normalize Swift package names to URL-style package identifiers
- register the extractor and document the supported inventory type

## Validation
- go test ./extractor/filesystem/language/swift/cartfile/...
- go test ./extractor/filesystem/language/swift/...
- go test ./extractor/filesystem/list/...
- go test ./plugin/list/...
- go build ./...
- go vet ./extractor/filesystem/language/swift/cartfile/... ./extractor/filesystem/list/...
- git diff --check
- golangci-lint run ./extractor/filesystem/language/swift/cartfile/...