### PR TITLE
Refactor GuidedRemediation to use os.Root

### DIFF
--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -18,9 +18,7 @@ package requirements
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
-	"io/fs"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -152,16 +150,13 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	pkgs = append(pkgs, newRepos...)
 
 	// Process all the recursive files that we found.
-	extraPKG, err := extractFromExtraPaths(input.Path, extraPaths, input.FS)
-	if err != nil {
-		return inventory.Inventory{}, err
-	}
+	extraPKG := extractFromExtraPaths(input.Path, extraPaths, input.FS)
 	pkgs = append(pkgs, extraPKG...)
 
 	return inventory.Inventory{Packages: pkgs}, nil
 }
 
-func extractFromExtraPaths(initPath string, extraPaths pathQueue, fsys scalibrfs.FS) ([]*extractor.Package, error) {
+func extractFromExtraPaths(initPath string, extraPaths pathQueue, fsys scalibrfs.FS) []*extractor.Package {
 	// File paths with packages already found in this extraction.
 	// We store these to remove duplicates in diamond dependency cases and prevent
 	// infinite loops in misconfigured lockfiles with cyclical deps.
@@ -174,11 +169,7 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fsys scalibrfs
 		if _, exists := found[inc.path]; exists {
 			continue
 		}
-		cleanPath := filepath.ToSlash(filepath.Clean(inc.path))
-		if !fs.ValidPath(cleanPath) {
-			return nil, fmt.Errorf("referenced requirements path %q escapes the scan root", inc.path)
-		}
-		newPKG, newPaths, err := openAndExtractFromFile(cleanPath, fsys)
+		newPKG, newPaths, err := openAndExtractFromFile(inc.path, fsys)
 		if err != nil {
 			log.Warnf("openAndExtractFromFile(%q): %v", inc.path, err)
 			continue
@@ -195,7 +186,7 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fsys scalibrfs
 		pkgs = append(pkgs, newPKG...)
 	}
 
-	return pkgs, nil
+	return pkgs
 }
 
 func openAndExtractFromFile(path string, fs scalibrfs.FS) ([]*extractor.Package, pathQueue, error) {

--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -18,7 +18,9 @@ package requirements
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
+	"io/fs"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -150,13 +152,16 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (in
 	pkgs = append(pkgs, newRepos...)
 
 	// Process all the recursive files that we found.
-	extraPKG := extractFromExtraPaths(input.Path, extraPaths, input.FS)
+	extraPKG, err := extractFromExtraPaths(input.Path, extraPaths, input.FS)
+	if err != nil {
+		return inventory.Inventory{}, err
+	}
 	pkgs = append(pkgs, extraPKG...)
 
 	return inventory.Inventory{Packages: pkgs}, nil
 }
 
-func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.FS) []*extractor.Package {
+func extractFromExtraPaths(initPath string, extraPaths pathQueue, fsys scalibrfs.FS) ([]*extractor.Package, error) {
 	// File paths with packages already found in this extraction.
 	// We store these to remove duplicates in diamond dependency cases and prevent
 	// infinite loops in misconfigured lockfiles with cyclical deps.
@@ -169,7 +174,11 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 		if _, exists := found[inc.path]; exists {
 			continue
 		}
-		newPKG, newPaths, err := openAndExtractFromFile(inc.path, fs)
+		cleanPath := filepath.ToSlash(filepath.Clean(inc.path))
+		if !fs.ValidPath(cleanPath) {
+			return nil, fmt.Errorf("referenced requirements path %q escapes the scan root", inc.path)
+		}
+		newPKG, newPaths, err := openAndExtractFromFile(cleanPath, fsys)
 		if err != nil {
 			log.Warnf("openAndExtractFromFile(%q): %v", inc.path, err)
 			continue
@@ -186,7 +195,7 @@ func extractFromExtraPaths(initPath string, extraPaths pathQueue, fs scalibrfs.F
 		pkgs = append(pkgs, newPKG...)
 	}
 
-	return pkgs
+	return pkgs, nil
 }
 
 func openAndExtractFromFile(path string, fs scalibrfs.FS) ([]*extractor.Package, pathQueue, error) {

--- a/guidedremediation/README.md
+++ b/guidedremediation/README.md
@@ -35,6 +35,15 @@ modifying the project's dependency files (manifests or lockfiles).
 > `requirements.txt` as the lockfile (compiled output). However, a standalone
 > `requirements.txt` can also be treated as a manifest depending on usage.
 
+## Project Boundary
+
+Guided remediation confines manifest and lockfile access to a project boundary.
+Set `ProjectRoot` to choose this boundary explicitly. If it is empty, guided
+remediation uses the nearest enclosing Git repository root and falls back to the
+directory containing the selected manifest or lockfile when no Git repository
+is found. Files outside this boundary, including Maven parent POMs, are not read
+or updated.
+
 ## Remediation Strategies
 
 Strategies are defined in the `guidedremediation/strategy` subpackage:
@@ -44,4 +53,3 @@ Strategies are defined in the `guidedremediation/strategy` subpackage:
   versions.
 - **`override`**: Uses ecosystem-specific override mechanisms to force a
 specific version.
-

--- a/guidedremediation/guidedremediation.go
+++ b/guidedremediation/guidedremediation.go
@@ -197,7 +197,7 @@ func Update(opts options.UpdateOptions) (result.Result, error) {
 		return result.Result{}, err
 	}
 
-	mf, err := parser.ParseManifest(opts.Manifest, manifestRW)
+	mf, err := parser.ParseManifest(opts.Manifest, manifestRW, opts.ProjectRoot)
 	if err != nil {
 		return result.Result{}, err
 	}
@@ -211,7 +211,7 @@ func Update(opts options.UpdateOptions) (result.Result, error) {
 		return result.Result{}, err
 	}
 
-	err = parser.WriteManifestPatches(opts.Manifest, mf, []result.Patch{patch}, manifestRW)
+	err = parser.WriteManifestPatches(opts.Manifest, mf, []result.Patch{patch}, manifestRW, opts.ProjectRoot)
 
 	return result.Result{
 		Path:      opts.Manifest,
@@ -232,7 +232,7 @@ func doManifestStrategy(ctx context.Context, s strategy.Strategy, rw manifest.Re
 	default:
 		return result.Result{}, fmt.Errorf("unsupported strategy: %q", s)
 	}
-	m, err := parser.ParseManifest(opts.Manifest, rw)
+	m, err := parser.ParseManifest(opts.Manifest, rw, opts.ProjectRoot)
 	if err != nil {
 		return result.Result{}, err
 	}
@@ -279,7 +279,7 @@ func doManifestStrategy(ctx context.Context, s strategy.Strategy, rw manifest.Re
 	if m.System() == resolve.Maven && opts.NoMavenNewDepMgmt {
 		res.Patches = filterMavenPatches(res.Patches, m.EcosystemSpecific())
 	}
-	if err := parser.WriteManifestPatches(opts.Manifest, m, res.Patches, rw); err != nil {
+	if err := parser.WriteManifestPatches(opts.Manifest, m, res.Patches, rw, opts.ProjectRoot); err != nil {
 		return res, err
 	}
 
@@ -297,7 +297,7 @@ func doLockfileStrategy(ctx context.Context, s strategy.Strategy, rw lockfile.Re
 	if s != strategy.StrategyInPlace {
 		return result.Result{}, fmt.Errorf("unsupported strategy: %q", s)
 	}
-	g, err := parser.ParseLockfile(opts.Lockfile, rw)
+	g, err := parser.ParseLockfile(opts.Lockfile, rw, opts.ProjectRoot)
 	if err != nil {
 		return result.Result{}, err
 	}
@@ -319,7 +319,7 @@ func doLockfileStrategy(ctx context.Context, s strategy.Strategy, rw lockfile.Re
 	}
 	res.Vulnerabilities = computeVulnsResultsLockfile(resolved, allPatches, opts.RemediationOptions)
 	res.Patches = choosePatches(allPatches, opts.MaxUpgrades, opts.NoIntroduce, true)
-	err = parser.WriteLockfilePatches(opts.Lockfile, res.Patches, rw)
+	err = parser.WriteLockfilePatches(opts.Lockfile, res.Patches, rw, opts.ProjectRoot)
 	return res, err
 }
 
@@ -531,7 +531,7 @@ func computeRelockPatches(ctx context.Context, res *result.Result, resolvedManif
 		return err
 	}
 
-	g, err := parser.ParseLockfile(opts.Lockfile, lockfileRW)
+	g, err := parser.ParseLockfile(opts.Lockfile, lockfileRW, opts.ProjectRoot)
 	if err != nil {
 		return err
 	}

--- a/guidedremediation/internal/lockfile/lockfile.go
+++ b/guidedremediation/internal/lockfile/lockfile.go
@@ -16,6 +16,8 @@
 package lockfile
 
 import (
+	"os"
+
 	"deps.dev/util/resolve"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/guidedremediation/result"
@@ -30,7 +32,6 @@ type ReadWriter interface {
 
 	// Write writes the lockfile after applying the patches to outputPath.
 	//
-	// path is the path to the original (unpatched) lockfile in fsys.
-	// outputPath is the path on disk (*not* in fsys) to write the entire patched lockfile to (this can overwrite the original lockfile).
-	Write(path string, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error
+	// path is relative to fsys and outputPath is relative to outputRoot.
+	Write(path string, fsys scalibrfs.FS, patches []result.Patch, outputRoot *os.Root, outputPath string) error
 }

--- a/guidedremediation/internal/lockfile/npm/packagelockjson.go
+++ b/guidedremediation/internal/lockfile/npm/packagelockjson.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -165,7 +166,7 @@ func (r readWriter) Read(path string, fsys scalibrfs.FS) (*resolve.Graph, error)
 }
 
 // Write writes the lockfile after applying the patches to outputPath.
-func (r readWriter) Write(path string, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error {
+func (r readWriter) Write(path string, fsys scalibrfs.FS, patches []result.Patch, outputRoot *os.Root, outputPath string) error {
 	// Read the whole package-lock.json into memory so we can use sjson to write in-place.
 	f, err := fsys.Open(path)
 	if err != nil {
@@ -189,7 +190,11 @@ func (r readWriter) Write(path string, fsys scalibrfs.FS, patches []result.Patch
 	}
 
 	// We need access to the npm registry to get information about the new versions. (e.g. hashes)
-	api, err := datasource.NewNPMRegistryAPIClient(filepath.Dir(outputPath))
+	if !fs.ValidPath(filepath.ToSlash(outputPath)) {
+		return fmt.Errorf("invalid output path %q", outputPath)
+	}
+	hostOutputPath := filepath.Join(outputRoot.Name(), filepath.FromSlash(outputPath))
+	api, err := datasource.NewNPMRegistryAPIClient(filepath.Dir(hostOutputPath))
 	if err != nil {
 		return fmt.Errorf("failed to connect to npm registry: %w", err)
 	}
@@ -202,10 +207,10 @@ func (r readWriter) Write(path string, fsys scalibrfs.FS, patches []result.Patch
 	}
 
 	// Write the patched lockfile to the output path.
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+	if err := outputRoot.MkdirAll(filepath.ToSlash(filepath.Dir(outputPath)), 0755); err != nil {
 		return err
 	}
-	return os.WriteFile(outputPath, lockf, 0644)
+	return outputRoot.WriteFile(filepath.ToSlash(outputPath), lockf, 0644)
 }
 
 func findDependencyNode(node *nodeModule, depName string) resolve.NodeID {

--- a/guidedremediation/internal/lockfile/npm/packagelockjson_test.go
+++ b/guidedremediation/internal/lockfile/npm/packagelockjson_test.go
@@ -236,7 +236,12 @@ func TestWrite(t *testing.T) {
 		t.Fatalf("error creating ReadWriter: %v", err)
 	}
 	gotPath := filepath.Join(outDir, "package-lock.json")
-	if err := rw.Write("write/package-lock.json", scalibrfs.DirFS("testdata"), patches, gotPath); err != nil {
+	outFS, err := os.OpenRoot(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFS.Close()
+	if err := rw.Write("write/package-lock.json", scalibrfs.DirFS("testdata"), patches, outFS, "package-lock.json"); err != nil {
 		t.Fatalf("error writing lockfile: %v", err)
 	}
 	got, err := os.ReadFile(gotPath)

--- a/guidedremediation/internal/lockfile/python/requirements.go
+++ b/guidedremediation/internal/lockfile/python/requirements.go
@@ -17,6 +17,7 @@ package python
 
 import (
 	"errors"
+	"os"
 
 	"deps.dev/util/resolve"
 	"github.com/google/osv-scalibr/fs"
@@ -47,6 +48,6 @@ func (r readWriter) Read(path string, fsys fs.FS) (*resolve.Graph, error) {
 }
 
 // Write is not supported as intended for requirements.txt.
-func (r readWriter) Write(path string, fsys fs.FS, patches []result.Patch, outputPath string) error {
+func (r readWriter) Write(path string, fsys fs.FS, patches []result.Patch, outputRoot *os.Root, outputPath string) error {
 	return errors.New("not supported")
 }

--- a/guidedremediation/internal/manifest/manifest.go
+++ b/guidedremediation/internal/manifest/manifest.go
@@ -16,6 +16,8 @@
 package manifest
 
 import (
+	"os"
+
 	"deps.dev/util/resolve"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/guidedremediation/result"
@@ -49,7 +51,6 @@ type ReadWriter interface {
 
 	// Write writes the manifest after applying the patches to outputPath.
 	//
-	// original is the manifest without patches. fsys is the FS that the manifest was read from.
-	// outputPath is the path on disk (*not* in fsys) to write the entire patched manifest to (this can overwrite the original manifest).
-	Write(original Manifest, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error
+	// original is the manifest without patches. outputPath is relative to outputRoot.
+	Write(original Manifest, fsys scalibrfs.FS, patches []result.Patch, outputRoot *os.Root, outputPath string) error
 }

--- a/guidedremediation/internal/manifest/maven/pomxml.go
+++ b/guidedremediation/internal/manifest/maven/pomxml.go
@@ -195,15 +195,7 @@ type readWriter struct {
 // projectRoot is the directory path to scan for local Maven modules.
 func GetReadWriter(client *datasource.MavenRegistryAPIClient, projectRoot string) (manifest.ReadWriter, error) {
 	if projectRoot != "" {
-		absProjectRoot, err := filepath.Abs(projectRoot)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get absolute path for project root %q: %w", projectRoot, err)
-		}
-		vol := filepath.VolumeName(absProjectRoot) + "/"
-		projectRoot, err = filepath.Rel(vol, absProjectRoot)
-		if err != nil {
-			return nil, fmt.Errorf("failed to make project root %q relative to volume %q: %w", absProjectRoot, vol, err)
-		}
+		projectRoot = "."
 	}
 	return readWriter{MavenRegistryAPIClient: client, projectRoot: projectRoot}, nil
 }
@@ -562,7 +554,7 @@ func getLocalDepsAndProps(fsys scalibrfs.FS, path string, parent maven.Parent) (
 // outputPath is the path on disk (*not* in fsys) to write the entire patched manifest to (this can overwrite the original manifest).
 //
 // If the original manifest referenced local parent POMs, they will be written alongside the patched manifest, maintaining the relative path structure as it existed in the original location.
-func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error {
+func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputRoot *os.Root, outputPath string) error {
 	specific, ok := original.EcosystemSpecific().(ManifestSpecific)
 	if !ok {
 		return errors.New("invalid maven ManifestSpecific data")
@@ -592,16 +584,16 @@ func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches
 		if err := write(in.String(), out, patches); err != nil {
 			return err
 		}
-		// Write the patched parent relative to the new outputPath
-		relativePatch, err := filepath.Rel(original.FilePath(), patchPath)
-		if err != nil {
+		// Parent paths are project-relative identities, so write them back to the
+		// same confined location. The primary manifest uses outputPath.
+		if patchPath == original.FilePath() {
+			patchPath = outputPath
+		}
+		patchPath = filepath.ToSlash(patchPath)
+		if err := outputRoot.MkdirAll(filepath.ToSlash(filepath.Dir(patchPath)), 0755); err != nil {
 			return err
 		}
-		patchPath = filepath.Join(outputPath, relativePatch)
-		if err := os.MkdirAll(filepath.Dir(patchPath), 0755); err != nil {
-			return err
-		}
-		if err := os.WriteFile(patchPath, out.Bytes(), 0644); err != nil {
+		if err := outputRoot.WriteFile(patchPath, out.Bytes(), 0644); err != nil {
 			return err
 		}
 	}

--- a/guidedremediation/internal/manifest/maven/pomxml_test.go
+++ b/guidedremediation/internal/manifest/maven/pomxml_test.go
@@ -540,7 +540,12 @@ func TestReadWrite(t *testing.T) {
 
 	// Test writing the files produces the same pom.xml files.
 	dir := t.TempDir()
-	if err := mavenRW.Write(got, fsys, nil, filepath.Join(dir, "my-app", "pom.xml")); err != nil {
+	outFS, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFS.Close()
+	if err := mavenRW.Write(got, fsys, nil, outFS, "my-app/pom.xml"); err != nil {
 		t.Fatalf("error writing manifest: %v", err)
 	}
 
@@ -651,13 +656,8 @@ func TestRead_MultiModuleDiscovery(t *testing.T) {
 		t.Fatalf("error creating ReadWriter: %v", err)
 	}
 
-	vol := filepath.VolumeName(dir) + "/"
-	fsys := scalibrfs.DirFS(vol)
-	relPOM, err := filepath.Rel(vol, filepath.Join(dir, "module-a", "pom.xml"))
-	if err != nil {
-		t.Fatalf("error getting relative path: %v", err)
-	}
-	got, err := mavenRW.Read(filepath.ToSlash(relPOM), fsys)
+	fsys := scalibrfs.DirFS(dir)
+	got, err := mavenRW.Read("module-a/pom.xml", fsys)
 	if err != nil {
 		t.Fatalf("error reading manifest: %v", err)
 	}
@@ -674,6 +674,46 @@ func TestRead_MultiModuleDiscovery(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected to find junit:junit with version 4.12, got requirements: %v", got.Requirements())
+	}
+}
+
+func TestWriteDoesNotEscapeProjectRoot(t *testing.T) {
+	parent := t.TempDir()
+	project := filepath.Join(parent, "project")
+	if err := os.Mkdir(project, 0755); err != nil {
+		t.Fatal(err)
+	}
+	pom := `<project><modelVersion>4.0.0</modelVersion><groupId>g</groupId><artifactId>a</artifactId><version>1</version></project>`
+	if err := os.WriteFile(filepath.Join(project, "pom.xml"), []byte(pom), 0644); err != nil {
+		t.Fatal(err)
+	}
+	client, err := datasource.NewDefaultMavenRegistryAPIClient(t.Context(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw, err := GetReadWriter(client, project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fsys := scalibrfs.DirFS(project)
+	m, err := rw.Read("pom.xml", fsys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	specific := m.EcosystemSpecific().(ManifestSpecific)
+	specific.ParentPaths = append(specific.ParentPaths, "../outside.xml")
+	m.(*mavenManifest).specific = specific
+	outFS, err := os.OpenRoot(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFS.Close()
+
+	if err := rw.Write(m, fsys, nil, outFS, "pom.xml"); err == nil {
+		t.Fatal("Write() accepted an escaping parent path")
+	}
+	if _, err := os.Stat(filepath.Join(parent, "outside.xml")); !os.IsNotExist(err) {
+		t.Fatalf("outside file exists after confined Maven write: %v", err)
 	}
 }
 
@@ -1258,13 +1298,8 @@ func TestRead_MultiModuleDiscovery_NonStandardPOM(t *testing.T) {
 		t.Fatalf("error creating ReadWriter: %v", err)
 	}
 
-	vol := filepath.VolumeName(dir) + "/"
-	fsys := scalibrfs.DirFS(vol)
-	relPOM, err := filepath.Rel(vol, filepath.Join(dir, "module-a", "pom.xml"))
-	if err != nil {
-		t.Fatalf("error getting relative path: %v", err)
-	}
-	got, err := mavenRW.Read(filepath.ToSlash(relPOM), fsys)
+	fsys := scalibrfs.DirFS(dir)
+	got, err := mavenRW.Read("module-a/pom.xml", fsys)
 	if err != nil {
 		t.Fatalf("error reading manifest: %v", err)
 	}

--- a/guidedremediation/internal/manifest/maven/pomxml_test.go
+++ b/guidedremediation/internal/manifest/maven/pomxml_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"testing"
 
 	"deps.dev/util/maven"
@@ -31,6 +32,7 @@ import (
 	"github.com/google/osv-scalibr/clients/datasource"
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/guidedremediation/internal/manifest"
+	"github.com/google/osv-scalibr/guidedremediation/internal/parser"
 	"github.com/google/osv-scalibr/guidedremediation/result"
 )
 
@@ -674,6 +676,61 @@ func TestRead_MultiModuleDiscovery(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected to find junit:junit with version 4.12, got requirements: %v", got.Requirements())
+	}
+}
+
+func TestReadFindsLocalParentFromGitRoot(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	moduleDir := filepath.Join(repo, "module")
+	if err := os.Mkdir(moduleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	parentPOM := `<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+</project>`
+	if err := os.WriteFile(filepath.Join(repo, "pom.xml"), []byte(parentPOM), 0644); err != nil {
+		t.Fatal(err)
+	}
+	childPOM := `<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>child</artifactId>
+</project>`
+	childPath := filepath.Join(moduleDir, "pom.xml")
+	if err := os.WriteFile(childPath, []byte(childPOM), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := datasource.NewDefaultMavenRegistryAPIClient(t.Context(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw, err := GetReadWriter(client, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := parser.ParseManifest(childPath, rw, "")
+	if err != nil {
+		t.Fatalf("ParseManifest() failed to read local parent from Git root: %v", err)
+	}
+	specific := m.EcosystemSpecific().(ManifestSpecific)
+	if !slices.Contains(specific.ParentPaths, "pom.xml") {
+		t.Fatalf("parent paths = %v, want repository-root pom.xml", specific.ParentPaths)
+	}
+	if err := parser.WriteManifestPatches(childPath, m, nil, rw, ""); err != nil {
+		t.Fatalf("WriteManifestPatches() failed to update manifests under the Git root: %v", err)
 	}
 }
 

--- a/guidedremediation/internal/manifest/npm/packagejson.go
+++ b/guidedremediation/internal/manifest/npm/packagejson.go
@@ -387,7 +387,7 @@ func SplitNPMAlias(v string) (name, version string) {
 }
 
 // Write applies the patches to the original manifest, writing the resulting manifest file to the file path in the filesystem.
-func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error {
+func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputRoot *os.Root, outputPath string) error {
 	// Read the whole package.json into memory so we can use sjson to write in-place.
 	f, err := fsys.Open(original.FilePath())
 	if err != nil {
@@ -464,10 +464,10 @@ func (r readWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches
 	}
 
 	// Write the patched manifest to the output path.
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+	if err := outputRoot.MkdirAll(filepath.ToSlash(filepath.Dir(outputPath)), 0755); err != nil {
 		return err
 	}
-	if err := os.WriteFile(outputPath, manif, 0644); err != nil {
+	if err := outputRoot.WriteFile(filepath.ToSlash(outputPath), manif, 0644); err != nil {
 		return err
 	}
 

--- a/guidedremediation/internal/manifest/npm/packagejson_test.go
+++ b/guidedremediation/internal/manifest/npm/packagejson_test.go
@@ -255,6 +255,39 @@ func TestReadWithWorkspaces(t *testing.T) {
 	checkManifest(t, "Manifest", got, want)
 }
 
+func TestReadDoesNotLoadWorkspaceOutsideProject(t *testing.T) {
+	dir := t.TempDir()
+	project := filepath.Join(dir, "project")
+	if err := os.Mkdir(project, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`{"name":"root","version":"1.0.0","workspaces":["../outside"]}`)
+	if err := os.WriteFile(filepath.Join(project, "package.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(dir, "outside")
+	if err := os.Mkdir(outside, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "package.json"), []byte(`{"name":"outside","version":"1.0.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rw, err := npm.GetReadWriter()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := rw.Read("package.json", scalibrfs.DirFS(project))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, req := range m.Requirements() {
+		if req.Name == "outside:workspace" {
+			t.Fatal("Read() loaded a workspace outside the project")
+		}
+	}
+}
+
 func TestWrite(t *testing.T) {
 	rw, err := npm.GetReadWriter()
 	if err != nil {
@@ -327,8 +360,13 @@ func TestWrite(t *testing.T) {
 	}
 	outDir := t.TempDir()
 	outFile := filepath.Join(outDir, "package.json")
+	outFS, err := os.OpenRoot(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFS.Close()
 
-	if err := rw.Write(manif, fsys, patches, outFile); err != nil {
+	if err := rw.Write(manif, fsys, patches, outFS, "package.json"); err != nil {
 		t.Fatalf("failed to write package.json: %v", err)
 	}
 

--- a/guidedremediation/internal/manifest/python/pipfile.go
+++ b/guidedremediation/internal/manifest/python/pipfile.go
@@ -17,6 +17,7 @@ package python
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -174,8 +175,8 @@ func extractVersionConstraint(name string, details any) (string, bool) {
 }
 
 // Write writes the manifest after applying the patches to outputPath.
-func (r pipfileReadWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error {
-	return write(fsys, original.FilePath(), outputPath, patches, updatePipfile)
+func (r pipfileReadWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputRoot *os.Root, outputPath string) error {
+	return write(fsys, original.FilePath(), outputRoot, outputPath, patches, updatePipfile)
 }
 
 // updatePipfile takes an io.Reader representing the Pipfile

--- a/guidedremediation/internal/manifest/python/pipfile_test.go
+++ b/guidedremediation/internal/manifest/python/pipfile_test.go
@@ -22,13 +22,13 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/osv-scalibr/fs"
+	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/guidedremediation/internal/manifest"
 	"github.com/google/osv-scalibr/guidedremediation/result"
 )
 
 func TestReadPipfile(t *testing.T) {
-	fsys := fs.DirFS("./testdata/pipfile")
+	fsys := scalibrfs.DirFS("./testdata/pipfile")
 	pipfileRW, _ := GetPipfileReadWriter()
 	got, err := pipfileRW.Read("Pipfile", fsys)
 	if err != nil {
@@ -160,7 +160,7 @@ func TestReadPipfile(t *testing.T) {
 
 func TestWritePipfile(t *testing.T) {
 	rw, _ := GetPipfileReadWriter()
-	fsys := fs.DirFS("./testdata/pipfile")
+	fsys := scalibrfs.DirFS("./testdata/pipfile")
 	manif, err := rw.Read("Pipfile", fsys)
 	if err != nil {
 		t.Fatalf("error reading manifest: %v", err)
@@ -194,8 +194,13 @@ func TestWritePipfile(t *testing.T) {
 	}
 	outDir := t.TempDir()
 	outFile := filepath.Join(outDir, "Pipfile")
+	outFS, err := os.OpenRoot(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFS.Close()
 
-	if err := rw.Write(manif, fsys, patches, outFile); err != nil {
+	if err := rw.Write(manif, fsys, patches, outFS, "Pipfile"); err != nil {
 		t.Fatalf("failed to write manifest: %v", err)
 	}
 

--- a/guidedremediation/internal/manifest/python/poetry.go
+++ b/guidedremediation/internal/manifest/python/poetry.go
@@ -31,6 +31,7 @@ package python
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -157,8 +158,8 @@ func (r poetryReadWriter) Read(path string, fsys scalibrfs.FS) (manifest.Manifes
 }
 
 // Write writes the manifest after applying the patches to outputPath.
-func (r poetryReadWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error {
-	return write(fsys, original.FilePath(), outputPath, patches, updatePyproject)
+func (r poetryReadWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputRoot *os.Root, outputPath string) error {
+	return write(fsys, original.FilePath(), outputRoot, outputPath, patches, updatePyproject)
 }
 
 // updatePyproject takes an io.Reader representing the pyproject.toml file

--- a/guidedremediation/internal/manifest/python/poetry_test.go
+++ b/guidedremediation/internal/manifest/python/poetry_test.go
@@ -22,13 +22,13 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/osv-scalibr/fs"
+	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/guidedremediation/internal/manifest"
 	"github.com/google/osv-scalibr/guidedremediation/result"
 )
 
 func TestReadPoetry(t *testing.T) {
-	fsys := fs.DirFS("./testdata/poetry")
+	fsys := scalibrfs.DirFS("./testdata/poetry")
 	poetryRW, _ := GetPoetryReadWriter()
 	got, err := poetryRW.Read("pyproject.toml", fsys)
 	if err != nil {
@@ -125,7 +125,7 @@ func TestReadPoetry(t *testing.T) {
 
 func TestWritePoetry(t *testing.T) {
 	rw, _ := GetPoetryReadWriter()
-	fsys := fs.DirFS("./testdata/poetry")
+	fsys := scalibrfs.DirFS("./testdata/poetry")
 	manif, err := rw.Read("pyproject.toml", fsys)
 	if err != nil {
 		t.Fatalf("error reading manifest: %v", err)
@@ -171,8 +171,13 @@ func TestWritePoetry(t *testing.T) {
 	}
 	outDir := t.TempDir()
 	outFile := filepath.Join(outDir, "pyproject.toml")
+	outFS, err := os.OpenRoot(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFS.Close()
 
-	if err := rw.Write(manif, fsys, patches, outFile); err != nil {
+	if err := rw.Write(manif, fsys, patches, outFS, "pyproject.toml"); err != nil {
 		t.Fatalf("failed to write manifest: %v", err)
 	}
 

--- a/guidedremediation/internal/manifest/python/python.go
+++ b/guidedremediation/internal/manifest/python/python.go
@@ -253,7 +253,7 @@ func findTokenizedRequirement(requirements []TokenizedRequirements, name string,
 // It reads the original manifest from inputPath, processes the required changes from patches,
 // and delegates the content modification to the provided update function. The resulting
 // patched content is then written to outputPath.
-func write(fsys scalibrfs.FS, inputPath, outputPath string, patches []result.Patch, update func(reader io.Reader, requirements []TokenizedRequirements) (string, error)) error {
+func write(fsys scalibrfs.FS, inputPath string, outputRoot *os.Root, outputPath string, patches []result.Patch, update func(reader io.Reader, requirements []TokenizedRequirements) (string, error)) error {
 	f, err := fsys.Open(inputPath)
 	if err != nil {
 		return err
@@ -277,10 +277,10 @@ func write(fsys scalibrfs.FS, inputPath, outputPath string, patches []result.Pat
 	}
 
 	// Write the patched manifest to the output path.
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+	if err := outputRoot.MkdirAll(filepath.ToSlash(filepath.Dir(outputPath)), 0755); err != nil {
 		return err
 	}
-	if err := os.WriteFile(outputPath, []byte(output), 0644); err != nil {
+	if err := outputRoot.WriteFile(filepath.ToSlash(outputPath), []byte(output), 0644); err != nil {
 		return err
 	}
 

--- a/guidedremediation/internal/manifest/python/requirements.go
+++ b/guidedremediation/internal/manifest/python/requirements.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -116,8 +117,8 @@ func (r requirementsReadWriter) Read(path string, fsys scalibrfs.FS) (manifest.M
 }
 
 // Write writes the manifest after applying the patches to outputPath.
-func (r requirementsReadWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputPath string) error {
-	return write(fsys, original.FilePath(), outputPath, patches, updateRequirements)
+func (r requirementsReadWriter) Write(original manifest.Manifest, fsys scalibrfs.FS, patches []result.Patch, outputRoot *os.Root, outputPath string) error {
+	return write(fsys, original.FilePath(), outputRoot, outputPath, patches, updateRequirements)
 }
 
 // updateRequirements takes an io.Reader representing the requirements.txt file

--- a/guidedremediation/internal/manifest/python/requirements_test.go
+++ b/guidedremediation/internal/manifest/python/requirements_test.go
@@ -133,7 +133,7 @@ func TestReadRequirements(t *testing.T) {
 	checkManifest(t, "Manifest", got, want)
 }
 
-func TestReadRequirementsRejectsRecursivePathOutsideProject(t *testing.T) {
+func TestReadRequirementsDoesNotReadRecursivePathOutsideProject(t *testing.T) {
 	dir := t.TempDir()
 	project := filepath.Join(dir, "project")
 	if err := os.Mkdir(project, 0755); err != nil {
@@ -149,9 +149,18 @@ func TestReadRequirementsRejectsRecursivePathOutsideProject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	root, err := os.OpenRoot(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
 
-	if _, err := rw.Read("requirements.txt", scalibrfs.DirFS(project)); err == nil {
-		t.Fatal("Read() accepted a recursive requirements path outside the project")
+	got, err := rw.Read("requirements.txt", root.FS().(scalibrfs.FS))
+	if err != nil {
+		t.Fatalf("Read() returned an error: %v", err)
+	}
+	if len(got.Requirements()) != 0 {
+		t.Fatalf("Read() included requirements from outside the project: %v", got.Requirements())
 	}
 }
 

--- a/guidedremediation/internal/manifest/python/requirements_test.go
+++ b/guidedremediation/internal/manifest/python/requirements_test.go
@@ -21,13 +21,13 @@ import (
 
 	"deps.dev/util/resolve"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/osv-scalibr/fs"
+	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/guidedremediation/internal/manifest"
 	"github.com/google/osv-scalibr/guidedremediation/result"
 )
 
 func TestReadRequirements(t *testing.T) {
-	fsys := fs.DirFS("./testdata/requirements")
+	fsys := scalibrfs.DirFS("./testdata/requirements")
 	pypiRW, _ := GetRequirementsReadWriter()
 	got, err := pypiRW.Read("requirements.txt", fsys)
 	if err != nil {
@@ -133,9 +133,31 @@ func TestReadRequirements(t *testing.T) {
 	checkManifest(t, "Manifest", got, want)
 }
 
+func TestReadRequirementsRejectsRecursivePathOutsideProject(t *testing.T) {
+	dir := t.TempDir()
+	project := filepath.Join(dir, "project")
+	if err := os.Mkdir(project, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "requirements.txt"), []byte("-r ../outside.txt\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "outside.txt"), []byte("requests==1.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rw, err := GetRequirementsReadWriter()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := rw.Read("requirements.txt", scalibrfs.DirFS(project)); err == nil {
+		t.Fatal("Read() accepted a recursive requirements path outside the project")
+	}
+}
+
 func TestWriteRequirements(t *testing.T) {
 	rw, _ := GetRequirementsReadWriter()
-	fsys := fs.DirFS("./testdata/requirements")
+	fsys := scalibrfs.DirFS("./testdata/requirements")
 	manif, err := rw.Read("requirements.txt", fsys)
 	if err != nil {
 		t.Fatalf("error reading manifest: %v", err)
@@ -172,8 +194,13 @@ func TestWriteRequirements(t *testing.T) {
 	}
 	outDir := t.TempDir()
 	outFile := filepath.Join(outDir, "requirements.txt")
+	outFS, err := os.OpenRoot(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFS.Close()
 
-	if err := rw.Write(manif, fsys, patches, outFile); err != nil {
+	if err := rw.Write(manif, fsys, patches, outFS, "requirements.txt"); err != nil {
 		t.Fatalf("failed to write requirements.txt: %v", err)
 	}
 

--- a/guidedremediation/internal/parser/parser.go
+++ b/guidedremediation/internal/parser/parser.go
@@ -17,7 +17,9 @@ package parser
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"deps.dev/util/resolve"
 	scalibrfs "github.com/google/osv-scalibr/fs"
@@ -26,28 +28,32 @@ import (
 	"github.com/google/osv-scalibr/guidedremediation/result"
 )
 
-// ParseManifest parses a manifest file into a manifest.Manifest.
-func ParseManifest(path string, rw manifest.ReadWriter) (manifest.Manifest, error) {
-	fsys, path, err := fsAndPath(path)
+// ParseManifest parses a manifest file into a manifest.Manifest. If projectRoot
+// is empty, the manifest's directory is used as the project boundary.
+func ParseManifest(path string, rw manifest.ReadWriter, projectRoot string) (manifest.Manifest, error) {
+	root, path, err := rootAndPath(path, projectRoot)
 	if err != nil {
 		return nil, err
 	}
+	defer root.Close()
 
-	m, err := rw.Read(path, fsys)
+	m, err := rw.Read(path, root.FS().(scalibrfs.FS))
 	if err != nil {
 		return nil, fmt.Errorf("error reading manifest: %w", err)
 	}
 	return m, nil
 }
 
-// ParseLockfile parses a lockfile file into a resolve.Graph.
-func ParseLockfile(path string, rw lockfile.ReadWriter) (*resolve.Graph, error) {
-	fsys, path, err := fsAndPath(path)
+// ParseLockfile parses a lockfile file into a resolve.Graph. If projectRoot is
+// empty, the lockfile's directory is used as the project boundary.
+func ParseLockfile(path string, rw lockfile.ReadWriter, projectRoot string) (*resolve.Graph, error) {
+	root, path, err := rootAndPath(path, projectRoot)
 	if err != nil {
 		return nil, err
 	}
+	defer root.Close()
 
-	g, err := rw.Read(path, fsys)
+	g, err := rw.Read(path, root.FS().(scalibrfs.FS))
 	if err != nil {
 		return nil, fmt.Errorf("error reading lockfile: %w", err)
 	}
@@ -55,48 +61,48 @@ func ParseLockfile(path string, rw lockfile.ReadWriter) (*resolve.Graph, error) 
 }
 
 // WriteManifestPatches writes the patches to the manifest file.
-func WriteManifestPatches(path string, m manifest.Manifest, patches []result.Patch, rw manifest.ReadWriter) error {
-	fsys, _, err := fsAndPath(path)
+func WriteManifestPatches(path string, m manifest.Manifest, patches []result.Patch, rw manifest.ReadWriter, projectRoot string) error {
+	root, relPath, err := rootAndPath(path, projectRoot)
 	if err != nil {
 		return err
 	}
+	defer root.Close()
 
-	return rw.Write(m, fsys, patches, path)
+	return rw.Write(m, root.FS().(scalibrfs.FS), patches, root, relPath)
 }
 
 // WriteLockfilePatches writes the patches to the lockfile file.
-func WriteLockfilePatches(path string, patches []result.Patch, rw lockfile.ReadWriter) error {
-	fsys, relPath, err := fsAndPath(path)
+func WriteLockfilePatches(path string, patches []result.Patch, rw lockfile.ReadWriter, projectRoot string) error {
+	root, relPath, err := rootAndPath(path, projectRoot)
 	if err != nil {
 		return err
 	}
+	defer root.Close()
 
-	return rw.Write(relPath, fsys, patches, path)
+	return rw.Write(relPath, root.FS().(scalibrfs.FS), patches, root, relPath)
 }
 
-func fsAndPath(path string) (scalibrfs.FS, string, error) {
-	// We need a DirFS that can potentially access files in parent directories from the file.
-	// But you cannot escape the base directory of dirfs.
-	// e.g. "pkg/core/pom.xml" may have a parent at "pkg/parent/pom.xml",
-	// if we had fsys := scalibrfs.DirFS("pkg/core"), we can't do fsys.Open("../parent/pom.xml")
-	//
-	// Since we don't know ahead of time which files might be needed,
-	// we must use the system root as the directory.
-
+func rootAndPath(path, projectRoot string) (*os.Root, string, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("failed to resolve path %q: %w", path, err)
 	}
-
-	// Get the path relative to the root (i.e. without the leading '/')
-	// On Windows, we need the path relative to the drive letter,
-	// which also means we can't open files across drives.
-	root := filepath.VolumeName(absPath) + "/"
-	relPath, err := filepath.Rel(root, absPath)
+	root := projectRoot
+	if root == "" {
+		root = filepath.Dir(absPath)
+	}
+	root, err = filepath.Abs(root)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("failed to resolve project root %q: %w", projectRoot, err)
 	}
-	relPath = filepath.ToSlash(relPath)
+	relPath, err := filepath.Rel(root, absPath)
+	if err != nil || relPath == ".." || filepath.IsAbs(relPath) || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		return nil, "", fmt.Errorf("path %q is outside project root %q", path, root)
+	}
+	rootFS, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to open project root %q: %w", root, err)
+	}
 
-	return scalibrfs.DirFS(root), relPath, nil
+	return rootFS, filepath.ToSlash(relPath), nil
 }

--- a/guidedremediation/internal/parser/parser.go
+++ b/guidedremediation/internal/parser/parser.go
@@ -29,7 +29,8 @@ import (
 )
 
 // ParseManifest parses a manifest file into a manifest.Manifest. If projectRoot
-// is empty, the manifest's directory is used as the project boundary.
+// is empty, the nearest Git repository root or the manifest's directory is used
+// as the project boundary.
 func ParseManifest(path string, rw manifest.ReadWriter, projectRoot string) (manifest.Manifest, error) {
 	root, path, err := rootAndPath(path, projectRoot)
 	if err != nil {
@@ -45,7 +46,8 @@ func ParseManifest(path string, rw manifest.ReadWriter, projectRoot string) (man
 }
 
 // ParseLockfile parses a lockfile file into a resolve.Graph. If projectRoot is
-// empty, the lockfile's directory is used as the project boundary.
+// empty, the nearest Git repository root or the lockfile's directory is used as
+// the project boundary.
 func ParseLockfile(path string, rw lockfile.ReadWriter, projectRoot string) (*resolve.Graph, error) {
 	root, path, err := rootAndPath(path, projectRoot)
 	if err != nil {
@@ -89,7 +91,13 @@ func rootAndPath(path, projectRoot string) (*os.Root, string, error) {
 	}
 	root := projectRoot
 	if root == "" {
-		root = filepath.Dir(absPath)
+		root, err = findGitRoot(filepath.Dir(absPath))
+		if err != nil {
+			return nil, "", err
+		}
+		if root == "" {
+			root = filepath.Dir(absPath)
+		}
 	}
 	root, err = filepath.Abs(root)
 	if err != nil {
@@ -105,4 +113,21 @@ func rootAndPath(path, projectRoot string) (*os.Root, string, error) {
 	}
 
 	return rootFS, filepath.ToSlash(relPath), nil
+}
+
+func findGitRoot(start string) (string, error) {
+	dir := filepath.Clean(start)
+	for {
+		if _, err := os.Lstat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		} else if !os.IsNotExist(err) {
+			return "", fmt.Errorf("failed to inspect Git repository marker in %q: %w", dir, err)
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
 }

--- a/guidedremediation/internal/parser/parser_test.go
+++ b/guidedremediation/internal/parser/parser_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/guidedremediation/internal/manifest/npm"
+)
+
+func TestParseManifestRejectsPathOutsideProjectRoot(t *testing.T) {
+	parent := t.TempDir()
+	projectRoot := filepath.Join(parent, "project")
+	if err := os.Mkdir(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(parent, "package.json")
+	if err := os.WriteFile(manifestPath, []byte(`{"name":"outside","version":"1.0.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rw, err := npm.GetReadWriter()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ParseManifest(manifestPath, rw, projectRoot)
+	if err == nil || !strings.Contains(err.Error(), "outside project root") {
+		t.Fatalf("ParseManifest() error = %v, want outside-project-root error", err)
+	}
+}
+
+func TestParseManifestRejectsEscapingSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require additional privileges on Windows")
+	}
+	parent := t.TempDir()
+	projectRoot := filepath.Join(parent, "project")
+	if err := os.Mkdir(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(parent, "outside.json")
+	if err := os.WriteFile(outside, []byte(`{"name":"outside","version":"1.0.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(projectRoot, "package.json")
+	if err := os.Symlink(outside, manifestPath); err != nil {
+		t.Fatal(err)
+	}
+	rw, err := npm.GetReadWriter()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ParseManifest(manifestPath, rw, projectRoot); err == nil {
+		t.Fatal("ParseManifest() succeeded through a symlink outside the project root")
+	}
+}
+
+func TestParseManifestAllowsSymlinkWithinProjectRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require additional privileges on Windows")
+	}
+	projectRoot := t.TempDir()
+	realDir := filepath.Join(projectRoot, "real")
+	if err := os.Mkdir(realDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "package.json"), []byte(`{"name":"inside","version":"1.0.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", filepath.Join(projectRoot, "linked")); err != nil {
+		t.Fatal(err)
+	}
+	rw, err := npm.GetReadWriter()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := ParseManifest(filepath.Join(projectRoot, "linked", "package.json"), rw, projectRoot)
+	if err != nil {
+		t.Fatalf("ParseManifest() rejected a symlink contained within the project root: %v", err)
+	}
+	if got := m.Root().Name; got != "inside" {
+		t.Fatalf("manifest root name = %q, want %q", got, "inside")
+	}
+}
+
+func TestParseManifestRejectsEscapingDirectorySymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require additional privileges on Windows")
+	}
+	parent := t.TempDir()
+	projectRoot := filepath.Join(parent, "project")
+	outDir := filepath.Join(parent, "outside")
+	if err := os.Mkdir(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(outDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "package.json"), []byte(`{"name":"outside","version":"1.0.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outDir, filepath.Join(projectRoot, "linked")); err != nil {
+		t.Fatal(err)
+	}
+	rw, err := npm.GetReadWriter()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ParseManifest(filepath.Join(projectRoot, "linked", "package.json"), rw, projectRoot); err == nil {
+		t.Fatal("ParseManifest() followed a directory symlink outside the project root")
+	}
+}
+
+func TestWriteManifestRejectsEscapingSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require additional privileges on Windows")
+	}
+	parent := t.TempDir()
+	projectRoot := filepath.Join(parent, "project")
+	if err := os.Mkdir(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(projectRoot, "package.json")
+	if err := os.WriteFile(manifestPath, []byte(`{"name":"inside","version":"1.0.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rw, err := npm.GetReadWriter()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := ParseManifest(manifestPath, rw, projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outDir := filepath.Join(parent, "outside")
+	if err := os.Mkdir(outDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(manifestPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outDir, "package.json"), manifestPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteManifestPatches(manifestPath, m, nil, rw, projectRoot); err == nil {
+		t.Fatal("WriteManifestPatches() wrote through a symlink outside the project root")
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "package.json")); !os.IsNotExist(err) {
+		t.Fatalf("outside file exists after confined write: %v", err)
+	}
+}

--- a/guidedremediation/internal/parser/parser_test.go
+++ b/guidedremediation/internal/parser/parser_test.go
@@ -45,6 +45,113 @@ func TestParseManifestRejectsPathOutsideProjectRoot(t *testing.T) {
 	}
 }
 
+func TestRootAndPathUsesNearestGitRoot(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifestDir := filepath.Join(repo, "module", "app")
+	if err := os.MkdirAll(manifestDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(manifestDir, "package.json")
+
+	root, relPath, err := rootAndPath(manifestPath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	if got := root.Name(); got != repo {
+		t.Fatalf("root.Name() = %q, want nearest Git root %q", got, repo)
+	}
+	if want := "module/app/package.json"; relPath != want {
+		t.Fatalf("relative path = %q, want %q", relPath, want)
+	}
+}
+
+func TestRootAndPathUsesNearestNestedGitRoot(t *testing.T) {
+	outer := t.TempDir()
+	if err := os.Mkdir(filepath.Join(outer, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	inner := filepath.Join(outer, "nested")
+	if err := os.MkdirAll(filepath.Join(inner, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(inner, "package.json")
+
+	root, _, err := rootAndPath(manifestPath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	if got := root.Name(); got != inner {
+		t.Fatalf("root.Name() = %q, want nearest nested Git root %q", got, inner)
+	}
+}
+
+func TestRootAndPathAcceptsGitFile(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, ".git"), []byte("gitdir: elsewhere\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	manifestDir := filepath.Join(repo, "module")
+	if err := os.Mkdir(manifestDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	root, _, err := rootAndPath(filepath.Join(manifestDir, "package.json"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	if got := root.Name(); got != repo {
+		t.Fatalf("root.Name() = %q, want Git worktree root %q", got, repo)
+	}
+}
+
+func TestRootAndPathFallsBackToManifestDirectory(t *testing.T) {
+	manifestDir := t.TempDir()
+	manifestPath := filepath.Join(manifestDir, "package.json")
+
+	root, relPath, err := rootAndPath(manifestPath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	if got := root.Name(); got != manifestDir {
+		t.Fatalf("root.Name() = %q, want manifest directory %q", got, manifestDir)
+	}
+	if relPath != "package.json" {
+		t.Fatalf("relative path = %q, want %q", relPath, "package.json")
+	}
+}
+
+func TestRootAndPathExplicitRootOverridesGitRoot(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	projectRoot := filepath.Join(repo, "project")
+	if err := os.Mkdir(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	root, _, err := rootAndPath(filepath.Join(projectRoot, "package.json"), projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	if got := root.Name(); got != projectRoot {
+		t.Fatalf("root.Name() = %q, want explicit project root %q", got, projectRoot)
+	}
+}
+
 func TestParseManifestRejectsEscapingSymlink(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation may require additional privileges on Windows")

--- a/guidedremediation/internal/tui/model/state_in_place_result.go
+++ b/guidedremediation/internal/tui/model/state_in_place_result.go
@@ -297,7 +297,7 @@ func (st stateInPlaceResult) write(m Model) tea.Msg {
 		}
 	}
 
-	return writeMsg{parser.WriteLockfilePatches(m.options.Lockfile, patches, m.lockfileRW)}
+	return writeMsg{parser.WriteLockfilePatches(m.options.Lockfile, patches, m.lockfileRW, m.options.ProjectRoot)}
 }
 
 func chooseAllCompatiblePatches(allPatches []result.Patch) []bool {

--- a/guidedremediation/internal/tui/model/state_initialize.go
+++ b/guidedremediation/internal/tui/model/state_initialize.go
@@ -134,7 +134,7 @@ type inPlaceResolutionMsg struct {
 
 func doInPlaceResolutionCmd(opts options.FixVulnsOptions, rw lockfile.ReadWriter) tea.Cmd {
 	return func() tea.Msg {
-		g, err := parser.ParseLockfile(opts.Lockfile, rw)
+		g, err := parser.ParseLockfile(opts.Lockfile, rw, opts.ProjectRoot)
 		if err != nil {
 			return inPlaceResolutionMsg{err: err}
 		}
@@ -158,7 +158,7 @@ type doRelockMsg struct {
 
 func doInitialRelockCmd(opts options.FixVulnsOptions, rw manifest.ReadWriter) tea.Cmd {
 	return func() tea.Msg {
-		m, err := parser.ParseManifest(opts.Manifest, rw)
+		m, err := parser.ParseManifest(opts.Manifest, rw, opts.ProjectRoot)
 		if err != nil {
 			return doRelockMsg{err: err}
 		}

--- a/guidedremediation/internal/tui/model/state_relock_result.go
+++ b/guidedremediation/internal/tui/model/state_relock_result.go
@@ -522,6 +522,7 @@ func (st stateRelockResult) write(m Model) tea.Msg {
 		m.relockBaseManifest.Manifest,
 		[]result.Patch{patches},
 		m.manifestRW,
+		m.options.ProjectRoot,
 	)
 	if err != nil {
 		return writeMsg{err}

--- a/guidedremediation/options/options.go
+++ b/guidedremediation/options/options.go
@@ -46,7 +46,7 @@ type FixVulnsOptions struct {
 	ResolveClient     resolve.Client                     // Client for dependency information.
 	MavenClient       *datasource.MavenRegistryAPIClient // Client for fetching Maven dependency information, may be nil.
 	DepCachePopulator DependencyCachePopulator           // Interface for populating the cache of the resolve.Client. Can be nil.
-	ProjectRoot       string                             // Optional directory path to scan for local modules.
+	ProjectRoot       string                             // Optional filesystem boundary for all manifest and lockfile access. Defaults to the primary file's directory.
 }
 
 // RemediationOptions are the configuration options for vulnerability remediation.
@@ -85,5 +85,5 @@ type UpdateOptions struct {
 
 	IgnoreDev     bool           // Whether to ignore updates on dev dependencies
 	UpgradeConfig upgrade.Config // Allowed upgrade levels per package.
-	ProjectRoot   string         // Optional directory path to scan for local modules.
+	ProjectRoot   string         // Optional filesystem boundary for all manifest access. Defaults to the manifest's directory.
 }

--- a/guidedremediation/options/options.go
+++ b/guidedremediation/options/options.go
@@ -46,7 +46,7 @@ type FixVulnsOptions struct {
 	ResolveClient     resolve.Client                     // Client for dependency information.
 	MavenClient       *datasource.MavenRegistryAPIClient // Client for fetching Maven dependency information, may be nil.
 	DepCachePopulator DependencyCachePopulator           // Interface for populating the cache of the resolve.Client. Can be nil.
-	ProjectRoot       string                             // Optional filesystem boundary for all manifest and lockfile access. Defaults to the primary file's directory.
+	ProjectRoot       string                             // Optional filesystem boundary for all manifest and lockfile access. Defaults to the nearest Git root, then the primary file's directory.
 }
 
 // RemediationOptions are the configuration options for vulnerability remediation.
@@ -85,5 +85,5 @@ type UpdateOptions struct {
 
 	IgnoreDev     bool           // Whether to ignore updates on dev dependencies
 	UpgradeConfig upgrade.Config // Allowed upgrade levels per package.
-	ProjectRoot   string         // Optional filesystem boundary for all manifest access. Defaults to the manifest's directory.
+	ProjectRoot   string         // Optional filesystem boundary for all manifest access. Defaults to the nearest Git root, then the manifest's directory.
 }


### PR DESCRIPTION
The fix ensures that Guided Remediation never touches hosts files outside of the scoped project by converting to using `os.Root` interface for file operations.

Please note, that this change makes some design choices for existing `ReaderWriter`s suboptimal (e.g. `guidedremediation/internal/manifest/maven/pomxml.go's `GetReadWriter`). However, this PR deliberately chooses to minimize the architectural changes in favor of making minimal changes required to enforce `os.Root` usage.