### PR TITLE
Extract Python dependencies from setup.cfg

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -106,6 +106,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | pdm.lock                                          | `python/pdmlock`                     |
 |            | Conda packages                                    | `python/condameta`                   |
 |            | setup.py                                          | `python/setup`                       |
+|            | setup.cfg                                         | `python/setupcfg`                    |
 |            | uv.lock                                           | `python/uvlock`                      |
 |            | pyproject.toml                                    | `python/pyprojecttoml`               |
 | R          | renv.lock                                         | `r/renvlock`                         |

--- a/extractor/filesystem/language/python/setupcfg/metadata.go
+++ b/extractor/filesystem/language/python/setupcfg/metadata.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setupcfg
+
+import (
+	"github.com/google/osv-scalibr/binary/proto/metadata"
+)
+
+func init() {
+	// setup.cfg dependency metadata is intentionally not serialized to a
+	// dedicated proto yet; it is preserved in-memory for extraction and tests.
+	metadata.RegisterNil[*Metadata]()
+}
+
+// Metadata contains additional information about a package parsed from a
+// setup.cfg dependency entry.
+type Metadata struct {
+	// VersionComparator is the comparator used in the requirement spec, e.g.
+	// "==", ">=", "~=". Empty when no comparator was present.
+	VersionComparator string
+	// DepGroup is the [options.extras_require] group the entry belongs to.
+	// Empty for entries from [options] install_requires.
+	DepGroup string
+}
+
+// IsProtoable marks the struct as a metadata type.
+func (m *Metadata) IsProtoable() {}

