### PR TITLE
SPDX output now contains dependency relationships

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -17,6 +17,8 @@
 package converter
 
 import (
+	"maps"
+	"slices"
 	"time"
 
 	"github.com/CycloneDX/cyclonedx-go"
@@ -26,6 +28,7 @@ import (
 	spdxmeta "github.com/google/osv-scalibr/extractor/filesystem/sbom/spdx/metadata"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/inventory/location"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/purl"
 	"github.com/google/uuid"
 	"github.com/spdx/tools-golang/spdx/v2/v2_3"
@@ -86,34 +89,123 @@ func ToCDX(i inventory.Inventory, c CDXConfig) *cyclonedx.BOM {
 	}
 
 	comps := make([]cyclonedx.Component, 0, len(i.Packages))
+	scalibrToBOMRef := make(map[string]string)
+	pkgToBOMRef := make(map[*extractor.Package]string)
 	for _, pkg := range i.Packages {
-		comp := cyclonedx.Component{
-			BOMRef:  uuid.New().String(),
-			Type:    cyclonedx.ComponentTypeLibrary,
-			Name:    pkg.Name,
-			Version: pkg.Version,
-		}
-		if p := ToPURL(pkg); p != nil {
-			comp.PackageURL = p.String()
-		}
-		if cpes := extractCPEs(pkg); len(cpes) > 0 {
-			comp.CPE = cpes[0]
-		}
-		occ := []cyclonedx.EvidenceOccurrence{}
-		occ = appendOccurrenceFromLocation(pkg.Location.Descriptor, occ)
-		for _, r := range pkg.Location.Related {
-			occ = appendOccurrenceFromLocation(&r, occ)
-		}
-		if len(occ) > 0 {
-			comp.Evidence = &cyclonedx.Evidence{
-				Occurrences: &occ,
-			}
-		}
-		comps = append(comps, comp)
+		bomRef := uuid.New().String()
+		indexBOMRefByIDAndName(pkg, bomRef, scalibrToBOMRef, pkgToBOMRef)
+		comps = append(comps, toComponent(pkg, bomRef))
 	}
 	bom.Components = &comps
+	edges := dependencyEdgesByParentRef(i.Packages, pkgToBOMRef, scalibrToBOMRef, bom.Metadata.Component.BOMRef)
+	if deps := toSortedDependencies(edges); len(deps) > 0 {
+		bom.Dependencies = &deps
+	}
 
 	return bom
+}
+
+// indexBOMRefByIDAndName records bomRef under the package's SCALIBR ID and, when
+// set, its name, so that ParentIDs referring to either can be resolved later.
+// The package is left out of the index if no ID can be generated for it.
+func indexBOMRefByIDAndName(
+	pkg *extractor.Package,
+	bomRef string,
+	scalibrToBOMRef map[string]string,
+	pkgToBOMRef map[*extractor.Package]string,
+) {
+	id, err := pkg.GetIDOrGenerate()
+	if err != nil {
+		log.Warnf("Failed to get or generate ID for package %v: %v", pkg, err)
+		return
+	}
+	scalibrToBOMRef[id] = bomRef
+	if pkg.Name != "" {
+		scalibrToBOMRef[pkg.Name] = bomRef
+	}
+	pkgToBOMRef[pkg] = bomRef
+}
+
+// toComponent converts a SCALIBR package into a CycloneDX library component.
+func toComponent(pkg *extractor.Package, bomRef string) cyclonedx.Component {
+	comp := cyclonedx.Component{
+		BOMRef:  bomRef,
+		Type:    cyclonedx.ComponentTypeLibrary,
+		Name:    pkg.Name,
+		Version: pkg.Version,
+	}
+	if p := ToPURL(pkg); p != nil {
+		comp.PackageURL = p.String()
+	}
+	if cpes := extractCPEs(pkg); len(cpes) > 0 {
+		comp.CPE = cpes[0]
+	}
+	occ := []cyclonedx.EvidenceOccurrence{}
+	occ = appendOccurrenceFromLocation(pkg.Location.Descriptor, occ)
+	for _, r := range pkg.Location.Related {
+		occ = appendOccurrenceFromLocation(&r, occ)
+	}
+	if len(occ) > 0 {
+		comp.Evidence = &cyclonedx.Evidence{
+			Occurrences: &occ,
+		}
+	}
+	return comp
+}
+
+// dependencyEdgesByParentRef inverts the packages' ParentIDs into a set of
+// dependent BOM refs per parent BOM ref, warning about unresolvable parents.
+func dependencyEdgesByParentRef(
+	pkgs []*extractor.Package,
+	pkgToBOMRef map[*extractor.Package]string,
+	scalibrToBOMRef map[string]string,
+	rootRef string,
+) map[string]map[string]bool {
+	edges := make(map[string]map[string]bool)
+	for _, pkg := range pkgs {
+		ref, ok := pkgToBOMRef[pkg]
+		if !ok {
+			continue
+		}
+		for _, parentID := range slices.Sorted(maps.Keys(pkg.ParentIDs)) {
+			parentRef, ok := parentBOMRef(parentID, scalibrToBOMRef, rootRef)
+			if !ok {
+				log.Warnf("Parent package ID %q for package %v not found in inventory", parentID, pkg)
+				continue
+			}
+			if _, ok := edges[parentRef]; !ok {
+				edges[parentRef] = make(map[string]bool)
+			}
+			edges[parentRef][ref] = true
+		}
+	}
+	return edges
+}
+
+// parentBOMRef resolves a SCALIBR parent ID to a BOM ref, mapping the
+// synthetic "root" parent to the document's main component.
+func parentBOMRef(parentID string, scalibrToBOMRef map[string]string, rootRef string) (string, bool) {
+	if ref, ok := scalibrToBOMRef[parentID]; ok {
+		return ref, true
+	}
+	if parentID == "root" {
+		return rootRef, true
+	}
+	return "", false
+}
+
+// toSortedDependencies flattens the dependency edges into CycloneDX entries,
+// with both the entries and their dependency lists sorted by BOM ref.
+func toSortedDependencies(edges map[string]map[string]bool) []cyclonedx.Dependency {
+	deps := make([]cyclonedx.Dependency, 0, len(edges))
+	for _, ref := range slices.Sorted(maps.Keys(edges)) {
+		refs := slices.Sorted(maps.Keys(edges[ref]))
+		deps = append(deps, cyclonedx.Dependency{
+			Ref:          ref,
+			Dependencies: &refs,
+		})
+	}
+	return deps
 }
 
 func extractCPEs(p *extractor.Package) []string {

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -108,7 +108,7 @@ func TestToCDX(t *testing.T) {
 						Name:    "sbom-2",
 						Type:    cyclonedx.ComponentTypeLibrary,
 						Version: "1.0.0",
-						BOMRef:  "81855ad8-681d-4d86-91e9-1e00167939cb",
+						BOMRef:  "6694d2c4-22ac-4208-a007-2939487f6999",
 					},
 					Authors: new([]cyclonedx.OrganizationalContact{{Name: "author"}}),
 					Tools: &cyclonedx.ToolsChoice{
@@ -125,12 +125,73 @@ func TestToCDX(t *testing.T) {
 				},
 				Components: new([]cyclonedx.Component{
 					{
-						BOMRef:     "6694d2c4-22ac-4208-a007-2939487f6999",
+						BOMRef:     "eb9d18a4-4784-445d-87f3-c67cf22746e9",
 						Type:       "library",
 						Name:       "software",
 						Version:    "1.2.3",
 						PackageURL: "pkg:pypi/software@1.2.3",
 					},
+				}),
+			},
+		},
+		{
+			desc: "Packages_with_parent_IDs_emit_dependencies",
+			inv: inventory.Inventory{
+				Packages: []*extractor.Package{
+					{
+						Name:      "parent",
+						ID:        "parent-id",
+						Version:   "1.0.0",
+						PURLType:  purl.TypePyPi,
+						ParentIDs: map[string]bool{"root": true},
+					},
+					{
+						Name:      "child",
+						ID:        "child-id",
+						Version:   "2.0.0",
+						PURLType:  purl.TypePyPi,
+						ParentIDs: map[string]bool{"parent-id": true, "missing-id": true},
+					},
+				},
+			},
+			config: converter.CDXConfig{ComponentName: "sbom-3"},
+			want: &cyclonedx.BOM{
+				Metadata: &cyclonedx.Metadata{
+					Component: &cyclonedx.Component{
+						Name:   "sbom-3",
+						BOMRef: "5fb90bad-b37c-4821-b6d9-5526a41a9504",
+					},
+					Tools: &cyclonedx.ToolsChoice{
+						Components: &[]cyclonedx.Component{
+							{
+								Type: cyclonedx.ComponentTypeApplication,
+								Name: "SCALIBR",
+								ExternalReferences: new([]cyclonedx.ExternalReference{
+									{URL: "https://github.com/google/osv-scalibr", Type: cyclonedx.ERTypeWebsite},
+								}),
+							},
+						},
+					},
+				},
+				Components: new([]cyclonedx.Component{
+					{
+						BOMRef:     "680b4e7c-8b76-4a1b-9d49-d4955c848621",
+						Type:       "library",
+						Name:       "parent",
+						Version:    "1.0.0",
+						PackageURL: "pkg:pypi/parent@1.0.0",
+					},
+					{
+						BOMRef:     "6325253f-ec73-4dd7-a9e2-8bf921119c16",
+						Type:       "library",
+						Name:       "child",
+						Version:    "2.0.0",
+						PackageURL: "pkg:pypi/child@2.0.0",
+					},
+				}),
+				Dependencies: new([]cyclonedx.Dependency{
+					{Ref: "5fb90bad-b37c-4821-b6d9-5526a41a9504", Dependencies: new([]string{"680b4e7c-8b76-4a1b-9d49-d4955c848621"})},
+					{Ref: "680b4e7c-8b76-4a1b-9d49-d4955c848621", Dependencies: new([]string{"6325253f-ec73-4dd7-a9e2-8bf921119c16"})},
 				}),
 			},
 		},

--- a/converter/spdx/spdx.go
+++ b/converter/spdx/spdx.go
@@ -226,7 +226,7 @@ func addRelationshipsAndNodes(
 			RefB:         toDocElementID(NoAssertion),
 			Relationship: "CONTAINS",
 		})
