### PR TITLE
fix: Set custom UA when fetching Maven registry

### DIFF
--- a/clients/datasource/maven_registry.go
+++ b/clients/datasource/maven_registry.go
@@ -52,6 +52,7 @@ type MavenRegistryAPIClient struct {
 	registryAuths   map[string]*HTTPAuthentication // Authentication for the registries keyed by registry ID. From settings.xml
 	localRegistry   string                         // The local directory that holds Maven manifests
 	localProjects   map[maven.ProjectKey]string    // Paths to projects available in the local source tree.
+	userAgent       string                         // User-Agent string to set on HTTP requests.
 
 	googleClient      *http.Client // A client for authenticating with Google services, used for Artifact Registry.
 	disableGoogleAuth bool         // If true, do not try to create google.DefaultClient for Artifact Registry.
@@ -144,7 +145,30 @@ func (m *MavenRegistryAPIClient) WithoutRegistries() *MavenRegistryAPIClient {
 		googleClient:      m.googleClient,
 		disableGoogleAuth: m.disableGoogleAuth,
 		localProjects:     m.localProjects,
+		userAgent:         m.userAgent,
 	}
+}
+
+// SetUserAgent sets the User-Agent header for the client requests.
+func (m *MavenRegistryAPIClient) SetUserAgent(userAgent string) {
+	m.userAgent = userAgent
+}
+
+type userAgentTransport struct {
+	userAgent string
+	base      http.RoundTripper
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.userAgent != "" && req.Header.Get("User-Agent") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("User-Agent", t.userAgent)
+	}
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
 }
 
 // AddRegistry adds the given registry to the list of registries if it has not been added.
@@ -354,6 +378,15 @@ func (m *MavenRegistryAPIClient) get(ctx context.Context, auth *HTTPAuthenticati
 		if m.googleClient != nil {
 			httpClient = m.googleClient
 		}
+	}
+
+	if m.userAgent != "" {
+		c := *httpClient
+		c.Transport = &userAgentTransport{
+			userAgent: m.userAgent,
+			base:      httpClient.Transport,
+		}
+		httpClient = &c
 	}
 
 	u := requestURL.JoinPath(paths...).String()

--- a/clients/resolution/combined_native_client.go
+++ b/clients/resolution/combined_native_client.go
@@ -43,6 +43,7 @@ type CombinedNativeClientOptions struct {
 	PyPIRegistry      string                             // The default PyPI registry to use.
 	MavenClient       *datasource.MavenRegistryAPIClient // The Maven registry client to use, if nil, a new client will be created.
 	DisableGoogleAuth bool                               // If true, do not try to create google.DefaultClient for Artifact Registry.
+	UserAgent         string                             // User-Agent string to set on client requests.
 }
 
 // NewCombinedNativeClient makes a new CombinedNativeClient.
@@ -50,6 +51,9 @@ func NewCombinedNativeClient(opts CombinedNativeClientOptions) (*CombinedNativeC
 	client := &CombinedNativeClient{opts: opts}
 	if opts.MavenClient != nil {
 		client.mavenRegistryClient = NewMavenRegistryClientWithAPI(opts.MavenClient)
+		if opts.UserAgent != "" {
+			client.mavenRegistryClient.SetUserAgent(opts.UserAgent)
+		}
 	}
 	return client, nil
 }
@@ -119,6 +123,9 @@ func (c *CombinedNativeClient) clientForSystem(ctx context.Context, sys resolve.
 			c.mavenRegistryClient, err = NewMavenRegistryClient(ctx, c.opts.MavenRegistry, c.opts.LocalRegistry, c.opts.DisableGoogleAuth)
 			if err != nil {
 				return nil, err
+			}
+			if c.opts.UserAgent != "" {
+				c.mavenRegistryClient.SetUserAgent(c.opts.UserAgent)
 			}
 		}
 		return c.mavenRegistryClient, nil

--- a/clients/resolution/maven_registry_client.go
+++ b/clients/resolution/maven_registry_client.go
@@ -49,6 +49,11 @@ func NewMavenRegistryClientWithAPI(api *datasource.MavenRegistryAPIClient) *Mave
 	return &MavenRegistryClient{api: api}
 }
 
+// SetUserAgent sets the User-Agent header for the client requests.
+func (c *MavenRegistryClient) SetUserAgent(userAgent string) {
+	c.api.SetUserAgent(userAgent)
+}
+
 // Version returns metadata of a version specified by the VersionKey.
 func (c *MavenRegistryClient) Version(ctx context.Context, vk resolve.VersionKey) (resolve.Version, error) {
 	g, a, found := strings.Cut(vk.Name, ":")

--- a/enricher/transitivedependency/pomxml/pomxml.go
+++ b/enricher/transitivedependency/pomxml/pomxml.go
@@ -103,6 +103,9 @@ func New(cfg *cpb.PluginConfig) (enricher.Enricher, error) {
 		URL:             upstreamRegistry,
 		ReleasesEnabled: true,
 	}, cfg.LocalRegistry, cfg.DisableGoogleAuth)
+	if cfg.UserAgent != "" {
+		mavenClient.SetUserAgent(cfg.UserAgent)
+	}
 
 	var depClient resolve.Client
 	var err error


### PR DESCRIPTION
## Problems

- Custom user agent header (e.g. `osv-scanner_scan-source/vx.x.x`) defined but not used when fetching POM from Maven registry. Default `Go-http-client/2.0` is used cause Maven registry to respond 429 status

## Changes

- Used defined custom user agent header when fetching Maven registry.