### PR TITLE
fix: support maven module path pointing directly to pom.xml

### DIFF
--- a/internal/mavenutil/maven.go
+++ b/internal/mavenutil/maven.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -354,8 +355,12 @@ func DiscoverModules(scanRoot *scalibrfs.ScanRoot, initialPaths []string, client
 		// Add modules to queue
 		dir := filepath.Dir(path)
 		for _, m := range project.Modules {
-			modulePath := filepath.Join(dir, string(m), "pom.xml")
-			queue = append(queue, filepath.ToSlash(modulePath))
+			modulePath := filepath.ToSlash(filepath.Join(dir, string(m)))
+			if info, err := fs.Stat(scanRoot.FS, modulePath); err == nil && !info.IsDir() {
+				queue = append(queue, modulePath)
+			} else {
+				queue = append(queue, filepath.ToSlash(filepath.Join(modulePath, "pom.xml")))
+			}
 		}
 
 		// Add parent to queue if it exists locally

--- a/internal/mavenutil/maven_test.go
+++ b/internal/mavenutil/maven_test.go
@@ -20,7 +20,10 @@ import (
 
 	"deps.dev/util/resolve"
 	"deps.dev/util/semver"
+	"github.com/google/osv-scalibr/clients/datasource"
+	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
 )
 
 func TestParentPOMPath(t *testing.T) {
@@ -171,5 +174,62 @@ func TestCompareVersions(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("CompareVersions(%v, %v, %v): got %b, want %b", tt.vk, tt.a, tt.b, got, tt.want)
 		}
+	}
+}
+
+func TestDiscoverModules(t *testing.T) {
+	txt := `
+-- pom.xml --
+<project>
+  <groupId>org.example</groupId>
+  <artifactId>parent-project</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>sub-dir</module>
+    <module>sub-file.xml</module>
+  </modules>
+</project>
+-- sub-dir/pom.xml --
+<project>
+  <groupId>org.example</groupId>
+  <artifactId>sub-dir-module</artifactId>
+  <version>1.0.0</version>
+</project>
+-- sub-file.xml --
+<project>
+  <groupId>org.example</groupId>
+  <artifactId>sub-file-module</artifactId>
+  <version>1.0.0</version>
+</project>
+`
+	fsys, err := fakefs.PrepareFS(txt)
+	if err != nil {
+		t.Fatalf("failed to prepare fake fs: %v", err)
+	}
+
+	client, err := datasource.NewDefaultMavenRegistryAPIClient(t.Context(), "")
+	if err != nil {
+		t.Fatalf("failed to create maven registry client: %v", err)
+	}
+
+	scanRoot := &scalibrfs.ScanRoot{FS: fsys, Path: ""}
+	DiscoverModules(scanRoot, []string{"pom.xml"}, client)
+
+	tests := []struct {
+		g, a, v string
+	}{
+		{g: "org.example", a: "parent-project", v: "1.0.0"},
+		{g: "org.example", a: "sub-dir-module", v: "1.0.0"},
+		{g: "org.example", a: "sub-file-module", v: "1.0.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a, func(t *testing.T) {
+			_, err := client.GetProject(t.Context(), tt.g, tt.a, tt.v)
+			if err != nil {
+				t.Errorf("failed to get project %s:%s:%s from local registry: %v", tt.g, tt.a, tt.v, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
When a Maven `<module>` tag points directly to a POM file (e.g. `<module>abc/pom.xml</module>`) instead of a directory, SCALIBR incorrectly appended `/pom.xml` to it (resulting in `app/pom.xml/pom.xml`), failing with a `not a directory` error.

To resolve this error, this PR uses `fs.Stat` to check if the module path is a file. If it exists and is not a directory, resolve it directly. Otherwise, fall back to appending `/pom.xml`.

Also added `TestDiscoverModules` in `internal/mavenutil/maven_test.go` to cover both directory and direct file module definitions.