### PR TITLE
Prevent npm lifecycle scripts in guided remediation TUI

### DIFF
--- a/guidedremediation/internal/tui/model/state_relock_result.go
+++ b/guidedremediation/internal/tui/model/state_relock_result.go
@@ -548,13 +548,13 @@ func (st stateRelockResult) write(m Model) tea.Msg {
 		return fmt.Errorf("failed removing old node_modules/: %w", err)
 	}
 
-	c := exec.CommandContext(context.Background(), npmPath, "install", "--package-lock-only")
+	c := exec.CommandContext(context.Background(), npmPath, "install", "--package-lock-only", "--ignore-scripts")
 	c.Dir = dir
 
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		if err != nil {
 			// try again with "--legacy-peer-deps"
-			c = exec.CommandContext(context.Background(), npmPath, "install", "--package-lock-only", "--legacy-peer-deps")
+			c = exec.CommandContext(context.Background(), npmPath, "install", "--package-lock-only", "--legacy-peer-deps", "--ignore-scripts")
 			c.Dir = dir
 
 			return tea.ExecProcess(c, func(err error) tea.Msg { return writeMsg{err} })()


### PR DESCRIPTION
NPM's `--ignore-scripts` flag prevents arbitrary scripts defined in package.json from being executed, significantly improving the security of NPM operations (such as `npm install`) on untrusted repositories.

CLI calls already run NPM operations with `--ignore-scripts`. This PR closes the remaining gap by applying the same protection to TUI calls.