### PR TITLE
Fix panic parsing an npm alias with no version in `package-lock.json`

### DIFF
--- a/extractor/filesystem/language/javascript/helper/helper.go
+++ b/extractor/filesystem/language/javascript/helper/helper.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package helper provides parsing helpers shared by the JavaScript extractors.
+package helper
+
+import "strings"
+
+// SplitNPMAlias extracts the real package name and version from an alias-specified version.
+//
+// e.g. "npm:pkg@^1.2.3" -> name: "pkg", version: "^1.2.3"
+//
+// If the version is not an alias specifier, the name will be empty and the version unchanged.
+func SplitNPMAlias(v string) (name, version string) {
+	if r, ok := strings.CutPrefix(v, "npm:"); ok {
+		// A leading "@" is the scope of e.g. "@babel/code-frame" rather than the
+		// separator before the version, so only split on a later one.
+		if i := strings.LastIndex(r, "@"); i > 0 {
+			return r[:i], r[i+1:]
+		}
+
+		return r, "" // alias with no version specified
+	}
+
+	return "", v // not an alias
+}

--- a/extractor/filesystem/language/javascript/helper/helper_test.go
+++ b/extractor/filesystem/language/javascript/helper/helper_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/helper"
+)
+
+func TestSplitNPMAlias(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantName    string
+		wantVersion string
+	}{
+		{
+			name:        "not an alias",
+			input:       "1.2.3",
+			wantName:    "",
+			wantVersion: "1.2.3",
+		},
+		{
+			name:        "empty",
+			input:       "",
+			wantName:    "",
+			wantVersion: "",
+		},
+		{
+			name:        "alias",
+			input:       "npm:string-width@^4.2.0",
+			wantName:    "string-width",
+			wantVersion: "^4.2.0",
+		},
+		{
+			name:        "scoped alias",
+			input:       "npm:@babel/code-frame@7.0.0",
+			wantName:    "@babel/code-frame",
+			wantVersion: "7.0.0",
+		},
+		{
+			name:        "alias with no version",
+			input:       "npm:string-width",
+			wantName:    "string-width",
+			wantVersion: "",
+		},
+		{
+			// The "@" here is the scope marker, not the separator before a version.
+			name:        "scoped alias with no version",
+			input:       "npm:@babel/code-frame",
+			wantName:    "@babel/code-frame",
+			wantVersion: "",
+		},
+		{
+			name:        "alias with no package",
+			input:       "npm:",
+			wantName:    "",
+			wantVersion: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotVersion := helper.SplitNPMAlias(tt.input)
+			if gotName != tt.wantName || gotVersion != tt.wantVersion {
+				t.Errorf("SplitNPMAlias(%q) = (%q, %q), want (%q, %q)",
+					tt.input, gotName, gotVersion, tt.wantName, tt.wantVersion)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
@@ -872,8 +872,10 @@ func TestNPMLockExtractor_Extract_V1(t *testing.T) {
 					},
 				},
 				{
-					Name:       "",
-					Version:    "",
+					// "npm:" specifies no package to alias, so the entry keeps its
+					// own name rather than being attributed to an empty one.
+					Name:       "empty-alias",
+					Version:    "npm:",
 					PURLType:   purl.TypeNPM,
 					Location:   extractor.LocationFromPath("testdata/alias-no-version.v1.json"),
 					SourceCode: &extractor.SourceCodeIdentifier{},

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson-v1_test.go
@@ -846,6 +846,44 @@ func TestNPMLockExtractor_Extract_V1(t *testing.T) {
 			},
 		},
 		{
+			Name: "alias with no version",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/alias-no-version.v1.json",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:       "string-width",
+					Version:    "",
+					PURLType:   purl.TypeNPM,
+					Location:   extractor.LocationFromPath("testdata/alias-no-version.v1.json"),
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+				{
+					Name:       "@babel/code-frame",
+					Version:    "",
+					PURLType:   purl.TypeNPM,
+					Location:   extractor.LocationFromPath("testdata/alias-no-version.v1.json"),
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+				{
+					Name:       "",
+					Version:    "",
+					PURLType:   purl.TypeNPM,
+					Location:   extractor.LocationFromPath("testdata/alias-no-version.v1.json"),
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+			},
+		},
+		{
 			Name: "optional package",
 			InputConfig: extracttest.ScanInputMockConfig{
 				Path: "testdata/optional-package.v1.json",

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson.go
@@ -110,10 +110,18 @@ func parseNpmLockDependencies(dependencies map[string]packagelockjson.Dependency
 
 		// If the package is aliased, get the name and version
 		// E.g. npm:string-width@^4.2.0
-		if strings.HasPrefix(detail.Version, "npm:") {
-			i := strings.LastIndex(detail.Version, "@")
-			name = detail.Version[4:i]
-			finalVersion = detail.Version[i+1:]
+		if alias, ok := strings.CutPrefix(detail.Version, "npm:"); ok {
+			// A leading "@" is the scope of e.g. "@babel/code-frame" rather than the
+			// separator before the version, so only split on a later one. Without the
+			// index check an alias with no version ("npm:", "npm:string-width") slices
+			// with a negative or zero bound. Matches npm.SplitNPMAlias.
+			if i := strings.LastIndex(alias, "@"); i > 0 {
+				name = alias[:i]
+				finalVersion = alias[i+1:]
+			} else {
+				name = alias
+				finalVersion = ""
+			}
 		}
 
 		// we can't resolve a version from a "file:" dependency

--- a/extractor/filesystem/language/javascript/packagelockjson/packagelockjson.go
+++ b/extractor/filesystem/language/javascript/packagelockjson/packagelockjson.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/extractor/filesystem/internal/linefinder"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/helper"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/internal/commitextractor"
 	"github.com/google/osv-scalibr/extractor/filesystem/osv"
 	"github.com/google/osv-scalibr/internal/dependencyfile/packagelockjson"
@@ -110,18 +111,9 @@ func parseNpmLockDependencies(dependencies map[string]packagelockjson.Dependency
 
 		// If the package is aliased, get the name and version
 		// E.g. npm:string-width@^4.2.0
-		if alias, ok := strings.CutPrefix(detail.Version, "npm:"); ok {
-			// A leading "@" is the scope of e.g. "@babel/code-frame" rather than the
-			// separator before the version, so only split on a later one. Without the
-			// index check an alias with no version ("npm:", "npm:string-width") slices
-			// with a negative or zero bound. Matches npm.SplitNPMAlias.
-			if i := strings.LastIndex(alias, "@"); i > 0 {
-				name = alias[:i]
-				finalVersion = alias[i+1:]
-			} else {
-				name = alias
-				finalVersion = ""
-			}
+		if aliasName, aliasVersion := helper.SplitNPMAlias(detail.Version); aliasName != "" {
+			name = aliasName
+			finalVersion = aliasVersion
 		}
 
 		// we can't resolve a version from a "file:" dependency

--- a/extractor/filesystem/language/javascript/packagelockjson/testdata/alias-no-version.v1.json
+++ b/extractor/filesystem/language/javascript/packagelockjson/testdata/alias-no-version.v1.json
@@ -1,0 +1,15 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "string-width-cjs": {
+      "version": "npm:string-width"
+    },
+    "babel-code-frame": {
+      "version": "npm:@babel/code-frame"
+    },
+    "empty-alias": {
+      "version": "npm:"
+    }
+  }
+}

--- a/guidedremediation/internal/lockfile/npm/packagelockjson.go
+++ b/guidedremediation/internal/lockfile/npm/packagelockjson.go
@@ -26,9 +26,9 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scalibr/clients/datasource"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/helper"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/guidedremediation/internal/lockfile"
-	"github.com/google/osv-scalibr/guidedremediation/internal/manifest/npm"
 	"github.com/google/osv-scalibr/guidedremediation/result"
 	"github.com/google/osv-scalibr/guidedremediation/strategy"
 	"github.com/google/osv-scalibr/internal/dependencyfile/packagelockjson"
@@ -223,7 +223,7 @@ func findDependencyNode(node *nodeModule, depName string) resolve.NodeID {
 func reVersionAliasedDeps(deps map[string]dependencyVersionSpec) {
 	// for the dependency maps, change versions from "npm:pkg@version" to "version"
 	for k, v := range deps {
-		_, v.Version = npm.SplitNPMAlias(v.Version)
+		_, v.Version = helper.SplitNPMAlias(v.Version)
 		deps[k] = v
 	}
 }

--- a/guidedremediation/internal/lockfile/npm/packagelockjsonv1.go
+++ b/guidedremediation/internal/lockfile/npm/packagelockjsonv1.go
@@ -25,6 +25,7 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scalibr/clients/datasource"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/helper"
 	"github.com/google/osv-scalibr/guidedremediation/internal/manifest/npm"
 	"github.com/google/osv-scalibr/internal/dependencyfile/packagelockjson"
 	"github.com/tidwall/gjson"
@@ -85,7 +86,7 @@ func nodesFromDependencies(lockJSON packagelockjson.LockFile, packageJSON io.Rea
 
 func computeDependenciesRecursive(g *resolve.Graph, parent *nodeModule, deps map[string]packagelockjson.Dependency) error {
 	for name, d := range deps {
-		actualName, version := npm.SplitNPMAlias(d.Version)
+		actualName, version := helper.SplitNPMAlias(d.Version)
 		nID := g.AddNode(resolve.VersionKey{
 			PackageKey: resolve.PackageKey{
 				System: resolve.NPM,
@@ -144,7 +145,7 @@ func writeDependenciesRecursive(lockf []byte, patchMap map[string]map[string]str
 			}
 		}
 		isAlias := false
-		realPkg, version := npm.SplitNPMAlias(data.Get("version").String())
+		realPkg, version := helper.SplitNPMAlias(data.Get("version").String())
 		if realPkg != "" {
 			isAlias = true
 			pkg = realPkg

--- a/guidedremediation/internal/manifest/npm/packagejson.go
+++ b/guidedremediation/internal/manifest/npm/packagejson.go
@@ -28,6 +28,7 @@ import (
 
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/helper"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/guidedremediation/internal/manifest"
 	"github.com/google/osv-scalibr/guidedremediation/result"
@@ -341,7 +342,7 @@ func parse(path string, fsys scalibrfs.FS, doWorkspaces bool) (*npmManifest, err
 
 func makeNPMReqVer(pkg, ver string) (resolve.RequirementVersion, bool) {
 	typ := dep.NewType() // don't use dep.NewType(dep.Dev) for devDeps to force the resolver to resolve them
-	realPkg, realVer := SplitNPMAlias(ver)
+	realPkg, realVer := helper.SplitNPMAlias(ver)
 	if realPkg != "" {
 		// This dependency is aliased, add it as a
 		// dependency on the actual name, with the
@@ -367,23 +368,6 @@ func makeNPMReqVer(pkg, ver string) (resolve.RequirementVersion, bool) {
 			VersionType: resolve.Requirement,
 		},
 	}, true
-}
-
-// SplitNPMAlias extracts the real package name and version from an alias-specified version.
-//
-// e.g. "npm:pkg@^1.2.3" -> name: "pkg", version: "^1.2.3"
-//
-// If the version is not an alias specifier, the name will be empty and the version unchanged.
-func SplitNPMAlias(v string) (name, version string) {
-	if r, ok := strings.CutPrefix(v, "npm:"); ok {
-		if i := strings.LastIndex(r, "@"); i > 0 {
-			return r[:i], r[i+1:]
-		}
-
-		return r, "" // alias with no version specified
-	}
-
-	return "", v // not an alias
 }
 
 // Write applies the patches to the original manifest, writing the resulting manifest file to the file path in the filesystem.


### PR DESCRIPTION
`parseNpmLockDependencies` splits an aliased dependency's version by slicing at `strings.LastIndex(detail.Version, "@")` without checking the returned index:

https://github.com/google/osv-scalibr/blob/54a7743545577fcbd0386fd26c23d6b19f6ac193/extractor/filesystem/language/javascript/packagelockjson/packagelockjson.go#L113-L117

`detail.Version` is read straight out of the lockfile, so an alias with no version makes the slice bound negative or zero:

| `version` value | before | after |
| --- | --- | --- |
| `npm:` | `[4:-1]` → panic | name `""`, version `""` |
| `npm:string-width` | `[4:-1]` → panic | name `string-width`, version `""` |
| `npm:@babel/code-frame` | name `""`, version `"babel/code-frame"` | name `@babel/code-frame`, version `""` |
| `npm:string-width@4.2.0` | unchanged | unchanged |
| `npm:@babel/code-frame@7.0.0` | unchanged | unchanged |

So the last row of the old behaviour was already relying on `LastIndex` finding the separator rather than the scope marker; with no version present there is no separator and a scoped alias silently parsed into the wrong name.

This is reachable from a default `osv-scanner scan source`: it needs only a `lockfileVersion: 1` file with no `packages` key, which routes to the `dependencies` path, and `packagelockjson` is in the default preset. A three-line `package-lock.json` is enough:

```json
{ "lockfileVersion": 1, "dependencies": { "colors": { "version": "npm:" } } }
```

```
panic: runtime error: slice bounds out of range [:-1]
  .../packagelockjson/packagelockjson.go:115
  .../extractor/filesystem/filesystem.go:609
```

## The fix

This repo already had the guarded parse in [`npm.SplitNPMAlias`](https://github.com/google/osv-scalibr/blob/54a7743545577fcbd0386fd26c23d6b19f6ac193/guidedremediation/internal/manifest/npm/packagejson.go#L377-L387), and [the npm registry client](https://github.com/google/osv-scalibr/blob/54a7743545577fcbd0386fd26c23d6b19f6ac193/clients/resolution/npm_registry_client.go#L95-L104) tests `i > 0` inline for the same reason. Per review, rather than replicating it, `SplitNPMAlias` is moved out of `guidedremediation/internal/manifest/npm` into a new `extractor/filesystem/language/javascript/helper` package, so there is one implementation and the extractor uses it. The four existing call sites in `guidedremediation` are repointed.

Tests:

- `helper_test.go` — unit tests for `SplitNPMAlias`, which had none. Covers the scoped-alias-with-no-version case, where the missing index check showed up as a wrong parse rather than a panic.
- `testdata/alias-no-version.v1.json` + a `packagelockjson` case covering all three rows above. Confirmed it panics at `packagelockjson.go:115` on the pre-fix code and passes after.

A bare `npm:` names no package to alias, so `SplitNPMAlias` returns an empty name and the extractor leaves the entry under its own name rather than attributing it to an empty one — which also avoids emitting the empty-named package my first version produced.

Separately, this panic aborts the entire scan rather than one file, because `runExtractor` calls `Extract` with no `recover()`. That is not specific to this parser, so I've raised it as its own PR — "Do not let a panicking extractor abort the whole filesystem walk".

## Disclosure

Reported to Google's OSS VRP first ([issue 536144722](https://issuetracker.google.com/issues/536144722)). It was closed as not meeting the bar for a security bug, with an explicit invitation to file publicly here, which is what this is.