-		relationships = dependsOn(relationships, pkg, pID, scalibrToSPDXID)
+		relationships = dependsOn(relationships, pkg, pID, scalibrToSPDXID, mainPackageID)
 		files, relationships = dependencyManifestOf(files, relationships, pkg, pID, seenFileSPDXID)
 		packages, relationships = descendantOf(packages, relationships, pkg, pID, seenSourceSPDXID)
 	}
@@ -239,20 +239,34 @@ func dependsOn(
 	pkg *extractor.Package,
 	pID string,
 	scalibrToSPDXID map[string]string,
+	mainPackageID string,
 ) []*v2_3.Relationship {
 	parentIDs := slices.Sorted(maps.Keys(pkg.ParentIDs))
 	for _, parentID := range parentIDs {
-		if parentSPDXID, ok := scalibrToSPDXID[parentID]; ok {
-			relationships = append(relationships, &v2_3.Relationship{
-				RefA:         toDocElementID(parentSPDXID),
-				RefB:         toDocElementID(pID),
-				Relationship: "DEPENDS_ON",
-			})
-		} else if parentID != "root" {
+		parentSPDXID, ok := parentSPDXID(parentID, scalibrToSPDXID, mainPackageID)
+		if !ok {
 			log.Warnf("Parent package ID %q for package %v not found in inventory", parentID, pkg)
+			continue
 		}
+		relationships = append(relationships, &v2_3.Relationship{
+			RefA:         toDocElementID(parentSPDXID),
+			RefB:         toDocElementID(pID),
+			Relationship: "DEPENDS_ON",
+		})
 	}
 	return relationships
+}
+
+// parentSPDXID resolves a SCALIBR parent ID to an SPDX ID, mapping the
+// synthetic "root" parent to the document's main package.
+func parentSPDXID(parentID string, scalibrToSPDXID map[string]string, mainPackageID string) (string, bool) {
+	if id, ok := scalibrToSPDXID[parentID]; ok {
+		return id, true
+	}
+	if parentID == "root" {
+		return mainPackageID, true
+	}
+	return "", false
 }
 
 // dependencyManifestOf appends a File node and a DEPENDENCY_MANIFEST_OF relationship

--- a/converter/spdx/spdx_test.go
+++ b/converter/spdx/spdx_test.go
@@ -936,6 +936,15 @@ func TestToSPDX23(t *testing.T) {
 							ElementRefID: "SPDXRef-Package-main-4c7215a3-b539-4b1e-9849-c6077dbb5722",
 						},
 						RefB: common.DocElementID{
+							ElementRefID: "SPDXRef-Package-parent-pkg-pkg-parent",
+						},
+						Relationship: "DEPENDS_ON",
+					},
+					{
+						RefA: common.DocElementID{
+							ElementRefID: "SPDXRef-Package-main-4c7215a3-b539-4b1e-9849-c6077dbb5722",
+						},
+						RefB: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-child-pkg-pkg-child",
 						},
 						Relationship: "CONTAINS",