--- a/extractor/filesystem/language/python/setupcfg/setupcfg.go
+++ b/extractor/filesystem/language/python/setupcfg/setupcfg.go
@@ -1,0 +1,378 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package setupcfg extracts Python package dependencies from setuptools
+// declarative setup.cfg files. It parses the [options] install_requires and
+// [options.extras_require] sections and emits PyPI PURLs for valid PEP 508
+// dependency entries.
+//
+// See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
+// and https://packaging.python.org/en/latest/specifications/dependency-specifiers/.
+package setupcfg
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "python/setupcfg"
+
+	// defaultMaxFileSizeBytes is the maximum file size an extractor will parse.
+	defaultMaxFileSizeBytes = 10 * units.MiB
+
+	sectionOptions       = "options"
+	sectionOptionsExtras = "options.extras_require"
+	keyInstallRequires   = "install_requires"
+)
+
+var (
+	// reValidPkg matches a valid (PEP 503 normalized) package name.
+	// https://packaging.python.org/en/latest/specifications/name-normalization/
+	reValidPkg = regexp.MustCompile(`(?i)^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$`)
+	// reExtras matches extras brackets, e.g. "pkg[extra1,extra2]".
+	reExtras = regexp.MustCompile(`\[[^\[\]]*\]`)
+	// reComment matches an inline comment introduced by whitespace + # (or a full-line comment).
+	reComment = regexp.MustCompile(`(^|\s+)#.*$`)
+	// reSpaceOps collapses spaces around comparator characters so PEP 508
+	// allows "pkg > 1.0"; names keep their spaces (which makes them invalid).
+	reSpaceOps = regexp.MustCompile(`\s*([<>=~!])\s*`)
+	// reUnsupportedConstraints matches version constraints we don't reduce to a single
+	// lowest version: wildcards, less-than, greater-than (not >=), not-equal, and
+	// comma-separated multiple specs. Matching such entries emits the package
+	// identity without a version instead of dropping the dependency.
+	reUnsupportedConstraints = regexp.MustCompile(`\*|<[^=]|>[^=]|,|!=`)
+	// reEnvVar matches environment variable / template interpolations such as ${VAR}
+	// or %(VAR)s that setuptools can expand at build time.
+	reEnvVar = regexp.MustCompile(`\$\{[A-Za-z0-9_]+\}|%\([A-Za-z0-9_]+\)s`)
+	// reURLScheme matches a leading URL/VCS scheme such as git+https://, file:, attr:.
+	reURLScheme = regexp.MustCompile(`(?i)^[A-Za-z][A-Za-z0-9+.-]*:`)
+)
+
+// Extractor extracts python packages from setup.cfg files.
+type Extractor struct {
+	Stats            stats.Collector
+	maxFileSizeBytes int64
+}
+
+// New returns a setup.cfg extractor.
+func New(cfg *cpb.PluginConfig) (filesystem.Extractor, error) {
+	maxFileSizeBytes := defaultMaxFileSizeBytes
+	if cfg.GetMaxFileSizeBytes() > 0 {
+		maxFileSizeBytes = cfg.GetMaxFileSizeBytes()
+	}
+	return &Extractor{maxFileSizeBytes: maxFileSizeBytes}, nil
+}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities { return &plugin.Capabilities{} }
+
+// FileRequired returns true if the specified file is a setup.cfg file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	if filepath.Base(path) != "setup.cfg" {
+		return false
+	}
+
+	fileinfo, err := api.Stat()
+	if err != nil {
+		return false
+	}
+	if e.maxFileSizeBytes > 0 && fileinfo.Size() > e.maxFileSizeBytes {
+		e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultSizeLimitExceeded)
+		return false
+	}
+
+	e.reportFileRequired(path, fileinfo.Size(), stats.FileRequiredResultOK)
+	return true
+}
+
+func (e Extractor) reportFileRequired(path string, fileSizeBytes int64, result stats.FileRequiredResult) {
+	if e.Stats == nil {
+		return
+	}
+	e.Stats.AfterFileRequired(e.Name(), &stats.FileRequiredStats{
+		Path:          path,
+		Result:        result,
+		FileSizeBytes: fileSizeBytes,
+	})
+}
+
+// Extract extracts packages from setup.cfg files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	pkgs, err := e.extractFromInput(ctx, input)
+
+	if e.Stats != nil {
+		var fileSizeBytes int64
+		if input.Info != nil {
+			fileSizeBytes = input.Info.Size()
+		}
+		e.Stats.AfterFileExtracted(e.Name(), &stats.FileExtractedStats{
+			Path:          input.Path,
+			Result:        filesystem.ExtractorErrorToFileExtractedResult(err),
+			FileSizeBytes: fileSizeBytes,
+		})
+	}
+	return inventory.Inventory{Packages: pkgs}, err
+}
+
+func (e Extractor) extractFromInput(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Package, error) {
+	// First pass: read all lines so we can look ahead for multi-line continuation
+	// values (setuptools allows indented continuation lines under a key).
+	var lines []string
+	s := bufio.NewScanner(input.Reader)
+	for s.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("%s halted due to context error: %w", e.Name(), err)
+		}
+		lines = append(lines, s.Text())
+	}
+	if err := s.Err(); err != nil {
+		return nil, fmt.Errorf("error while scanning setup.cfg file: %w", err)
+	}
+
+	var pkgs []*extractor.Package
+	currentSection := ""
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		trimmed := strings.TrimSpace(raw)
+
+		// Skip blank lines and full-line comments.
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			continue
+		}
+
+		// Section header, e.g. "[options]" or "[options.extras_require]".
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			currentSection = strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+			continue
+		}
+
+		switch currentSection {
+		case sectionOptions:
+			// Only install_requires is a dependency list under [options].
+			key, value, contLines, nextIdx := parseKeyValue(lines, i)
+			if !strings.EqualFold(key, keyInstallRequires) {
+				i = nextIdx - 1
+				continue
+			}
+			pkgs = append(pkgs, parseRequirementLines(value, contLines, "", input.Path)...)
+			i = nextIdx - 1
+		case sectionOptionsExtras:
+			// Each key under [options.extras_require] is an extras group whose
+			// value is a list of requirements.
+			group, value, contLines, nextIdx := parseKeyValue(lines, i)
+			pkgs = append(pkgs, parseRequirementLines(value, contLines, group, input.Path)...)
+			i = nextIdx - 1
+		}
+	}
+
+	return pkgs, nil
+}
+
+// parsedContLine is a single continuation requirement entry with its source line number.
+type parsedContLine struct {
+	text string
+	line int
+}
+
+// parseKeyValue reads a "key = value" line at index i and gathers any indented
+// continuation lines that follow it. It returns the key, the inline value (if
+// any), the list of continuation requirement lines (with their 1-based line
+// numbers), and the index of the next line to process.
+func parseKeyValue(lines []string, i int) (key, inline string, cont []parsedContLine, nextIdx int) {
+	raw := lines[i]
+	key, inline, _ = strings.Cut(raw, "=")
+	key = strings.TrimSpace(key)
+	inline = strings.TrimSpace(inline)
+
+	idx := i + 1
+	// setuptools multi-line values are continuation lines that begin with
+	// whitespace. A blank line or a non-indented line ends the value.
+	for idx < len(lines) {
+		next := lines[idx]
+		tNext := strings.TrimSpace(next)
+		if tNext == "" {
+			// A blank line terminates a multi-line value but is otherwise
+			// harmless; stop collecting continuation lines here.
+			break
+		}
+		if next[0] != ' ' && next[0] != '\t' {
+			// Non-indented line: belongs to the next key/section.
+			break
+		}
+		cont = append(cont, parsedContLine{text: tNext, line: idx + 1})
+		idx++
+	}
+	return key, inline, cont, idx
+}
+
+// parseRequirementLines converts the inline value and continuation lines into
+// packages. The inline value is attributed to the key's own line; continuation
+// lines keep their own line numbers. depGroup is the extras_require group name
+// (empty for install_requires).
+func parseRequirementLines(inline string, cont []parsedContLine, depGroup, path string) []*extractor.Package {
+	var pkgs []*extractor.Package
+
+	// The inline portion of install_requires/extras_require is usually empty
+	// (the entries live on continuation lines), but setuptools permits a
+	// single inline entry too, e.g. "install_requires = requests>=2.0".
+	if inline != "" {
+		// We don't have a precise line for the inline value; attribute it to
+		// the first continuation line if present, otherwise skip line tracking.
+		line := 0
+		if len(cont) > 0 {
+			line = cont[0].line - 1
+		}
+		if p := parseRequirement(inline, path, line, depGroup); p != nil {
+			pkgs = append(pkgs, p)
+		}
+	}
+
+	for _, c := range cont {
+		if p := parseRequirement(c.text, path, c.line, depGroup); p != nil {
+			pkgs = append(pkgs, p)
+		}
+	}
+	return pkgs
+}
+
+// parseRequirement parses a single PEP 508-style requirement string and returns
+// a Package, or nil if the entry should be skipped (empty, commented, dynamic
+// source, invalid name, or unsupported form).
+func parseRequirement(s, path string, line int, depGroup string) *extractor.Package {
+	// Strip inline comments.
+	s = reComment.ReplaceAllString(s, "")
+	// Drop environment markers (everything after ';'). We do not evaluate them.
+	s = strings.SplitN(s, ";", 2)[0]
+	// Drop extras brackets, e.g. "pkg[extra]" -> "pkg".
+	s = reExtras.ReplaceAllString(s, "")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+
+	// Skip dynamic / indirect dependency sources.
+	if isDynamicSource(s) {
+		return nil
+	}
+
+	name, version, comp := getLowestVersion(s)
+	if name == "" || !isValidPackage(name) {
+		return nil
+	}
+	if version == "" && comp != "" {
+		// A comparator with no version is malformed.
+		return nil
+	}
+
+	md := &Metadata{VersionComparator: comp}
+	if depGroup != "" {
+		md.DepGroup = depGroup
+	}
+
+	return &extractor.Package{
+		Name:     name,
+		Version:  version,
+		PURLType: purl.TypePyPi,
+		Location: extractor.LocationFromPathAndLine(filepath.ToSlash(path), line),
+		Metadata: md,
+	}
+}
+
+// isDynamicSource reports whether the requirement string refers to a dynamic or
+// indirect dependency source that this extractor does not resolve: file:/
+// attr: directives, environment-variable/template values, local paths, VCS/URL
+// schemes, and editable installs.
+func isDynamicSource(s string) bool {
+	// Editable install flag, e.g. "-e ./local/pkg" or "-e git+https://...".
+	if strings.HasPrefix(s, "-e ") || s == "-e" {
+		return true
+	}
+	// URL / VCS / directive schemes: file:, attr:, http(s)://, git+..., hg+...,
+	// svn+..., bzr+..., git://, etc.
+	if reURLScheme.MatchString(s) {
+		return true
+	}
+	// Environment variable / template interpolation.
+	if reEnvVar.MatchString(s) {
+		return true
+	}
+	// Local filesystem paths (relative or absolute), e.g. "./pkg", "../pkg",
+	// "/abs/path". A bare "." or ".." alone is not a package name.
+	if strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") || strings.HasPrefix(s, "/") {
+		return true
+	}
+	return false
+}
+
+// getLowestVersion extracts the package name, version, and comparator from a
+// requirement string. For supported comparators (===, ==, >=, <=, ~=) it
+// returns the version that appears in the spec. For unsupported constraints
+// (wildcards, <, !=, comma-separated specs) it returns the name with an empty
+// version so the package is still listed for dependency resolution.
+func getLowestVersion(s string) (name, version, comparator string) {
+	// PEP 508 permits spaces around comparators; normalize those (and only
+	// those) so the regex and separator checks behave the same for
+	// "pkg > 1.0" and "pkg>1.0" while malformed names with spaces stay invalid.
+	s = reSpaceOps.ReplaceAllString(s, "$1")
+	if reUnsupportedConstraints.FindString(s) != "" {
+		return nameFromRequirement(s), "", ""
+	}
+
+	separators := []string{"===", "==", ">=", "<=", "~="}
+	for _, sep := range separators {
+		if strings.Contains(s, sep) {
+			t := strings.SplitN(s, sep, 2)
+			if len(t) != 2 {
+				return "", "", ""
+			}
+			return strings.TrimSpace(t[0]), strings.TrimSpace(t[1]), sep
+		}
+	}
+	// No comparator: bare package name.
+	return strings.TrimSpace(s), "", ""
+}
+
+func nameFromRequirement(s string) string {
+	for _, sep := range []string{"===", "==", ">=", "<=", "~=", "!=", "<", ">"} {
+		s, _, _ = strings.Cut(s, sep)
+	}
+	return strings.TrimSpace(s)
+}
+
+func isValidPackage(s string) bool {
+	return reValidPkg.MatchString(s)
+}

