### PR TITLE
extractor/os/rpm: add openSUSE Leap ecosystem mapping

### DIFF
--- a/extractor/filesystem/os/ecosystem/ecosystem.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem.go
@@ -100,6 +100,15 @@ func MakeEcosystem(metadata any) osvecosystem.Parsed {
 		if m.OSID == "azurelinux" || m.OSID == "mariner" {
 			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemAzureLinux, Suffix: m.OSVersionID}
 		}
+		if m.OSID == "opensuse-leap" {
+			// OSV.dev openSUSE advisories use the suffix "Leap X.Y"
+			// (e.g. "openSUSE:Leap 15.5"), confirmed via OSV.dev API.
+			// Using VERSION_ID alone ("15.5") would not match any advisory.
+			if m.OSVersionID == "" {
+				return osvecosystem.FromEcosystem(osvconstants.EcosystemOpenSUSE)
+			}
+			return osvecosystem.Parsed{Ecosystem: osvconstants.EcosystemOpenSUSE, Suffix: "Leap " + m.OSVersionID}
+		}
 
 	case *snapmeta.Metadata:
 		if m.OSID == "ubuntu" {

--- a/extractor/filesystem/os/ecosystem/ecosystem_test.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem_test.go
@@ -428,6 +428,40 @@ func TestEcosystemRPM(t *testing.T) {
 			want: "Azure Linux",
 		},
 		{
+			// OSV.dev openSUSE advisories use suffix "Leap X.Y" (e.g. "openSUSE:Leap 15.5").
+			// Confirmed via OSV.dev API: SUSE-SU-2022:1657-1 lists openSUSE:Leap 15.3 and 15.4.
+			desc: "openSUSE_Leap_15.5",
+			metadata: &rpmmeta.Metadata{
+				OSID:        "opensuse-leap",
+				OSVersionID: "15.5",
+			},
+			want: "openSUSE:Leap 15.5",
+		},
+		{
+			desc: "openSUSE_Leap_15.3",
+			metadata: &rpmmeta.Metadata{
+				OSID:        "opensuse-leap",
+				OSVersionID: "15.3",
+			},
+			want: "openSUSE:Leap 15.3",
+		},
+		{
+			desc: "openSUSE_Leap_15.4",
+			metadata: &rpmmeta.Metadata{
+				OSID:        "opensuse-leap",
+				OSVersionID: "15.4",
+			},
+			want: "openSUSE:Leap 15.4",
+		},
+		{
+			// When VERSION_ID is missing, return the base ecosystem without suffix.
+			desc: "openSUSE_Leap_no_version",
+			metadata: &rpmmeta.Metadata{
+				OSID: "opensuse-leap",
+			},
+			want: "openSUSE",
+		},
+		{
 			desc:     "OS ID not present",
 			metadata: &rpmmeta.Metadata{},
 			want:     "",


### PR DESCRIPTION
## Summary

`ID=opensuse-leap` from `/etc/os-release` had no case in the `*rpmmeta.Metadata` switch in `ecosystem.go`. It fell through with `namespace = ""`, producing an empty ecosystem string. As a result, none of the 12,954 openSUSE advisories tracked on OSV.dev were ever reachable for any openSUSE Leap container scan.

Closes #2203.

## Root cause

The `MakeEcosystem` function handles `rhel`, `rocky`, `openEuler`, and `almalinux` explicitly before falling through to the generic namespace path. `opensuse-leap` was not included, so the namespace remained `""` and the ecosystem was never set.

`EcosystemOpenSUSE` was already defined in `inventory/osvecosystem/parsed.go` but never referenced in `ecosystem.go`.

## Fix

Added one `if` branch for `OSID == "opensuse-leap"` that constructs the suffix as `"Leap " + m.OSVersionID`. This matches the format used by OSV.dev for openSUSE advisories (e.g. `openSUSE:Leap 15.5`). Using `VERSION_ID` alone (`"15.5"`) does not match any advisory.

When `VERSION_ID` is absent, the function returns the base ecosystem without suffix via `osvecosystem.FromEcosystem`.

## Verification

Verified against OSV.dev API:
- `openSUSE:Leap 15.5` returns SUSE-SU advisories for curl, openssl, and others.
- `openSUSE:Leap 15.3` and `openSUSE:Leap 15.4` match SUSE-SU-2022:1657-1 (curl, High severity).
- `openSUSE:15.5` (no "Leap" prefix) returns zero results.

Confirmed `/etc/os-release` on `opensuse/leap:15.5`:
```
ID="opensuse-leap"
VERSION_ID="15.5"
```

All existing `TestEcosystemRPM` cases continue to pass. New test cases added for Leap 15.3, 15.4, 15.5, and the no-version edge case.

## Files changed

- `extractor/filesystem/os/ecosystem/ecosystem.go`: add `opensuse-leap` case
- `extractor/filesystem/os/ecosystem/ecosystem_test.go`: add four test cases for openSUSE Leap