### PR TITLE
Extract Dart dependencies from .dart_tool/package_config.json

### DIFF
--- a/docs/supported_inventory_types.md
+++ b/docs/supported_inventory_types.md
@@ -73,6 +73,7 @@ See the docs on [how to add a new Extractor](/docs/new_extractor.md).
 |            | project.assets.json                               | `dotnet/projectassetsjson`           |
 | C++        | Conan packages                                    | `cpp/conanlock`                      |
 | Dart       | pubspec.lock                                      | `dart/pubspec`                       |
+|            | .dart_tool/package_config.json                    | `dart/packageconfig`                 |
 | Erlang     | mix.lock                                          | `erlang/mixlock`                     |
 | Elixir     | mix.lock                                          | `elixir/mixlock`                     |
 | Gleam      | gleam.toml                                        | `gleam/gleamtoml`                    |

--- a/extractor/filesystem/language/dart/packageconfig/packageconfig.go
+++ b/extractor/filesystem/language/dart/packageconfig/packageconfig.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package packageconfig extracts Dart .dart_tool/package_config.json files.
+package packageconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+)
+
+const (
+	// Name is the unique name of this extractor.
+	Name = "dart/packageconfig"
+
+	// packageConfigFilename is the filename of the Dart package configuration file.
+	packageConfigFilename = "package_config.json"
+
+	// packageConfigDir is the directory the file is expected to live in.
+	packageConfigDir = ".dart_tool"
+)
+
+// packageConfigPackage is a single package entry in package_config.json.
+// The version field is optional and may be missing or empty; rootUri is not
+// followed on disk.
+type packageConfigPackage struct {
+	Name    string `json:"name"`
+	RootURI string `json:"rootUri"`
+	Version string `json:"version"`
+}
+
+// packageConfigFile is the top-level package_config.json structure.
+// See https://dart.dev/go/package-config.
+type packageConfigFile struct {
+	ConfigVersion int                    `json:"configVersion"`
+	Packages      []packageConfigPackage `json:"packages"`
+}
+
+// Extractor extracts Dart .dart_tool/package_config.json files.
+type Extractor struct{}
+
+var _ filesystem.Extractor = Extractor{}
+
+// New returns a new instance of this extractor.
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) { return &Extractor{}, nil }
+
+// Name of the extractor.
+func (e Extractor) Name() string { return Name }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true if the specified file is a .dart_tool/package_config.json file.
+func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
+	path := api.Path()
+	if filepath.Base(path) != packageConfigFilename {
+		return false
+	}
+	// The file must live inside a .dart_tool directory. Match the immediate
+	// parent directory name so that unrelated package_config.json-like files
+	// (e.g. mypkg/package_config.json) are not picked up.
+	parent := filepath.Base(filepath.Dir(path))
+	return parent == packageConfigDir
+}
+
+// Extract extracts Dart packages from .dart_tool/package_config.json files
+// passed through the input. rootUri values are not followed on disk.
+func (e Extractor) Extract(_ context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
+	var parsed packageConfigFile
+	if err := json.NewDecoder(input.Reader).Decode(&parsed); err != nil {
+		return inventory.Inventory{}, fmt.Errorf("could not extract: %w", err)
+	}
+
+	packages := make([]*extractor.Package, 0, len(parsed.Packages))
+	for _, pkg := range parsed.Packages {
+		name := strings.TrimSpace(pkg.Name)
+		if name == "" {
+			continue
+		}
+
+		packages = append(packages, &extractor.Package{
+			Name:     name,
+			Version:  strings.TrimSpace(pkg.Version),
+			PURLType: purl.TypePub,
+			Location: extractor.LocationFromPath(input.Path),
+		})
+	}
+
+	return inventory.Inventory{Packages: packages}, nil
+}