--- a/extractor/filesystem/language/python/setupcfg/setupcfg_test.go
+++ b/extractor/filesystem/language/python/setupcfg/setupcfg_test.go
@@ -1,0 +1,414 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setupcfg_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/internal/units"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/setupcfg"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/stats"
+	"github.com/google/osv-scalibr/testing/extracttest"
+	"github.com/google/osv-scalibr/testing/fakefs"
+	"github.com/google/osv-scalibr/testing/testcollector"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+func TestFileRequired(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		fileSizeBytes    int64
+		maxFileSizeBytes int64
+		wantRequired     bool
+		wantResultMetric stats.FileRequiredResult
+	}{
+		{
+			name:             "setup.cfg file",
+			path:             "pkg/setup.cfg",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "setup.cfg required if file size < max file size",
+			path:             "pkg/setup.cfg",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "setup.cfg required if file size == max file size",
+			path:             "pkg/setup.cfg",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 1000 * units.KiB,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:             "setup.cfg not required if file size > max file size",
+			path:             "pkg/setup.cfg",
+			fileSizeBytes:    1000 * units.KiB,
+			maxFileSizeBytes: 100 * units.KiB,
+			wantRequired:     false,
+			wantResultMetric: stats.FileRequiredResultSizeLimitExceeded,
+		},
+		{
+			name:             "setup.cfg required if max file size set to 0",
+			path:             "pkg/setup.cfg",
+			fileSizeBytes:    100 * units.KiB,
+			maxFileSizeBytes: 0,
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
+			name:         "setup.py is not setup.cfg",
+			path:         "pkg/setup.py",
+			wantRequired: false,
+		},
+		{
+			name:         "setup.cfg.bak is not setup.cfg",
+			path:         "pkg/setup.cfg.bak",
+			wantRequired: false,
+		},
+		{
+			name:         "setup.cfg as directory",
+			path:         "pkg/setup.cfg/inner",
+			wantRequired: false,
+		},
+		{
+			name:         "uppercase SETUP.CFG is not matched",
+			path:         "pkg/SETUP.CFG",
+			wantRequired: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := testcollector.New()
+			e, err := setupcfg.New(&cpb.PluginConfig{MaxFileSizeBytes: tt.maxFileSizeBytes})
+			if err != nil {
+				t.Fatalf("setupcfg.New(%v) error: %v", tt.maxFileSizeBytes, err)
+			}
+			e.(*setupcfg.Extractor).Stats = collector
+
+			fileSizeBytes := tt.fileSizeBytes
+			if fileSizeBytes == 0 {
+				fileSizeBytes = 1000
+			}
+
+			isRequired := e.FileRequired(simplefileapi.New(tt.path, fakefs.FakeFileInfo{
+				FileName: filepath.Base(tt.path),
+				FileMode: fs.ModePerm,
+				FileSize: fileSizeBytes,
+			}))
+			if isRequired != tt.wantRequired {
+				t.Fatalf("FileRequired(%s): got %v, want %v", tt.path, isRequired, tt.wantRequired)
+			}
+
+			gotResultMetric := collector.FileRequiredResult(tt.path)
+			if tt.wantResultMetric != "" && gotResultMetric != tt.wantResultMetric {
+				t.Errorf("FileRequired(%s) recorded result metric %v, want result metric %v", tt.path, gotResultMetric, tt.wantResultMetric)
+			}
+		})
+	}
+}
+
+func TestExtract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "basic install_requires and extras_require",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/basic.cfg",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "2.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/basic.cfg", 7),
+					Metadata: &setupcfg.Metadata{VersionComparator: ">="},
+				},
+				{
+					Name:     "importlib-metadata",
+					Version:  "6.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/basic.cfg", 8),
+					Metadata: &setupcfg.Metadata{VersionComparator: "=="},
+				},
+				{
+					Name:     "flask",
+					Version:  "3.1.1",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/basic.cfg", 9),
+					Metadata: &setupcfg.Metadata{VersionComparator: "=="},
+				},
+				{
+					Name:     "numpy",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/basic.cfg", 10),
+					Metadata: &setupcfg.Metadata{},
+				},
+				{
+					Name:     "pytest",
+					Version:  "7",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/basic.cfg", 14),
+					Metadata: &setupcfg.Metadata{VersionComparator: ">=", DepGroup: "dev"},
+				},
+				{
+					Name:     "black",
+					Version:  "23.1.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/basic.cfg", 15),
+					Metadata: &setupcfg.Metadata{VersionComparator: "==", DepGroup: "dev"},
+				},
+			},
+		},
+		{
+			Name: "multiple extras_require groups",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/extras.cfg",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "2.31.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/extras.cfg", 3),
+					Metadata: &setupcfg.Metadata{VersionComparator: "=="},
+				},
+				{
+					Name:     "pytest",
+					Version:  "7.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/extras.cfg", 7),
+					Metadata: &setupcfg.Metadata{VersionComparator: ">=", DepGroup: "dev"},
+				},
+				{
+					Name:     "coverage",
+					Version:  "7.4",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/extras.cfg", 8),
+					Metadata: &setupcfg.Metadata{VersionComparator: "~=", DepGroup: "dev"},
+				},
+				{
+					Name:     "sphinx",
+					Version:  "5.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/extras.cfg", 10),
+					Metadata: &setupcfg.Metadata{VersionComparator: ">=", DepGroup: "docs"},
+				},
+				{
+					Name:     "myst-parser",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/extras.cfg", 11),
+					Metadata: &setupcfg.Metadata{DepGroup: "docs"},
+				},
+			},
+		},
+		{
+			Name: "environment markers are stripped not evaluated",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/markers.cfg",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "2.20.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/markers.cfg", 3),
+					Metadata: &setupcfg.Metadata{VersionComparator: ">="},
+				},
+				{
+					Name:     "importlib-metadata",
+					Version:  "6.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/markers.cfg", 4),
+					Metadata: &setupcfg.Metadata{VersionComparator: "=="},
+				},
+				{
+					Name:     "dataclasses",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/markers.cfg", 5),
+					Metadata: &setupcfg.Metadata{},
+				},
+				{
+					Name:     "pytest",
+					Version:  "7",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/markers.cfg", 9),
+					Metadata: &setupcfg.Metadata{VersionComparator: ">=", DepGroup: "dev"},
+				},
+			},
+		},
+		{
+			Name: "inline and full-line comments are ignored",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/comments.cfg",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "2.31.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/comments.cfg", 3),
+					Metadata: &setupcfg.Metadata{VersionComparator: "=="},
+				},
+				{
+					Name:     "flask",
+					Version:  "2.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/comments.cfg", 6),
+					Metadata: &setupcfg.Metadata{VersionComparator: ">="},
+				},
+				{
+					Name:     "numpy",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/comments.cfg", 7),
+					Metadata: &setupcfg.Metadata{},
+				},
+				{
+					Name:     "pytest",
+					Version:  "7",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/comments.cfg", 11),
+					Metadata: &setupcfg.Metadata{VersionComparator: ">=", DepGroup: "dev"},
+				},
+				{
+					Name:     "black",
+					Version:  "23.1.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/comments.cfg", 12),
+					Metadata: &setupcfg.Metadata{VersionComparator: "==", DepGroup: "dev"},
+				},
+			},
+		},
+		{
+			Name: "dynamic and indirect sources are skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/dynamic.cfg",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "requests",
+					Version:  "2.31.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/dynamic.cfg", 14),
+					Metadata: &setupcfg.Metadata{VersionComparator: "=="},
+				},
+				{
+					Name:     "pytest",
+					Version:  "7",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/dynamic.cfg", 19),
+					Metadata: &setupcfg.Metadata{VersionComparator: ">=", DepGroup: "dev"},
+				},
+			},
+		},
+		{
+			Name: "malformed entries are skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/malformed.cfg",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "valid-pkg",
+					Version:  "1.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/malformed.cfg", 6),
+					Metadata: &setupcfg.Metadata{VersionComparator: "=="},
+				},
+				{
+					Name:     "good",
+					Version:  "2.0.0",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/malformed.cfg", 8),
+					Metadata: &setupcfg.Metadata{VersionComparator: "=="},
+				},
+				{
+					Name:     "ok-pkg",
+					Version:  "1.2",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/malformed.cfg", 13),
+					Metadata: &setupcfg.Metadata{VersionComparator: "~=", DepGroup: "dev"},
+				},
+			},
+		},
+		{
+			Name: "unsupported single comparators emit name-only packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/unsupported-comparators.cfg",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "stevedore",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/unsupported-comparators.cfg", 3),
+					Metadata: &setupcfg.Metadata{},
+				},
+				{
+					Name:     "netaddr",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/unsupported-comparators.cfg", 4),
+					Metadata: &setupcfg.Metadata{},
+				},
+			},
+		},
+		{
+			Name: "no dependency sections yields no packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/empty.cfg",
+			},
+			WantPackages: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			collector := testcollector.New()
+
+			e, err := setupcfg.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("setupcfg.New() error: %v", err)
+			}
+			e.(*setupcfg.Extractor).Stats = collector
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := e.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", e.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/python/setupcfg/testdata/basic.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/basic.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = mypkg
+version = 1.0.0
+
+[options]
+install_requires =
+    requests>=2.0
+    importlib-metadata==6.0.0
+    flask[async]==3.1.1
+    numpy
+
+[options.extras_require]
+dev =
+    pytest>=7
+    black==23.1.0

