### PR TITLE
feat: add Python setup.cfg inventory extractor (python/setupcfg)

### DIFF
--- a/enricher/enricherlist/list.go
+++ b/enricher/enricherlist/list.go
@@ -37,6 +37,7 @@ import (
 	"github.com/google/osv-scalibr/enricher/transitivedependency/nodemodules"
 	"github.com/google/osv-scalibr/enricher/transitivedependency/pomxml"
 	"github.com/google/osv-scalibr/enricher/transitivedependency/requirements"
+	enrichersetupcfg "github.com/google/osv-scalibr/enricher/transitivedependency/setupcfg"
 	"github.com/google/osv-scalibr/enricher/vex/filter"
 	"github.com/google/osv-scalibr/enricher/vulnmatch/osvdev"
 	"github.com/google/osv-scalibr/enricher/vulnmatch/osvlocal"
@@ -218,10 +219,11 @@ var (
 
 	// TransitiveDependency enrichers.
 	TransitiveDependency = InitMap{
-		javaarchive.Name:  {javaarchive.New},
-		nodemodules.Name:  {nodemodules.New},
-		requirements.Name: {requirements.New},
-		pomxml.Name:       {pomxml.New},
+		javaarchive.Name:      {javaarchive.New},
+		nodemodules.Name:      {nodemodules.New},
+		requirements.Name:     {requirements.New},
+		pomxml.Name:           {pomxml.New},
+		enrichersetupcfg.Name: {enrichersetupcfg.New},
 	}
 
 	// PackageDeprecation enricher.

--- a/enricher/transitivedependency/setupcfg/setupcfg.go
+++ b/enricher/transitivedependency/setupcfg/setupcfg.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package setupcfg implements an enricher to perform dependency resolution for Python setup.cfg.
+package setupcfg
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"deps.dev/util/pypi"
+	"deps.dev/util/resolve"
+	"deps.dev/util/resolve/dep"
+	pypiresolve "deps.dev/util/resolve/pypi"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/clients/resolution"
+	"github.com/google/osv-scalibr/depsdev"
+	"github.com/google/osv-scalibr/enricher"
+	"github.com/google/osv-scalibr/enricher/transitivedependency/internal"
+	"github.com/google/osv-scalibr/extractor"
+	extractorsetupcfg "github.com/google/osv-scalibr/extractor/filesystem/language/python/setupcfg"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/log"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/plugin/config"
+	"github.com/google/osv-scalibr/purl"
+)
+
+const (
+	// Name is the unique name of this enricher.
+	Name = "transitivedependency/setupcfg"
+)
+
+// Enricher performs dependency resolution for setup.cfg.
+type Enricher struct {
+	resolve.Client
+}
+
+// Name returns the name of the enricher.
+func (Enricher) Name() string { return Name }
+
+// Version returns the version of the enricher.
+func (Enricher) Version() int { return 0 }
+
+// Requirements returns the requirements of the enricher.
+func (Enricher) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{
+		Network: plugin.NetworkOnline,
+	}
+}
+
+// RequiredPlugins returns the names of the plugins required by the enricher.
+func (Enricher) RequiredPlugins() []string {
+	return []string{extractorsetupcfg.Name}
+}
+
+// New creates a new Enricher.
+func New(cfg *config.PluginConfig) (enricher.Enricher, error) {
+	if cfg == nil || cfg.ClientFactories == nil {
+		return nil, fmt.Errorf("client factories not configured for %s", Name)
+	}
+
+	upstreamRegistry := ""
+	depsDevRequirements := false
+	var protoCfg *cpb.PluginConfig
+	localRegistry := ""
+	if cfg.ProtoConfig != nil {
+		protoCfg = cfg.ProtoConfig
+		localRegistry = cfg.ProtoConfig.LocalRegistry
+	}
+	specific := plugin.FindConfig(protoCfg, func(c *cpb.PluginSpecificConfig) *cpb.PythonRequirementsTransitiveConfig {
+		return c.GetPythonRequirementsTransitive()
+	})
+	if specific != nil {
+		upstreamRegistry = specific.UpstreamRegistry
+		depsDevRequirements = specific.DepsDevRequirements
+	}
+
+	var depClient resolve.Client
+	var err error
+	if depsDevRequirements {
+		conn, err := cfg.ClientFactories.GRPCClientConn(depsdev.DepsdevAPI)
+		if err != nil {
+			return nil, err
+		}
+		depClient = resolution.NewDepsDevClientWithConn(conn)
+	} else {
+		depClient, err = resolution.NewPyPIRegistryClient(upstreamRegistry, localRegistry, cfg.ClientFactories.HTTPClient())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Enricher{
+		Client: depClient,
+	}, nil
+}
+
+// Enrich enriches the inventory from setup.cfg with transitive dependencies.
+func (e Enricher) Enrich(ctx context.Context, input *enricher.ScanInput, inv *inventory.Inventory) error {
+	pkgGroups := internal.GroupPackagesFromPlugin(inv.Packages, extractorsetupcfg.Name)
+	paths := make([]string, 0, len(pkgGroups))
+	for p := range pkgGroups {
+		paths = append(paths, p)
+	}
+	slices.Sort(paths)
+
+	var errs error
+	for _, path := range paths {
+		pkgMap := pkgGroups[path]
+		packages := make([]internal.PackageWithIndex, 0, len(pkgMap))
+		for _, indexPkg := range pkgMap {
+			packages = append(packages, indexPkg)
+		}
+		slices.SortFunc(packages, func(a, b internal.PackageWithIndex) int {
+			return a.Index - b.Index
+		})
+
+		list := make([]*extractor.Package, 0, len(packages))
+		for _, indexPkg := range packages {
+			list = append(list, indexPkg.Pkg)
+		}
+
+		scanRoot := ""
+		if input.ScanRoot != nil {
+			scanRoot = input.ScanRoot.Path
+		}
+
+		pkgs, err := e.resolve(ctx, path, scanRoot, list)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("resolving %s: %w", path, err))
+			continue
+		}
+		inv.Packages = append(inv.Packages, pkgs...)
+	}
+	return errs
+}
+
+func (e Enricher) resolve(ctx context.Context, path, scanRoot string, list []*extractor.Package) ([]*extractor.Package, error) {
+	overrideClient := resolution.NewOverrideClient(e.Client)
+	resolver := pypiresolve.NewResolver(overrideClient)
+
+	root := resolve.Version{
+		VersionKey: resolve.VersionKey{
+			PackageKey: resolve.PackageKey{
+				System: resolve.PyPI,
+			},
+			VersionType: resolve.Concrete,
+		}}
+
+	reqs := make([]resolve.RequirementVersion, len(list))
+	for i, pkg := range list {
+		m, ok := pkg.Metadata.(*extractorsetupcfg.Metadata)
+		if !ok {
+			log.Errorf("unexpected metadata type for setup.cfg package %s", pkg.Name)
+			continue
+		}
+		d, err := pypi.ParseDependency(m.Requirement)
+		if err != nil {
+			log.Errorf("failed to parse requirement %s: %v", m.Requirement, err)
+			continue
+		}
+
+		t := dep.NewType()
+		if d.Extras != "" {
+			t.AddAttr(dep.EnabledDependencies, d.Extras)
+		}
+		if d.Environment != "" {
+			t.AddAttr(dep.Environment, d.Environment)
+		}
+
+		reqs[i] = resolve.RequirementVersion{
+			VersionKey: resolve.VersionKey{
+				PackageKey: resolve.PackageKey{
+					System: resolve.PyPI,
+					Name:   d.Name,
+				},
+				VersionType: resolve.Requirement,
+				Version:     d.Constraint,
+			},
+			Type: t,
+		}
+	}
+	overrideClient.AddVersion(root, reqs)
+
+	g, err := resolver.Resolve(ctx, root.VersionKey)
+	if err != nil {
+		return nil, err
+	}
+	if g.Error != "" {
+		return nil, errors.New(g.Error)
+	}
+
+	nameToID, err := internal.GetNameToIDMapping(g, list)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgs := make([]*extractor.Package, len(g.Nodes)-1)
+	for i := 1; i < len(g.Nodes); i++ {
+		node := g.Nodes[i]
+
+		parents, err := internal.GetParentIDs(g, nameToID, resolve.NodeID(i))
+		if err != nil {
+			return nil, err
+		}
+
+		pkgs[i-1] = &extractor.Package{
+			ID:        nameToID[node.Version.Name],
+			Name:      node.Version.Name,
+			ParentIDs: parents,
+			Version:   node.Version.Version,
+			PURLType:  purl.TypePyPi,
+			ScanRoot:  scanRoot,
+			Location:  extractor.LocationFromPath(path),
+			Plugins:   []string{Name},
+		}
+	}
+
+	// Sort for deterministic output (mirrors requirements enricher pattern).
+	slices.SortFunc(pkgs, func(a, b *extractor.Package) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	return pkgs, nil
+}

--- a/extractor/filesystem/language/python/setupcfg/metadata.go
+++ b/extractor/filesystem/language/python/setupcfg/metadata.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setupcfg
+
+// Metadata holds setup.cfg-specific package metadata for future enrichment.
+type Metadata struct {
+	// Requirement is the full PEP 508 requirement string (e.g. "requests==2.31.0").
+	Requirement string
+	// VersionComparator is the operator used (e.g. "==", ">=", "~=").
+	VersionComparator string
+	// DepGroupVals holds the extras group (e.g. "dev", "test") if this
+	// dependency came from [options.extras_require].
+	DepGroupVals []string
+}
+
+// IsProtoable marks this metadata as not proto-serialized yet.
+func (m *Metadata) IsProtoable() {}

--- a/extractor/filesystem/language/python/setupcfg/metadata.go
+++ b/extractor/filesystem/language/python/setupcfg/metadata.go
@@ -14,6 +14,14 @@
 
 package setupcfg
 
+import (
+	"github.com/google/osv-scalibr/binary/proto/metadata"
+)
+
+func init() {
+	metadata.RegisterNil[*Metadata]()
+}
+
 // Metadata holds setup.cfg-specific package metadata for future enrichment.
 type Metadata struct {
 	// Requirement is the full PEP 508 requirement string (e.g. "requests==2.31.0").

--- a/extractor/filesystem/language/python/setupcfg/setupcfg.go
+++ b/extractor/filesystem/language/python/setupcfg/setupcfg.go
@@ -1,0 +1,290 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package setupcfg extracts Python dependencies from setup.cfg files.
+package setupcfg
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "python/setupcfg"
+)
+
+var (
+	// reValidPkg matches valid PyPI package names per PEP 508.
+	// https://packaging.python.org/en/latest/specifications/name-normalization/
+	reValidPkg = regexp.MustCompile(`(?i)^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$`)
+	// reUnsupportedConstraints covers wildcards, less-than, not-equal, and
+	// compound constraints that we cannot resolve to a single version.
+	reUnsupportedConstraints = regexp.MustCompile(`\*|<[^=]|,|!=`)
+	// reExtras strips extras from a requirement string (e.g. "requests[security]").
+	reExtras = regexp.MustCompile(`\[[^\[\]]*\]`)
+	// reSection matches an INI section header such as "[options]".
+	reSection = regexp.MustCompile(`^\[([^\]]+)\]$`)
+	// reEnvMarker matches PEP 508 environment markers ("; python_version ...").
+	reEnvMarker = regexp.MustCompile(`;.*$`)
+	// reSkippedDep matches entries that should be skipped: file://, attr:, VCS
+	// URLs, local paths (starting with . or /), and editable installs (-e).
+	reSkippedDep = regexp.MustCompile(`(?i)^(file:|attr:|git\+|hg\+|svn\+|bzr\+|\.|/|-e\s)`)
+)
+
+// Extractor extracts Python packages from setup.cfg manifests.
+type Extractor struct{}
+
+// New returns a new instance of the extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the file is named exactly "setup.cfg".
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	return filepath.Base(api.Path()) == "setup.cfg"
+}
+
+// Extract extracts packages from setup.cfg files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	if err := ctx.Err(); err != nil {
+		return inventory.Inventory{}, err
+	}
+
+	pkgs, err := parse(input)
+	if err != nil {
+		return inventory.Inventory{}, fmt.Errorf("setupcfg: %w", err)
+	}
+	return inventory.Inventory{Packages: pkgs}, nil
+}
+
+// parse reads a setup.cfg file and returns all discovered packages.
+func parse(input *filesystem.ScanInput) ([]*extractor.Package, error) {
+	// seen deduplicates by normalized name.
+	seen := map[string]bool{}
+	var pkgs []*extractor.Package
+
+	addDep := func(raw, group string) {
+		pkg := parseDep(raw, group, input.Path)
+		if pkg == nil {
+			return
+		}
+		if seen[pkg.Name] {
+			return
+		}
+		seen[pkg.Name] = true
+		pkgs = append(pkgs, pkg)
+	}
+
+	// INI parsing state.
+	type section int
+	const (
+		sectionOther     section = iota
+		sectionOptions           // [options]
+		sectionExtrasReq         // [options.extras_require]
+	)
+
+	current := sectionOther
+	// currentKey is "install_requires" or an extras name inside extras_require.
+	currentKey := ""
+	// inValue is true when we are reading continuation lines of a multi-line value.
+	inValue := false
+	// extrasGroup is the current extras key (treated as dep group).
+	extrasGroup := ""
+
+	scanner := bufio.NewScanner(input.Reader)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Strip inline comments.
+		if idx := strings.Index(line, " #"); idx >= 0 {
+			line = line[:idx]
+		}
+		trimmed := strings.TrimSpace(line)
+
+		// Skip blank lines and full-line comments.
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			inValue = false
+			continue
+		}
+
+		// Detect section headers.
+		if m := reSection.FindStringSubmatch(trimmed); m != nil {
+			sec := strings.ToLower(strings.TrimSpace(m[1]))
+			switch sec {
+			case "options":
+				current = sectionOptions
+			case "options.extras_require":
+				current = sectionExtrasReq
+			default:
+				current = sectionOther
+			}
+			inValue = false
+			currentKey = ""
+			extrasGroup = ""
+			continue
+		}
+
+		if current == sectionOther {
+			continue
+		}
+
+		// Detect new key = value assignment (not a continuation line).
+		// Continuation lines start with whitespace.
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			inValue = false
+			currentKey = ""
+			extrasGroup = ""
+
+			if eqIdx := strings.Index(trimmed, "="); eqIdx > 0 {
+				key := strings.ToLower(strings.TrimSpace(trimmed[:eqIdx]))
+				val := strings.TrimSpace(trimmed[eqIdx+1:])
+
+				switch current {
+				case sectionOptions:
+					if key == "install_requires" {
+						currentKey = key
+						inValue = true
+						if val != "" {
+							addDep(val, "")
+						}
+					}
+				case sectionExtrasReq:
+					// Any key is an extras group name (e.g. "dev", "test").
+					extrasGroup = key
+					currentKey = key
+					inValue = true
+					if val != "" {
+						addDep(val, extrasGroup)
+					}
+				}
+			}
+			continue
+		}
+
+		// Continuation line — only process if we are inside a known value.
+		if inValue && currentKey != "" {
+			group := ""
+			if current == sectionExtrasReq {
+				group = extrasGroup
+			}
+			addDep(trimmed, group)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return pkgs, nil
+}
+
+// parseDep parses a single PEP 508 dependency string and returns a Package, or
+// nil if the entry should be skipped (invalid name, unsupported format, etc.).
+func parseDep(raw, group, path string) *extractor.Package {
+	// Strip environment markers ("; python_version < '3.10'").
+	raw = reEnvMarker.ReplaceAllString(raw, "")
+	// Strip extras like [security].
+	raw = reExtras.ReplaceAllString(raw, "")
+	raw = strings.TrimSpace(raw)
+
+	if raw == "" {
+		return nil
+	}
+
+	// Skip file:, attr:, VCS URLs, local paths, editable installs.
+	if reSkippedDep.MatchString(raw) {
+		return nil
+	}
+
+	name, version, comparator := getLowestVersion(raw)
+	// Normalize per PEP 503.
+	name = normalizeName(name)
+	if name == "" || !reValidPkg.MatchString(name) {
+		return nil
+	}
+
+	req := name
+	if version != "" {
+		req = name + comparator + version
+	}
+
+	var groupVals []string
+	if group != "" {
+		groupVals = []string{group}
+	}
+
+	return &extractor.Package{
+		Name:     name,
+		Version:  version,
+		PURLType: purl.TypePyPi,
+		Location: extractor.LocationFromPath(path),
+		Metadata: &Metadata{
+			Requirement:       req,
+			VersionComparator: comparator,
+			DepGroupVals:      groupVals,
+		},
+	}
+}
+
+// normalizeName applies PEP 503 normalization: lowercase and collapse [-_.]+
+// runs to a single hyphen.
+var reNorm = regexp.MustCompile(`[-_.]+`)
+
+func normalizeName(name string) string {
+	return reNorm.ReplaceAllString(strings.ToLower(name), "-")
+}
+
+// getLowestVersion extracts the package name, version string, and comparator
+// from a PEP 508 requirement string, matching the logic in requirements.go.
+func getLowestVersion(s string) (name, version, comparator string) {
+	if reUnsupportedConstraints.FindString(s) != "" {
+		return nameFromRequirement(s), "", ""
+	}
+	separators := []string{"===", "==", ">=", "<=", "~="}
+	for _, sep := range separators {
+		if v, after, ok := strings.Cut(s, sep); ok {
+			return strings.TrimSpace(v), strings.TrimSpace(after), sep
+		}
+	}
+	return strings.TrimSpace(s), "", ""
+}
+
+func nameFromRequirement(s string) string {
+	for _, sep := range []string{"===", "==", ">=", "<=", "~=", "!=", "<"} {
+		s, _, _ = strings.Cut(s, sep)
+	}
+	return strings.TrimSpace(s)
+}
+
+var _ filesystem.Extractor = Extractor{}