--- a/extractor/filesystem/language/dart/packageconfig/packageconfig_test.go
+++ b/extractor/filesystem/language/dart/packageconfig/packageconfig_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packageconfig_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/packageconfig"
+	"github.com/google/osv-scalibr/extractor/filesystem/simplefileapi"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/testing/extracttest"
+)
+
+func TestExtractor_FileRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputPath string
+		want      bool
+	}{
+		{
+			name:      "empty path",
+			inputPath: "",
+			want:      false,
+		},
+		{
+			name:      "exact package_config.json not in dart_tool",
+			inputPath: "package_config.json",
+			want:      false,
+		},
+		{
+			name:      "dart_tool package_config.json",
+			inputPath: ".dart_tool/package_config.json",
+			want:      true,
+		},
+		{
+			name:      "nested dart_tool package_config.json",
+			inputPath: "path/to/project/.dart_tool/package_config.json",
+			want:      true,
+		},
+		{
+			name:      "package_config.json in unrelated dir",
+			inputPath: "mypkg/package_config.json",
+			want:      false,
+		},
+		{
+			name:      "package_config.json-like file",
+			inputPath: ".dart_tool/package_config.json.bak",
+			want:      false,
+		},
+		{
+			name:      "directory named package_config.json",
+			inputPath: ".dart_tool/package_config.json/file",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := packageconfig.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("packageconfig.New() error: %v", err)
+			}
+			got := e.FileRequired(simplefileapi.New(tt.inputPath, nil))
+			if got != tt.want {
+				t.Errorf("FileRequired(%s) got = %v, want %v", tt.inputPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractor_Extract(t *testing.T) {
+	tests := []extracttest.TestTableEntry{
+		{
+			Name: "malformed json",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/malformed.json",
+			},
+			WantErr: extracttest.ContainsErrStr{Str: "could not extract"},
+		},
+		{
+			Name: "no packages",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/no-packages.json",
+			},
+			WantPackages: []*extractor.Package{},
+		},
+		{
+			Name: "basic config without versions",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/basic.json",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "shelf",
+					Version:  "",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/basic.json"),
+				},
+				{
+					Name:     "shelf_web_socket",
+					Version:  "",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/basic.json"),
+				},
+			},
+		},
+		{
+			Name: "config with versions",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/with-versions.json",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "http",
+					Version:  "1.1.0",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/with-versions.json"),
+				},
+				{
+					Name:     "path",
+					Version:  "1.8.3",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/with-versions.json"),
+				},
+			},
+		},
+		{
+			Name: "missing and empty versions",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/missing-versions.json",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "no_version_pkg",
+					Version:  "",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/missing-versions.json"),
+				},
+				{
+					Name:     "empty_version_pkg",
+					Version:  "",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/missing-versions.json"),
+				},
+				{
+					Name:     "with_version_pkg",
+					Version:  "0.4.1",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/missing-versions.json"),
+				},
+			},
+		},
+		{
+			Name: "missing and blank names are skipped",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/missing-names.json",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					Name:     "good_pkg",
+					Version:  "1.0.0",
+					PURLType: purl.TypePub,
+					Location: extractor.LocationFromPath("testdata/missing-names.json"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			extr, err := packageconfig.New(&cpb.PluginConfig{})
+			if err != nil {
+				t.Fatalf("packageconfig.New() error: %v", err)
+			}
+
+			scanInput := extracttest.GenerateScanInputMock(t, tt.InputConfig)
+			defer extracttest.CloseTestScanInput(t, scanInput)
+
+			got, err := extr.Extract(t.Context(), &scanInput)
+
+			if diff := cmp.Diff(tt.WantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s.Extract(%q) error diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+				return
+			}
+
+			wantInv := inventory.Inventory{Packages: tt.WantPackages}
+			if diff := cmp.Diff(wantInv, got, cmpopts.SortSlices(extracttest.PackageCmpLess)); diff != "" {
+				t.Errorf("%s.Extract(%q) diff (-want +got):\n%s", extr.Name(), tt.InputConfig.Path, diff)
+			}
+		})
+	}
+}

--- a/extractor/filesystem/language/dart/packageconfig/testdata/basic.json
+++ b/extractor/filesystem/language/dart/packageconfig/testdata/basic.json
@@ -1,0 +1,18 @@
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "shelf",
+      "rootUri": "../.dart_tool/pub/incremental/shelf-1.3.2",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "shelf_web_socket",
+      "rootUri": "../.dart_tool/pub/incremental/shelf_web_socket-1.0.2",
+      "packageUri": "lib/",
+      "languageVersion": "2.14"
+    }
+  ],
+  "generator": "pub"
+}