--- a/extractor/filesystem/language/python/setupcfg/testdata/comments.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/comments.cfg
@@ -1,0 +1,12 @@
+[options]
+install_requires =
+    requests==2.31.0  # pin for security
+    # this is a full-line comment
+    ; semicolon comment too
+    flask>=2.0  # web framework
+    numpy   # scientific computing
+
+[options.extras_require]
+dev =
+    pytest>=7  # testing
+    black==23.1.0

--- a/extractor/filesystem/language/python/setupcfg/testdata/dynamic.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/dynamic.cfg
@@ -1,0 +1,19 @@
+[options]
+install_requires =
+    file:requirements.txt
+    attr:mypkg.__version__
+    ${REQ_VERSION}
+    %(REQ_VERSION)s
+    ./local/pkg
+    ../sibling/pkg
+    /abs/path/pkg
+    git+https://github.com/org/repo.git
+    https://example.com/pkg.tar.gz
+    -e ./editable/pkg
+    -e git+https://github.com/org/repo.git#egg=mypkg
+    requests==2.31.0
+
+[options.extras_require]
+dev =
+    file:dev-requirements.txt
+    pytest>=7

--- a/extractor/filesystem/language/python/setupcfg/testdata/empty.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/empty.cfg
@@ -1,0 +1,4 @@
+[metadata]
+name = mypkg
+version = 1.0.0
+description = no dependency sections here