@@ -1114,6 +1123,15 @@ func TestToSPDX23(t *testing.T) {
 							ElementRefID: "SPDXRef-Package-main-0b4b3739-7011-4e82-ad6f-4125c8fa7311",
 						},
 						RefB: common.DocElementID{
+							ElementRefID: "SPDXRef-Package-parent-pkg1-pkg-parent1",
+						},
+						Relationship: "DEPENDS_ON",
+					},
+					{
+						RefA: common.DocElementID{
+							ElementRefID: "SPDXRef-Package-main-0b4b3739-7011-4e82-ad6f-4125c8fa7311",
+						},
+						RefB: common.DocElementID{
 							ElementRefID: "SPDXRef-Package-parent-pkg2-pkg-parent2",
 						},
 						Relationship: "CONTAINS",
@@ -1126,6 +1144,15 @@ func TestToSPDX23(t *testing.T) {
 							SpecialID: spdx.NoAssertion,
 						},
 						Relationship: "CONTAINS",
+					},
+					{
+						RefA: common.DocElementID{
+							ElementRefID: "SPDXRef-Package-main-0b4b3739-7011-4e82-ad6f-4125c8fa7311",
+						},
+						RefB: common.DocElementID{
+							ElementRefID: "SPDXRef-Package-parent-pkg2-pkg-parent2",
+						},
+						Relationship: "DEPENDS_ON",
 					},
 					{
 						RefA: common.DocElementID{


### PR DESCRIPTION
Populate SPDX relationships from the extracted dependency graph, matching the existing CycloneDX support.