--- a/extractor/filesystem/language/python/setupcfg/setupcfg_test.go
+++ b/extractor/filesystem/language/python/setupcfg/setupcfg_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setupcfg_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/setupcfg"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "setup.cfg", path: "setup.cfg", want: true},
+		{name: "nested setup.cfg", path: "project/setup.cfg", want: true},
+		{name: "not setup.cfg", path: "setup.py", want: false},
+		{name: "not setup.cfg 2", path: "mysetup.cfg", want: false},
+		{name: "requirements.txt", path: "requirements.txt", want: false},
+	}
+	e := setupcfg.Extractor{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := e.FileRequired(simplefileapi.New(tc.path, nil))
+			if got != tc.want {
+				t.Errorf("FileRequired(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantPkgs []*extractor.Package
+		wantErr  bool
+	}{
+		{
+			name:     "empty — no deps sections",
+			path:     "testdata/empty.cfg",
+			wantPkgs: nil,
+		},
+		{
+			name: "valid — installs and extras",
+			path: "testdata/valid.cfg",
+			wantPkgs: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "2.31.0",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement:       "requests==2.31.0",
+						VersionComparator: "==",
+					},
+				},
+				{
+					Name:     "flask",
+					Version:  "2.0",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement:       "flask>=2.0",
+						VersionComparator: ">=",
+					},
+				},
+				{
+					Name:     "click",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement: "click",
+					},
+				},
+				{
+					Name:     "numpy",
+					Version:  "1.24.0",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement:       "numpy~=1.24.0",
+						VersionComparator: "~=",
+					},
+				},
+				// cryptography>=41.0,<42.0 — compound, version stripped but pkg kept.
+				{
+					Name:     "cryptography",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement: "cryptography",
+					},
+				},
+				// importlib-metadata with env marker — included (marker stripped).
+				{
+					Name:     "importlib-metadata",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement: "importlib-metadata",
+					},
+				},
+				// Pillow[jpeg]==10.0.0 — extras stripped, name normalized.
+				{
+					Name:     "pillow",
+					Version:  "10.0.0",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement:       "pillow==10.0.0",
+						VersionComparator: "==",
+					},
+				},
+				// file: dep is skipped entirely.
+				// dev extras.
+				{
+					Name:     "pytest",
+					Version:  "7.0",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement:       "pytest>=7.0",
+						VersionComparator: ">=",
+						DepGroupVals:      []string{"dev"},
+					},
+				},
+				{
+					Name:     "pytest-cov",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement:  "pytest-cov",
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				// tox in test extras.
+				{
+					Name:     "tox",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement:  "tox",
+						DepGroupVals: []string{"test"},
+					},
+				},
+				// coverage!=5.0 — unsupported constraint, version stripped but kept.
+				{
+					Name:     "coverage",
+					Version:  "",
+					PURLType: purl.TypePyPi,
+					Metadata: &setupcfg.Metadata{
+						Requirement:  "coverage",
+						DepGroupVals: []string{"test"},
+					},
+				},
+			},
+		},
+	}
+
+	e := setupcfg.Extractor{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.Open(tc.path)
+			if err != nil {
+				t.Fatalf("os.Open(%q): %v", tc.path, err)
+			}
+			defer f.Close()
+
+			info, err := f.Stat()
+			if err != nil {
+				t.Fatalf("f.Stat(): %v", err)
+			}
+
+			got, err := e.Extract(context.Background(), &filesystem.ScanInput{
+				Path:   tc.path,
+				Reader: f,
+				Info:   info,
+			})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Extract() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			want := inventory.Inventory{Packages: tc.wantPkgs}
+			if diff := cmp.Diff(want, got,
+				cmpopts.IgnoreFields(extractor.Package{}, "Location"),
+				cmpopts.EquateEmpty(),
+			); diff != "" {
+				t.Errorf("Extract() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/python/setupcfg/testdata/empty.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/empty.cfg
@@ -1,0 +1,2 @@
+[metadata]
+name = emptyproject

--- a/extractor/filesystem/language/python/setupcfg/testdata/valid.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/valid.cfg
@@ -1,0 +1,22 @@
+[metadata]
+name = myproject
+version = 1.0.0
+
+[options]
+install_requires =
+    requests==2.31.0
+    flask>=2.0
+    Click
+    numpy~=1.24.0
+    cryptography>=41.0,<42.0
+    importlib-metadata; python_version < "3.10"
+    Pillow[jpeg]==10.0.0
+    file:./local-package
+
+[options.extras_require]
+dev =
+    pytest>=7.0
+    pytest-cov
+test =
+    tox
+    coverage!=5.0

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -81,6 +81,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pyprojecttoml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/setup"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/setupcfg"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/uvlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/wheelegg"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/r/renvlock"
@@ -265,6 +266,7 @@ var (
 		ipythoninstall.Name: {protoCfg(ipythoninstall.New)},
 		uvlock.Name:         {protoCfg(uvlock.New)},
 		pyprojecttoml.Name:  {protoCfg(pyprojecttoml.New)},
+		setupcfg.Name:       {protoCfg(setupcfg.New)},
 	}
 	// PythonArtifact extractors for Python.
 	PythonArtifact = InitMap{

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -52,7 +52,7 @@ func TestExtractorsFromName(t *testing.T) {
 		{
 			desc:     "Find_all_extractors_of_a_type",
 			name:     "python",
-			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/ipythoninstall", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "python/pyprojecttoml"},
+			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/ipythoninstall", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "python/pyprojecttoml", "python/setupcfg"},
 		},
 		{
 			desc:     "Nonexistent_plugin",

--- a/plugin/list/list_test.go
+++ b/plugin/list/list_test.go
@@ -131,12 +131,12 @@ func TestFromNames(t *testing.T) {
 		{
 			desc:      "Find_all_Plugins_of_a_type",
 			names:     []string{"python", "windows", "cis", "layerdetails"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/ipythoninstall", "python/uvlock", "python/wheelegg", "python/pyprojecttoml", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/ipythoninstall", "python/uvlock", "python/wheelegg", "python/pyprojecttoml", "python/requirements", "python/setup", "python/setupcfg", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
 		},
 		{
 			desc:      "Remove_duplicates",
 			names:     []string{"python", "python"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/ipythoninstall", "python/uvlock", "python/wheelegg", "python/pyprojecttoml", "python/requirements", "python/setup"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/ipythoninstall", "python/uvlock", "python/wheelegg", "python/pyprojecttoml", "python/requirements", "python/setup", "python/setupcfg"},
 		},
 		{
 			desc:      "Nonexistent_plugin",


### PR DESCRIPTION
## Summary

Adds a new extractor `python/setupcfg` for Python `setup.cfg` files — the declarative setuptools configuration format.

Closes #2200.

## What's extracted

- **`[options] install_requires`** — production dependencies
- **`[options.extras_require]`** — optional/dev dependency groups (group name stored in `DepGroupVals`)

## Parsing approach

Follows the same conventions as `python/requirements`:

- Package names normalized per **PEP 503** (lowercase, `[-_.]+` to `-`)
- Version/comparator extracted with same `getLowestVersion` logic as `requirements.go`
- Compound/wildcard/unsupported constraints (`!=`, `<`, `*`, `,`) — package emitted with empty version for downstream dependency resolution
- **PEP 508 environment markers** stripped (`; python_version < "3.10"`)
- **Extras** stripped (`requests[security]` becomes `requests`)
- **Skipped entries**: `file:`, `attr:`, VCS URLs (`git+`, `hg+`, etc.), local paths, editable installs (`-e`)
- Inline `#` comments stripped
- Multi-line continuation values handled (INI indented lines)
- Deduplication by normalized name (first occurrence wins)

## Metadata

```go
type Metadata struct {
    Requirement       string   // e.g. "requests==2.31.0"
    VersionComparator string   // e.g. "==", ">=", "~="
    DepGroupVals      []string // e.g. ["dev"] from [options.extras_require]
}
```

## Files changed

- `extractor/filesystem/language/python/setupcfg/setupcfg.go` — extractor
- `extractor/filesystem/language/python/setupcfg/metadata.go` — metadata struct
- `extractor/filesystem/language/python/setupcfg/setupcfg_test.go` — tests
- `extractor/filesystem/language/python/setupcfg/testdata/` — test fixtures
- `extractor/filesystem/list/list.go` — registered as `python/setupcfg`
- `extractor/filesystem/list/list_test.go` — updated expectations
- `plugin/list/list_test.go` — updated expectations