--- a/extractor/filesystem/language/python/setupcfg/testdata/extras.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/extras.cfg
@@ -1,0 +1,11 @@
+[options]
+install_requires =
+    requests==2.31.0
+
+[options.extras_require]
+dev =
+    pytest>=7.0
+    coverage~=7.4
+docs =
+    sphinx>=5.0
+    myst-parser

--- a/extractor/filesystem/language/python/setupcfg/testdata/malformed.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/malformed.cfg
@@ -1,0 +1,13 @@
+[options]
+install_requires =
+    ==
+    requests==
+    123bad name
+    valid-pkg==1.0.0
+    another_pkg>=
+    good==2.0.0
+
+[options.extras_require]
+dev =
+    ==1.0.0
+    ok-pkg~=1.2

--- a/extractor/filesystem/language/python/setupcfg/testdata/markers.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/markers.cfg
@@ -1,0 +1,9 @@
+[options]
+install_requires =
+    requests>=2.20.0; python_version >= "3.8"
+    importlib-metadata==6.0.0; python_version < "3.10"
+    dataclasses; python_version < "3.7"
+
+[options.extras_require]
+dev =
+    pytest>=7; platform_system == "Linux"

--- a/extractor/filesystem/language/python/setupcfg/testdata/unsupported-comparators.cfg
+++ b/extractor/filesystem/language/python/setupcfg/testdata/unsupported-comparators.cfg
@@ -1,0 +1,4 @@
+[options]
+install_requires =
+    stevedore>1.0
+    netaddr > 0.7

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -78,6 +78,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pyprojecttoml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/setup"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/python/setupcfg"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/uvlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/wheelegg"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/r/renvlock"
@@ -253,6 +254,7 @@ var (
 		// requirements extraction for environments with and without network access.
 		requirements.Name:  {protoCfg(requirements.New)},
 		setup.Name:         {protoCfg(setup.New)},
+		setupcfg.Name:      {protoCfg(setupcfg.New)},
 		pipfilelock.Name:   {protoCfg(pipfilelock.New)},
 		pdmlock.Name:       {protoCfg(pdmlock.New)},
 		poetrylock.Name:    {protoCfg(poetrylock.New)},

--- a/extractor/filesystem/list/list_test.go
+++ b/extractor/filesystem/list/list_test.go
@@ -52,7 +52,7 @@ func TestExtractorsFromName(t *testing.T) {
 		{
 			desc:     "Find_all_extractors_of_a_type",
 			name:     "python",
-			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "python/pyprojecttoml"},
+			wantExts: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/requirements", "python/setup", "python/setupcfg", "python/pyprojecttoml"},
 		},
 		{
 			desc:     "Nonexistent_plugin",

--- a/plugin/list/list_test.go
+++ b/plugin/list/list_test.go
@@ -131,12 +131,12 @@ func TestFromNames(t *testing.T) {
 		{
 			desc:      "Find_all_Plugins_of_a_type",
 			names:     []string{"python", "windows", "cis", "layerdetails"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/pyprojecttoml", "python/requirements", "python/setup", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/pyprojecttoml", "python/requirements", "python/setup", "python/setupcfg", "windows/dismpatch", "cis/generic-linux/etcpasswdpermissions", "baseimage"},
 		},
 		{
 			desc:      "Remove_duplicates",
 			names:     []string{"python", "python"},
-			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/pyprojecttoml", "python/requirements", "python/setup"},
+			wantNames: []string{"python/pdmlock", "python/pipfilelock", "python/poetrylock", "python/pylock", "python/condameta", "python/uvlock", "python/wheelegg", "python/pyprojecttoml", "python/requirements", "python/setup", "python/setupcfg"},
 		},
 		{
 			desc:      "Nonexistent_plugin",


### PR DESCRIPTION
Fixes #2200

Implements the `python/setupcfg` filesystem inventory extractor per the issue spec.

**What it does**
- Matches files whose basename is exactly `setup.cfg` (size-capped, configurable).
- Parses `[options] install_requires` and `[options.extras_require]` (inline + multi-line continuation values), emitting PyPI PURLs with file+line locations.
- Version handling per spec: supported comparators (`===`, `==`, `>=`, `<=`, `~=`) yield a concrete version; other single comparators (`>`, `<`, `!=`, wildcards, compound specs) emit the package identity name-only.
- Skips dynamic/indirect sources per spec: `file:`/`attr:` directives, VCS/URL schemes, env-var/template values (`${VAR}`, `%(VAR)s`), local paths, editable installs. Environment markers are stripped, not evaluated. Extras brackets are dropped from names.
- Multi-line values keep per-entry line numbers (manual INI line parser, since INI libraries collapse continuations). No new third-party dependencies.

**Tests**
- 9 `FileRequired` + 10 `Extract` table-driven subtests with 8 testdata fixtures, covering: basic/extras/markers/comments, dynamic-source skips, malformed entries, unsupported comparators (incl. spaced `pkg > 1.0`), empty file.

Build and `go test ./extractor/...` pass.
