### PR TITLE
docs: update supported inventory for OCaml opam extractor

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -96,6 +96,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 | Julia      | Julia package/project dependencies (Project.toml) | `julia/projecttoml`                  |
 |            | Julia installed packages (Manifest.toml)          | `julia/manifesttoml`                 |
 | Lua        | Luarocks modules                                  | `lua/luarocks`                       |
+| OCaml      | Installed opam packages (.opam-switch/install)    | `ocaml/opam`                         |
 | ObjectiveC | Podfile.lock                                      | `swift/podfilelock`                  |
 | PHP        | Composer                                          | `php/composerlock`                   |
 | Python     | Installed PyPI packages (global and venv)         | `python/wheelegg`                    |


### PR DESCRIPTION
Add the OCaml opam extractor from https://github.com/google/osv-scalibr/pull/1739 to the [supported inventory types](https://github.com/google/osv-scalibr/blob/main/docs/supported_inventory_types.md)

I assume this was missed when the original PR to add the extractor was merged.