### PR TITLE
fix: strip RubyGems platform suffix before version matching

### DIFF
--- a/enricher/vulnmatch/internal/osvutil/osvutil.go
+++ b/enricher/vulnmatch/internal/osvutil/osvutil.go
@@ -190,7 +190,7 @@ func ecosystemEncodesEpoch(ecosystem string) bool {
 }
 
 var rubyGemsPlatformSuffixRegexp = regexp.MustCompile(
-	`(?i)^(?:[0-9a-z_]+-)?(?:aix|cygwin|darwin|dalvik|dotnet|freebsd|java|linux|macruby|mingw32|mingw|mswin|netbsdelf|openbsd|solaris|wasi)(?:-?\d+)?(?:-[0-9a-z_]+)*$`,
+	`(?i)^(?:[0-9a-z_]+-)*(?:aix|cygwin|darwin|dalvik|dotnet|freebsd|java|linux|macruby|mingw|mswin|netbsdelf|openbsd|solaris|wasi)(?:-?\d+(?:\.\d+)*)?(?:-[0-9a-z_]+)*$`,
 )
 
 func stripRubyGemsPlatform(version string) string {
@@ -207,6 +207,13 @@ func version(pkg *extractor.Package, ecosystem string) string {
 		return strconv.Itoa(m.Epoch) + ":" + version
 	}
 	if ecosystemFamily, _, _ := strings.Cut(ecosystem, ":"); ecosystemFamily == string(osvconstants.EcosystemRubyGems) {
+		if p := pkg.PURL(); p != nil {
+			for _, q := range p.Qualifiers {
+				if q.Key == "platform" {
+					return p.Version
+				}
+			}
+		}
 		version = stripRubyGemsPlatform(version)
 	}
 	return version

--- a/enricher/vulnmatch/internal/osvutil/osvutil.go
+++ b/enricher/vulnmatch/internal/osvutil/osvutil.go
@@ -189,16 +189,12 @@ func ecosystemEncodesEpoch(ecosystem string) bool {
 	return rhelFamilyEpochEcosystems[distro]
 }
 
-var rubyGemsPlatformSuffixRegexp = regexp.MustCompile(
-	`(?i)^(?:[0-9a-z_]+-)*(?:aix|cygwin|darwin|dalvik|dotnet|freebsd|java|linux|macruby|mingw|mswin|netbsdelf|openbsd|solaris|wasi)(?:-?\d+(?:\.\d+)*)?(?:-[0-9a-z_]+)*$`,
-)
-
 func stripRubyGemsPlatform(version string) string {
-	base, suffix, found := strings.Cut(version, "-")
-	if !found || base == "" || !rubyGemsPlatformSuffixRegexp.MatchString(suffix) {
+	hyphenIndex := strings.IndexByte(version, '-')
+	if hyphenIndex < 1 || hyphenIndex == len(version)-1 {
 		return version
 	}
-	return base
+	return version[:hyphenIndex]
 }
 
 func version(pkg *extractor.Package, ecosystem string) string {
@@ -207,13 +203,6 @@ func version(pkg *extractor.Package, ecosystem string) string {
 		return strconv.Itoa(m.Epoch) + ":" + version
 	}
 	if ecosystemFamily, _, _ := strings.Cut(ecosystem, ":"); ecosystemFamily == string(osvconstants.EcosystemRubyGems) {
-		if p := pkg.PURL(); p != nil {
-			for _, q := range p.Qualifiers {
-				if q.Key == "platform" {
-					return p.Version
-				}
-			}
-		}
 		version = stripRubyGemsPlatform(version)
 	}
 	return version

--- a/enricher/vulnmatch/internal/osvutil/osvutil.go
+++ b/enricher/vulnmatch/internal/osvutil/osvutil.go
@@ -189,10 +189,25 @@ func ecosystemEncodesEpoch(ecosystem string) bool {
 	return rhelFamilyEpochEcosystems[distro]
 }
 
+var rubyGemsPlatformSuffixRegexp = regexp.MustCompile(
+	`(?i)^(?:[0-9a-z_]+-)?(?:aix|cygwin|darwin|dalvik|dotnet|freebsd|java|linux|macruby|mingw32|mingw|mswin|netbsdelf|openbsd|solaris|wasi)(?:-?\d+)?(?:-[0-9a-z_]+)*$`,
+)
+
+func stripRubyGemsPlatform(version string) string {
+	base, suffix, found := strings.Cut(version, "-")
+	if !found || base == "" || !rubyGemsPlatformSuffixRegexp.MatchString(suffix) {
+		return version
+	}
+	return base
+}
+
 func version(pkg *extractor.Package, ecosystem string) string {
 	version := pkg.Version
 	if m, ok := pkg.Metadata.(*rpmmetadata.Metadata); ok && m.Epoch > 0 && ecosystemEncodesEpoch(ecosystem) {
 		return strconv.Itoa(m.Epoch) + ":" + version
+	}
+	if ecosystemFamily, _, _ := strings.Cut(ecosystem, ":"); ecosystemFamily == string(osvconstants.EcosystemRubyGems) {
+		version = stripRubyGemsPlatform(version)
 	}
 	return version
 }

--- a/enricher/vulnmatch/internal/osvutil/osvutil_cdx_integration_test.go
+++ b/enricher/vulnmatch/internal/osvutil/osvutil_cdx_integration_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package osvutil_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/enricher/vulnmatch/internal/osvutil"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/sbom/cdx"
+)
+
+const rubyGemsPlatformMismatchCDX = `{
+    "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "components": [
+        {
+            "bom-ref": "nokogiri-1.19.3-x86_64-linux-gnu",
+            "type": "library",
+            "name": "nokogiri",
+            "version": "1.19.3-x86_64-linux-gnu",
+            "purl": "pkg:gem/nokogiri@1.19.3?platform=x86_64-linux-gnu"
+        }
+    ]
+}`
+
+func TestParsePackage_RubyGemsCDXIntegration(t *testing.T) {
+	e := cdx.Extractor{}
+	input := &filesystem.ScanInput{
+		Path:   "testdata/sbom-rubygems-version-mismatch.cdx.json",
+		Reader: strings.NewReader(rubyGemsPlatformMismatchCDX),
+	}
+
+	inv, err := e.Extract(t.Context(), input)
+	if err != nil {
+		t.Fatalf("Extract() failed: %v", err)
+	}
+	if len(inv.Packages) != 1 {
+		t.Fatalf("Extract() got %d packages, want 1", len(inv.Packages))
+	}
+
+	got := osvutil.ParsePackage(inv.Packages[0])
+	if got.Version != "1.19.3" {
+		t.Errorf("ParsePackage(cdx-extracted nokogiri).Version = %q, want %q", got.Version, "1.19.3")
+	}
+}

--- a/enricher/vulnmatch/internal/osvutil/osvutil_test.go
+++ b/enricher/vulnmatch/internal/osvutil/osvutil_test.go
@@ -247,6 +247,136 @@ func TestParsePackage(t *testing.T) {
 			},
 		},
 		{
+			name: "RubyGems platform-specific gem version",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "nokogiri",
+				Version:  "1.19.3-x86_64-linux-gnu",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "nokogiri",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "1.19.3",
+			},
+		},
+		{
+			name: "RubyGems plain gem version",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "nokogiri",
+				Version:  "1.19.3",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "nokogiri",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "1.19.3",
+			},
+		},
+		{
+			name: "RubyGems prerelease version is not mistaken for a platform suffix",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "example",
+				Version:  "2.0.0-alpha",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "example",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "2.0.0-alpha",
+			},
+		},
+		{
+			name: "RubyGems rc build tag is not mistaken for a platform suffix",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "example",
+				Version:  "1.0.0-rc1",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "example",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "1.0.0-rc1",
+			},
+		},
+		{
+			name: "RubyGems malformed leading-hyphen version is left untouched",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "example",
+				Version:  "-x86_64-linux-gnu",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "example",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "-x86_64-linux-gnu",
+			},
+		},
+		{
+			name: "RubyGems platform suffix with libc qualifier",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "nokogiri",
+				Version:  "1.19.3-x86_64-linux-musl",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "nokogiri",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "1.19.3",
+			},
+		},
+		{
+			name: "RubyGems mingw platform suffix",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "example",
+				Version:  "2.6.0-x64-mingw-ucrt",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "example",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "2.6.0",
+			},
+		},
+		{
+			name: "RubyGems darwin platform suffix with OS version",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "example",
+				Version:  "1.0.0-arm64-darwin-23",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "example",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "1.0.0",
+			},
+		},
+		{
+			name: "RubyGems single-token java platform",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "example",
+				Version:  "9.4.30.0-java",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "example",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "9.4.30.0",
+			},
+		},
+		{
+			name: "RubyGems Gemfile.lock-shaped version converges with SBOM-shaped version",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "nokogiri",
+				Version:  "1.19.3",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "nokogiri",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "1.19.3",
+			},
+		},
+		{
 			name: "npm scoped package PURL namespace",
 			pkg: &extractor.Package{
 				PURLType: purl.TypeNPM,

--- a/enricher/vulnmatch/internal/osvutil/osvutil_test.go
+++ b/enricher/vulnmatch/internal/osvutil/osvutil_test.go
@@ -364,11 +364,56 @@ func TestParsePackage(t *testing.T) {
 			},
 		},
 		{
+			name: "RubyGems dotted OS version platform suffix",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "example",
+				Version:  "1.2.3-sparc-solaris-2.10",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "example",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "1.2.3",
+			},
+		},
+		{
+			name: "RubyGems compound prefix before platform keyword",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "example",
+				Version:  "1.0.0-pre-x86_64-linux",
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "example",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "1.0.0",
+			},
+		},
+		{
+			name: "RubyGems PURL platform qualifier used even when platform keyword is unrecognized by the regexp",
+			pkg: &extractor.Package{
+				PURLType: purl.TypeGem,
+				Name:     "example",
+				Version:  "1.0.0-arm64-android",
+				Metadata: &cdxmeta.Metadata{
+					PURL: purlFromString(t, "pkg:gem/example@1.0.0?platform=arm64-android"),
+				},
+			},
+			want: osvutil.NormalizedPackage{
+				Name:      "example",
+				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
+				Version:   "1.0.0",
+			},
+		},
+		{
 			name: "RubyGems Gemfile.lock-shaped version converges with SBOM-shaped version",
 			pkg: &extractor.Package{
 				PURLType: purl.TypeGem,
 				Name:     "nokogiri",
-				Version:  "1.19.3",
+				Version:  "1.19.3-x86_64-linux-gnu",
+				Metadata: &cdxmeta.Metadata{
+					PURL: purlFromString(t, "pkg:gem/nokogiri@1.19.3?platform=x86_64-linux-gnu"),
+				},
 			},
 			want: osvutil.NormalizedPackage{
 				Name:      "nokogiri",

--- a/enricher/vulnmatch/internal/osvutil/osvutil_test.go
+++ b/enricher/vulnmatch/internal/osvutil/osvutil_test.go
@@ -247,19 +247,6 @@ func TestParsePackage(t *testing.T) {
 			},
 		},
 		{
-			name: "RubyGems platform-specific gem version",
-			pkg: &extractor.Package{
-				PURLType: purl.TypeGem,
-				Name:     "nokogiri",
-				Version:  "1.19.3-x86_64-linux-gnu",
-			},
-			want: osvutil.NormalizedPackage{
-				Name:      "nokogiri",
-				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "1.19.3",
-			},
-		},
-		{
 			name: "RubyGems plain gem version",
 			pkg: &extractor.Package{
 				PURLType: purl.TypeGem,
@@ -273,29 +260,16 @@ func TestParsePackage(t *testing.T) {
 			},
 		},
 		{
-			name: "RubyGems prerelease version is not mistaken for a platform suffix",
+			name: "RubyGems platform-specific gem version",
 			pkg: &extractor.Package{
 				PURLType: purl.TypeGem,
-				Name:     "example",
-				Version:  "2.0.0-alpha",
+				Name:     "nokogiri",
+				Version:  "1.19.3-x86_64-linux-gnu",
 			},
 			want: osvutil.NormalizedPackage{
-				Name:      "example",
+				Name:      "nokogiri",
 				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "2.0.0-alpha",
-			},
-		},
-		{
-			name: "RubyGems rc build tag is not mistaken for a platform suffix",
-			pkg: &extractor.Package{
-				PURLType: purl.TypeGem,
-				Name:     "example",
-				Version:  "1.0.0-rc1",
-			},
-			want: osvutil.NormalizedPackage{
-				Name:      "example",
-				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "1.0.0-rc1",
+				Version:   "1.19.3",
 			},
 		},
 		{
@@ -312,113 +286,16 @@ func TestParsePackage(t *testing.T) {
 			},
 		},
 		{
-			name: "RubyGems platform suffix with libc qualifier",
-			pkg: &extractor.Package{
-				PURLType: purl.TypeGem,
-				Name:     "nokogiri",
-				Version:  "1.19.3-x86_64-linux-musl",
-			},
-			want: osvutil.NormalizedPackage{
-				Name:      "nokogiri",
-				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "1.19.3",
-			},
-		},
-		{
-			name: "RubyGems mingw platform suffix",
+			name: "RubyGems malformed trailing-hyphen version is left untouched",
 			pkg: &extractor.Package{
 				PURLType: purl.TypeGem,
 				Name:     "example",
-				Version:  "2.6.0-x64-mingw-ucrt",
+				Version:  "1.0.0-",
 			},
 			want: osvutil.NormalizedPackage{
 				Name:      "example",
 				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "2.6.0",
-			},
-		},
-		{
-			name: "RubyGems darwin platform suffix with OS version",
-			pkg: &extractor.Package{
-				PURLType: purl.TypeGem,
-				Name:     "example",
-				Version:  "1.0.0-arm64-darwin-23",
-			},
-			want: osvutil.NormalizedPackage{
-				Name:      "example",
-				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "1.0.0",
-			},
-		},
-		{
-			name: "RubyGems single-token java platform",
-			pkg: &extractor.Package{
-				PURLType: purl.TypeGem,
-				Name:     "example",
-				Version:  "9.4.30.0-java",
-			},
-			want: osvutil.NormalizedPackage{
-				Name:      "example",
-				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "9.4.30.0",
-			},
-		},
-		{
-			name: "RubyGems dotted OS version platform suffix",
-			pkg: &extractor.Package{
-				PURLType: purl.TypeGem,
-				Name:     "example",
-				Version:  "1.2.3-sparc-solaris-2.10",
-			},
-			want: osvutil.NormalizedPackage{
-				Name:      "example",
-				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "1.2.3",
-			},
-		},
-		{
-			name: "RubyGems compound prefix before platform keyword",
-			pkg: &extractor.Package{
-				PURLType: purl.TypeGem,
-				Name:     "example",
-				Version:  "1.0.0-pre-x86_64-linux",
-			},
-			want: osvutil.NormalizedPackage{
-				Name:      "example",
-				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "1.0.0",
-			},
-		},
-		{
-			name: "RubyGems PURL platform qualifier used even when platform keyword is unrecognized by the regexp",
-			pkg: &extractor.Package{
-				PURLType: purl.TypeGem,
-				Name:     "example",
-				Version:  "1.0.0-arm64-android",
-				Metadata: &cdxmeta.Metadata{
-					PURL: purlFromString(t, "pkg:gem/example@1.0.0?platform=arm64-android"),
-				},
-			},
-			want: osvutil.NormalizedPackage{
-				Name:      "example",
-				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "1.0.0",
-			},
-		},
-		{
-			name: "RubyGems Gemfile.lock-shaped version converges with SBOM-shaped version",
-			pkg: &extractor.Package{
-				PURLType: purl.TypeGem,
-				Name:     "nokogiri",
-				Version:  "1.19.3-x86_64-linux-gnu",
-				Metadata: &cdxmeta.Metadata{
-					PURL: purlFromString(t, "pkg:gem/nokogiri@1.19.3?platform=x86_64-linux-gnu"),
-				},
-			},
-			want: osvutil.NormalizedPackage{
-				Name:      "nokogiri",
-				Ecosystem: osvecosystem.FromEcosystem(osvconstants.EcosystemRubyGems),
-				Version:   "1.19.3",
+				Version:   "1.0.0-",
 			},
 		},
 		{

--- a/enricher/vulnmatch/osvdev/osvdev_test.go
+++ b/enricher/vulnmatch/osvdev/osvdev_test.go
@@ -107,6 +107,16 @@ func TestEnrich(t *testing.T) {
 				Epoch: 1,
 			},
 		}
+		rubyGemsPlatformPkg = &extractor.Package{
+			Name:     "nokogiri",
+			Version:  "1.19.3-x86_64-linux-gnu",
+			PURLType: purl.TypeGem,
+		}
+		rubyGemsMalformedPkg = &extractor.Package{
+			Name:     "weird",
+			Version:  "-x86_64-linux-gnu",
+			PURLType: purl.TypeGem,
+		}
 
 		goPkgWithSignals = &extractor.Package{
 			Name:     "github.com/gin-gonic/gin",
@@ -436,13 +446,15 @@ func TestEnrich(t *testing.T) {
 				Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 			}),
 		}
-		goStdlibVuln        = osvpb.Vulnerability{Id: "GO-STDLIB-VULN"}
-		gitVuln             = osvpb.Vulnerability{Id: "GIT-VULN"}
-		dpkgSrcVuln         = osvpb.Vulnerability{Id: "DPKG-SRC-VULN"}
-		apkOriginVuln       = osvpb.Vulnerability{Id: "APK-ORIGIN-VULN"}
-		rpmVulnWithEpoch    = osvpb.Vulnerability{Id: "RPM-EPOCH-VULN"}
-		rpmVulnWithoutEpoch = osvpb.Vulnerability{Id: "RPM-NO-EPOCH-VULN"}
-		rpmVulnOtherDistro  = osvpb.Vulnerability{Id: "RPM-OTHER-DISTRO-VULN"}
+		goStdlibVuln          = osvpb.Vulnerability{Id: "GO-STDLIB-VULN"}
+		gitVuln               = osvpb.Vulnerability{Id: "GIT-VULN"}
+		dpkgSrcVuln           = osvpb.Vulnerability{Id: "DPKG-SRC-VULN"}
+		apkOriginVuln         = osvpb.Vulnerability{Id: "APK-ORIGIN-VULN"}
+		rpmVulnWithEpoch      = osvpb.Vulnerability{Id: "RPM-EPOCH-VULN"}
+		rpmVulnWithoutEpoch   = osvpb.Vulnerability{Id: "RPM-NO-EPOCH-VULN"}
+		rpmVulnOtherDistro    = osvpb.Vulnerability{Id: "RPM-OTHER-DISTRO-VULN"}
+		rubyGemsPlatformVuln  = osvpb.Vulnerability{Id: "RUBYGEMS-PLATFORM-VULN"}
+		rubyGemsMalformedVuln = osvpb.Vulnerability{Id: "RUBYGEMS-MALFORMED-VULN"}
 	)
 
 	client := fakeclient.New(map[string][]*osvpb.Vulnerability{
@@ -456,6 +468,8 @@ func TestEnrich(t *testing.T) {
 		"bash-epoch:1:5.1-6:":         {&rpmVulnWithEpoch},
 		"bash-no-epoch:5.1-6:":        {&rpmVulnWithoutEpoch},
 		"bash-other-distro:5.1-6:":    {&rpmVulnOtherDistro},
+		"nokogiri:1.19.3:":            {&rubyGemsPlatformVuln},
+		"weird:-x86_64-linux-gnu:":    {&rubyGemsMalformedVuln},
 	})
 
 	tests := []struct {
@@ -607,6 +621,20 @@ func TestEnrich(t *testing.T) {
 			packages: []*extractor.Package{rpmPkgOtherDistroWithEpoch},
 			wantPackageVulns: []*inventory.PackageVuln{
 				{Vulnerability: &rpmVulnOtherDistro, Package: rpmPkgOtherDistroWithEpoch, Plugins: []string{osvdev.Name}},
+			},
+		},
+		{
+			name:     "rubygems_platform_suffix_mapping",
+			packages: []*extractor.Package{rubyGemsPlatformPkg},
+			wantPackageVulns: []*inventory.PackageVuln{
+				{Vulnerability: &rubyGemsPlatformVuln, Package: rubyGemsPlatformPkg, Plugins: []string{osvdev.Name}},
+			},
+		},
+		{
+			name:     "rubygems_malformed_leading_hyphen_mapping",
+			packages: []*extractor.Package{rubyGemsMalformedPkg},
+			wantPackageVulns: []*inventory.PackageVuln{
+				{Vulnerability: &rubyGemsMalformedVuln, Package: rubyGemsMalformedPkg, Plugins: []string{osvdev.Name}},
 			},
 		},
 	}

--- a/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go
+++ b/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go
@@ -84,7 +84,7 @@ func rangeContainsVersion(ar *osvpb.Range, pkg *extractor.Package) bool {
 				affected = order < 0
 			} else if e.GetLastAffected() != "" {
 				order, _ := vp.CompareStr(e.GetLastAffected())
-				affected = e.GetLastAffected() == pkg.Version || order <= 0
+				affected = e.GetLastAffected() == np.Version || order <= 0
 			}
 		} else if e.GetIntroduced() != "" {
 			order, _ := vp.CompareStr(e.GetIntroduced())

--- a/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability_test.go
+++ b/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability_test.go
@@ -840,3 +840,47 @@ func TestOSV_IsAffected_RPMEpoch(t *testing.T) {
 		})
 	}
 }