--- a/extractor/filesystem/language/dart/packageconfig/testdata/malformed.json
+++ b/extractor/filesystem/language/dart/packageconfig/testdata/malformed.json
@@ -1,0 +1,1 @@
+{ this is not valid json

--- a/extractor/filesystem/language/dart/packageconfig/testdata/missing-names.json
+++ b/extractor/filesystem/language/dart/packageconfig/testdata/missing-names.json
@@ -1,0 +1,21 @@
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "good_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "version": "1.0.0"
+    },
+    {
+      "rootUri": "../",
+      "packageUri": "lib/"
+    },
+    {
+      "name": "   ",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "version": "2.0.0"
+    }
+  ]
+}

--- a/extractor/filesystem/language/dart/packageconfig/testdata/missing-versions.json
+++ b/extractor/filesystem/language/dart/packageconfig/testdata/missing-versions.json
@@ -1,0 +1,22 @@
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "no_version_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/"
+    },
+    {
+      "name": "empty_version_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "version": ""
+    },
+    {
+      "name": "with_version_pkg",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "version": "0.4.1"
+    }
+  ]
+}

--- a/extractor/filesystem/language/dart/packageconfig/testdata/no-packages.json
+++ b/extractor/filesystem/language/dart/packageconfig/testdata/no-packages.json
@@ -1,0 +1,4 @@
+{
+  "configVersion": 2,
+  "packages": []
+}

--- a/extractor/filesystem/language/dart/packageconfig/testdata/with-versions.json
+++ b/extractor/filesystem/language/dart/packageconfig/testdata/with-versions.json
@@ -1,0 +1,19 @@
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "http",
+      "rootUri": "file:///home/user/.pub-cache/hosted/pub.dev/http-1.1.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.19",
+      "version": "1.1.0"
+    },
+    {
+      "name": "path",
+      "rootUri": "file:///home/user/.pub-cache/hosted/pub.dev/path-1.8.3",
+      "packageUri": "lib/",
+      "languageVersion": "2.12",
+      "version": "1.8.3"
+    }
+  ]
+}

--- a/extractor/filesystem/list/list.go
+++ b/extractor/filesystem/list/list.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/embeddedfs/vmdk"
 	"github.com/google/osv-scalibr/extractor/filesystem/ffa/unknownbinariesextr"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanlock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/packageconfig"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspec"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/csproj"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/depsjson"
@@ -275,7 +276,10 @@ var (
 		gobinary.Name: {protoCfg(gobinary.New)},
 	}
 	// DartSource extractors for Dart.
-	DartSource = InitMap{pubspec.Name: {protoCfg(pubspec.New)}}
+	DartSource = InitMap{
+		pubspec.Name:       {protoCfg(pubspec.New)},
+		packageconfig.Name: {protoCfg(packageconfig.New)},
+	}
 	// ErlangSource extractors for Erlang.
 	ErlangSource = InitMap{mixlock.Name: {protoCfg(mixlock.New)}}
 	// GleamSource extractors for Gleam.


### PR DESCRIPTION
Fixes #2217

Implements a filesystem inventory extractor for Dart/Flutter `.dart_tool/package_config.json` (Pub ecosystem), per the issue spec and the [package config spec](https://dart.dev/go/package-config).

**What it does**
- Plugin name `dart/packageconfig`; only files named `package_config.json` whose immediate parent directory is `.dart_tool` (rejects unrelated look-alike paths).
- Emits `pkg:pub` PURLs for each entry; `version` is optional and may be empty (mirrors pubspec behavior). Entries with empty names are skipped. `rootUri` is parsed but never followed on disk.
- Stdlib `encoding/json` only — no new dependencies.

**Tests**
- 7 `FileRequired` + 6 `Extract` subtests with 6 fixtures: basic, with/without versions, missing/blank names, no packages, malformed JSON, look-alike path rejection.

Build and `go test ./extractor/...` pass.
