### PR TITLE
Reject tar entries whose names escape the extraction root in image unpack

### DIFF
--- a/artifact/image/unpack/unpack.go
+++ b/artifact/image/unpack/unpack.go
@@ -277,6 +277,14 @@ func unpack(dir string, reader io.Reader, symlinkResolution SymlinkResolution, s
 		cleanPath := path.Clean(header.Name)
 		fullPath := path.Join(dir, cleanPath)
 
+		// Skip entries whose names escape the extraction root. The content
+		// writes are confined by os.Root, but os.MkdirAll and os.Symlink below
+		// operate on the joined path directly and are not root-confined.
+		if fullPath != dir && !strings.HasPrefix(fullPath, dir+string(os.PathSeparator)) {
+			log.Warnf("skipping %q: path escapes the extraction root", header.Name)
+			continue
+		}
+
 		// Skip files already unpacked.
 		// Lstat is used instead of Stat to avoid following symlinks, because their targets may not exist yet.
 		if _, err = root.Lstat(fullPath); err == nil {

--- a/artifact/image/unpack/unpack_test.go
+++ b/artifact/image/unpack/unpack_test.go
@@ -447,6 +447,44 @@ func TestUnpackSquashedFromTarball(t *testing.T) {
 			// directory.
 			want: map[string]contentAndMode{},
 		},
+		{
+			name: "member names escaping the extraction root are skipped",
+			cfg:  unpack.DefaultUnpackerConfig(),
+			dir:  t.TempDir(),
+			tarEntries: []tarEntry{
+				{
+					Header: &tar.Header{
+						Name:     "../escape/pwn-link",
+						Typeflag: tar.TypeSymlink,
+						Linkname: "/etc/hostname",
+						Mode:     0777,
+					},
+				},
+				{
+					Header: &tar.Header{
+						Name: "../escape/pwn-file",
+						Mode: 0777,
+						Size: int64(len("pwn")),
+					},
+					Data: bytes.NewBufferString("pwn"),
+				},
+				{
+					Header: &tar.Header{
+						Name: "normal.txt",
+						Mode: 0777,
+						Size: int64(len("normal")),
+					},
+					Data: bytes.NewBufferString("normal"),
+				},
+			},
+			// Only the entry with the non-escaping name is extracted. Without the escape
+			// check, os.MkdirAll and os.Symlink create the "../escape" directories and
+			// plant the symlink outside of the unpack directory, even though the content
+			// write itself is blocked by os.Root.
+			want: map[string]contentAndMode{
+				filepath.Join("unpack", "normal.txt"): {content: "normal", mode: fs.FileMode(0777)},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## What

Adds an explicit check in `artifact/image/unpack/unpack.go` that skips tar entries whose cleaned member names resolve outside the extraction directory, before any filesystem operation is performed for them.

## Why

In `unpack()`, `fullPath := path.Join(dir, cleanPath)` collapses `..` segments, so a member name such as `../escape/x` produces a `fullPath` outside `dir`. `root.Lstat(fullPath)` errors for such paths, so the entries are not treated as already-unpacked and continue to be processed:

- `os.MkdirAll(filepath.Dir(fullPath), fs.ModePerm)` (the TypeReg branch and the TypeLink/TypeSymlink branch) then creates directories **outside** the extraction root;
- `os.Symlink(targetPath, fullPath)` plants a symlink at an attacker-controlled path **outside** the root (pointing into the extraction dir, since absolute targets are retargeted).

File *content* writes are unaffected: `safeWriteFile` goes through `os.Root` and correctly rejects escaping paths — but that guard runs only after `MkdirAll` has already created directories. `symlink.TargetOutsideRoot` validates the symlink's target, not its own location, so it does not catch this either.

## Fix

Skip any entry whose joined path does not remain under `dir`. This closes both the directory-creation and the symlink-planting paths for escaping member names while leaving all existing behavior for well-formed archives unchanged.

## Test

Adds a case to `TestUnpackSquashedFromTarball` with two escaping entries (a symlink member and a regular member named `../escape/...`) plus one normal entry: only the normal entry may be extracted, and nothing may appear outside the unpack directory.

Verified: `go build ./artifact/image/unpack/` passes with the repo toolchain; `gofmt` clean. (The unpack tests are Linux-gated upstream, so the new case runs in CI rather than on the macOS machine used for development.)

Reported through the Google Bug Hunters OSS VRP (report acknowledged; fix submitted here as suggested by the VRP team).