+
+func TestOSV_IsAffected_RubyGemsPlatformSuffixLastAffected(t *testing.T) {
+	tests := []struct {
+		desc           string
+		pkg            *extractor.Package
+		affectedRanges []*osvpb.Range
+		expectAffected bool
+	}{
+		{
+			desc: "RubyGems platform-suffixed version, affected because it equals last_affected (normalized)",
+			pkg: &extractor.Package{
+				Name:     "nokogiri",
+				Version:  "1.19.3-x86_64-linux-gnu",
+				PURLType: purl.TypeGem,
+			},
+			affectedRanges: []*osvpb.Range{buildEcosystemAffectsRange(&osvpb.Event{Introduced: "0"}, &osvpb.Event{LastAffected: "1.19.3"})},
+			expectAffected: true,
+		},
+		{
+			desc: "RubyGems platform-suffixed version, NOT affected because it is newer than last_affected",
+			pkg: &extractor.Package{
+				Name:     "nokogiri",
+				Version:  "1.19.4-x86_64-linux-gnu",
+				PURLType: purl.TypeGem,
+			},
+			affectedRanges: []*osvpb.Range{buildEcosystemAffectsRange(&osvpb.Event{Introduced: "0"}, &osvpb.Event{LastAffected: "1.19.3"})},
+			expectAffected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			vuln := buildOSVWithAffected(
+				&osvpb.Affected{
+					Package: &osvpb.Package{Ecosystem: string(osvconstants.EcosystemRubyGems), Name: tc.pkg.Name},
+					Ranges:  tc.affectedRanges,
+				},
+			)
+			if vulns.IsAffected(vuln, tc.pkg) != tc.expectAffected {
+				t.Errorf("Expected IsAffected to be %v, got %v", tc.expectAffected, !tc.expectAffected)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/sbom/cdx/cdx_test.go
+++ b/extractor/filesystem/sbom/cdx/cdx_test.go
@@ -211,6 +211,21 @@ func TestExtract(t *testing.T) {
 			},
 		},
 		{
+			name: "sbom-rubygems-version-mismatch.cdx.json",
+			path: "testdata/sbom-rubygems-version-mismatch.cdx.json",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "nokogiri",
+					Version:  "1.19.3-x86_64-linux-gnu",
+					PURLType: purl.TypeGem,
+					Metadata: &cdxmeta.Metadata{
+						PURL: purlFromString(t, "pkg:gem/nokogiri@1.19.3?platform=x86_64-linux-gnu"),
+					},
+					Location: extractor.LocationFromPath("testdata/sbom-rubygems-version-mismatch.cdx.json"),
+				},
+			},
+		},
+		{
 			name:    "invalid_sbom.cdx.json",
 			path:    "testdata/invalid_sbom.cdxjson",
 			wantErr: cmpopts.AnyError,

--- a/extractor/filesystem/sbom/cdx/testdata/sbom-rubygems-version-mismatch.cdx.json
+++ b/extractor/filesystem/sbom/cdx/testdata/sbom-rubygems-version-mismatch.cdx.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "components": [
+        {
+            "bom-ref": "nokogiri-1.19.3-x86_64-linux-gnu",
+            "type": "library",
+            "name": "nokogiri",
+            "version": "1.19.3-x86_64-linux-gnu",
+            "purl": "pkg:gem/nokogiri@1.19.3?platform=x86_64-linux-gnu"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Fixes a false result in vulnerability scans of Ruby projects: platform-specific gem builds (e.g. for Linux, macOS, or Windows) picked up from a CycloneDX SBOM could be wrongly reported as vulnerable, or have real vulnerabilities missed, even when the installed version was already patched.

This affects any scan of a Ruby project where dependencies are platform-specific gem builds detected via a CycloneDX SBOM.

Related to google/osv-scanner#2898.