### PR TITLE
Fix requirements.txt recursive include path traversal

### DIFF
--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -162,11 +162,20 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 	// infinite loops in misconfigured lockfiles with cyclical deps.
 	var found = map[string]bool{initPath: true}
 	var pkgs []*extractor.Package
+	// Every `-r` include, however deeply chained, must stay within the
+	// directory tree of the file that started this extraction. Anchoring on
+	// initPath (rather than each include's immediate parent) stops a chain
+	// of includes from walking out one hop at a time.
+	anchor := filepath.Dir(initPath)
 
 	for len(extraPaths) > 0 {
 		inc := extraPaths[0]
 		extraPaths = extraPaths[1:]
 		if _, exists := found[inc.path]; exists {
+			continue
+		}
+		if escapesRoot(anchor, inc.path) {
+			log.Warnf("requirements: skipping -r include %q, which escapes the scan root", inc.path)
 			continue
 		}
 		newPKG, newPaths, err := openAndExtractFromFile(inc.path, fs)
@@ -187,6 +196,27 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 	}
 
 	return pkgs
+}
+
+// escapesRoot reports whether resolved (an already filepath.Join/Clean-ed
+// include path) falls outside the directory tree rooted at anchor.
+//
+// filepath.Join/Clean silently absorb ".." segments against the preceding
+// path components, so a cleaned path can end up with no literal ".." left
+// in it at all even when the include walked above the intended root -- see
+// #2323, where `-r ../../secret.txt` resolved to a clean, ".."-free path
+// once enough real directory components were available to cancel against.
+// Checking the cleaned string for a leading ".." is therefore not
+// sufficient on its own. filepath.Rel instead recomputes, from scratch,
+// how you'd actually get from anchor to resolved -- if that requires any
+// upward step, the result begins with "..", regardless of whether the
+// intermediate join happened to cancel out completely.
+func escapesRoot(anchor, resolved string) bool {
+	rel, err := filepath.Rel(anchor, resolved)
+	if err != nil {
+		return true
+	}
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func openAndExtractFromFile(path string, fs scalibrfs.FS) ([]*extractor.Package, pathQueue, error) {

--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -162,10 +162,12 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 	// infinite loops in misconfigured lockfiles with cyclical deps.
 	var found = map[string]bool{initPath: true}
 	var pkgs []*extractor.Package
-	// Every `-r` include, however deeply chained, must stay within the
-	// directory tree of the file that started this extraction. Anchoring on
-	// initPath (rather than each include's immediate parent) stops a chain
-	// of includes from walking out one hop at a time.
+	// This is a scalibr-imposed security boundary rather than a pip
+	// requirement. Recursive includes are constrained to the directory tree
+	// of the initial requirements file to prevent path traversal outside the
+	// intended scan root (#2323). Anchoring on initPath (rather than each
+	// include's immediate parent) stops a chain of includes from walking out
+	// one hop at a time.
 	anchor := filepath.Dir(initPath)
 
 	for len(extraPaths) > 0 {
@@ -216,7 +218,7 @@ func escapesRoot(anchor, resolved string) bool {
 	if err != nil {
 		return true
 	}
-	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	return !filepath.IsLocal(rel)
 }
 
 func openAndExtractFromFile(path string, fs scalibrfs.FS) ([]*extractor.Package, pathQueue, error) {

--- a/extractor/filesystem/language/python/requirements/requirements_test.go
+++ b/extractor/filesystem/language/python/requirements/requirements_test.go
@@ -16,6 +16,7 @@ package requirements_test
 
 import (
 	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -672,5 +673,55 @@ func TestExtract(t *testing.T) {
 				t.Errorf("Extract(%s) recorded file size %v, want file size %v", tt.path, gotFileSizeMetric, info.Size())
 			}
 		})
+	}
+}
+
+// TestRequirementsRecursiveIncludeEscape reproduces #2323: a `-r` include
+// that walks upward enough times to land outside the directory of the
+// top-level requirements.txt that started the extraction. Unlike a naive
+// "-r ../secret.txt", the joined-and-cleaned path here ends up with no
+// literal ".." left in it at all (it fully cancels against "a/b/reqs"),
+// which is exactly what let this slip past a plain string check.
+func TestRequirementsRecursiveIncludeEscape(t *testing.T) {
+	root := t.TempDir()
+	reqsDir := filepath.Join(root, "a", "b", "reqs")
+	if err := os.MkdirAll(reqsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", reqsDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "secret.txt"), []byte("secret-package==1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(secret.txt): %v", err)
+	}
+	reqPath := filepath.Join(reqsDir, "requirements.txt")
+	if err := os.WriteFile(reqPath, []byte("-r ../../../secret.txt\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(requirements.txt): %v", err)
+	}
+
+	e, err := requirements.New(&cpb.PluginConfig{})
+	if err != nil {
+		t.Fatalf("requirements.New() error: %v", err)
+	}
+
+	fsys := scalibrfs.DirFS(root)
+	relPath := "a/b/reqs/requirements.txt"
+	r, err := fsys.Open(relPath)
+	if err != nil {
+		t.Fatalf("Open(%q): %v", relPath, err)
+	}
+	defer r.Close()
+	info, err := r.Stat()
+	if err != nil {
+		t.Fatalf("Stat(): %v", err)
+	}
+
+	input := &filesystem.ScanInput{FS: fsys, Path: relPath, Info: info, Reader: r}
+	got, err := e.Extract(t.Context(), input)
+	if err != nil {
+		t.Fatalf("Extract(%s): %v", relPath, err)
+	}
+
+	for _, pkg := range got.Packages {
+		if pkg.Name == "secret-package" {
+			t.Errorf("Extract(%s) leaked package %+v from outside the top-level file's directory tree", relPath, pkg)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes the path traversal issue described in #2323.

Previously, recursive `-r` includes were resolved relative to the current include path without verifying that the resolved path remained inside the directory tree of the original top-level `requirements.txt`. Because `filepath.Join`/`filepath.Clean` normalize `..` components, traversal could succeed even when the final path no longer contained any literal `..` segments.

### Changes

* Anchor recursive `-r` includes to the directory of the initial `requirements.txt`.
* Reject resolved include paths that escape the anchored directory using `filepath.Rel`.
* Add a regression test (`TestRequirementsRecursiveIncludeEscape`) covering the traversal case from #2323.

### Rationale

Checking for a literal `..` prefix is insufficient because `filepath.Join` and `filepath.Clean` may completely eliminate `..` components during normalization. Using `filepath.Rel` recomputes the relationship between the anchor directory and the resolved path, allowing upward traversal to be detected even after path normalization.

This change prevents recursive includes from escaping the original requirements tree while preserving existing include behavior for valid paths.

### Testing

```bash
go test ./extractor/filesystem/language/python/requirements -v
```

Result:

* All existing tests pass.
* `TestRequirementsRecursiveIncludeEscape` passes.

### Notes

This patch hardens the requirements extractor itself by preventing recursive includes from escaping the original requirements tree. It complements, but does not replace, scan-root enforcement performed elsewhere in the scanning pipeline.

Fixes #2323
