### PR TITLE
Scanner digitalocean http

### DIFF
--- a/.github/workflows/lint-plugger.yml
+++ b/.github/workflows/lint-plugger.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Run plugger
         run: make lint-plugger
+
+      - name: Check secure protocols
+        run: make lint-secureprotocol

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ lint-plugger:
 		-interface github.com/google/osv-scalibr/veles.Detector \
 		./...
 
+lint-secureprotocol:
+	go run linter/secureprotocol/main.go ./...
+
 test:
 	CGO_ENABLED=1 go test ./...
 

--- a/linter/secureprotocol/main.go
+++ b/linter/secureprotocol/main.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The secureprotocol command flags hardcoded insecure network endpoints.
+package main
+
+import (
+	"github.com/google/osv-scalibr/linter/secureprotocol/secureprotocol"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+func main() {
+	singlechecker.Main(secureprotocol.Analyzer)
+}

--- a/linter/secureprotocol/secureprotocol/secureprotocol.go
+++ b/linter/secureprotocol/secureprotocol/secureprotocol.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package secureprotocol defines an analyzer that rejects hardcoded insecure
+// Package secureprotocol defines an analyzer that requires HTTPS for hardcoded
 // URLs at credential-bearing HTTP request sinks.
 package secureprotocol
 
@@ -33,7 +33,7 @@ const velesSecretsPrefix = "github.com/google/osv-scalibr/veles/secrets/"
 // Analyzer rejects compile-time-constant non-HTTPS URLs used by Veles HTTP validators.
 var Analyzer = &analysis.Analyzer{
 	Name: "secureprotocol",
-	Doc:  "reject hardcoded insecure URLs used by secret validators",
+	Doc:  "require HTTPS for hardcoded URLs used by secret HTTP validators",
 	Run:  run,
 }
 
@@ -141,6 +141,6 @@ func checkURL(pass *analysis.Pass, expr ast.Expr) {
 		return
 	}
 	if !strings.EqualFold(parsed.Scheme, "https") {
-		pass.Reportf(expr.Pos(), "hardcoded validator endpoint %q uses insecure protocol %q; use HTTPS", rawURL, parsed.Scheme)
+		pass.Reportf(expr.Pos(), "hardcoded HTTP validator endpoint %q uses scheme %q; use HTTPS", rawURL, parsed.Scheme)
 	}
 }

--- a/linter/secureprotocol/secureprotocol/secureprotocol.go
+++ b/linter/secureprotocol/secureprotocol/secureprotocol.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package secureprotocol defines an analyzer that rejects hardcoded insecure
+// URLs at credential-bearing HTTP request sinks.
+package secureprotocol
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/types"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const simplevalidatePackage = "github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+const velesSecretsPrefix = "github.com/google/osv-scalibr/veles/secrets/"
+
+// Analyzer rejects compile-time-constant non-HTTPS URLs used by Veles HTTP validators.
+var Analyzer = &analysis.Analyzer{
+	Name: "secureprotocol",
+	Doc:  "reject hardcoded insecure URLs used by secret validators",
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		if strings.HasSuffix(filepath.Base(pass.Fset.Position(file.Pos()).Filename), "_test.go") {
+			continue
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch expr := node.(type) {
+			case *ast.CompositeLit:
+				checkValidatorLiteral(pass, expr)
+			case *ast.CallExpr:
+				checkHTTPRequest(pass, expr)
+			}
+			return true
+		})
+	}
+	return nil, nil
+}
+
+func checkValidatorLiteral(pass *analysis.Pass, literal *ast.CompositeLit) {
+	if !isSimpleValidator(pass.TypesInfo.TypeOf(literal)) {
+		return
+	}
+	for _, element := range literal.Elts {
+		field, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		name, ok := field.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch name.Name {
+		case "Endpoint":
+			checkURL(pass, field.Value)
+		case "Endpoints":
+			values, ok := field.Value.(*ast.CompositeLit)
+			if !ok {
+				continue
+			}
+			for _, value := range values.Elts {
+				checkURL(pass, value)
+			}
+		}
+	}
+}
+
+func isSimpleValidator(t types.Type) bool {
+	if pointer, ok := t.(*types.Pointer); ok {
+		t = pointer.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Origin().Obj()
+	return obj.Pkg() != nil && obj.Pkg().Path() == simplevalidatePackage && obj.Name() == "Validator"
+}
+
+func checkHTTPRequest(pass *analysis.Pass, call *ast.CallExpr) {
+	if !strings.HasPrefix(pass.Pkg.Path(), velesSecretsPrefix) {
+		return
+	}
+	function := calledFunction(pass, call)
+	if function == nil || function.Pkg() == nil || function.Pkg().Path() != "net/http" {
+		return
+	}
+	var urlArg int
+	switch function.Name() {
+	case "NewRequest":
+		urlArg = 1
+	case "NewRequestWithContext":
+		urlArg = 2
+	default:
+		return
+	}
+	if len(call.Args) > urlArg {
+		checkURL(pass, call.Args[urlArg])
+	}
+}
+
+func calledFunction(pass *analysis.Pass, call *ast.CallExpr) *types.Func {
+	switch function := call.Fun.(type) {
+	case *ast.Ident:
+		fn, _ := pass.TypesInfo.Uses[function].(*types.Func)
+		return fn
+	case *ast.SelectorExpr:
+		fn, _ := pass.TypesInfo.Uses[function.Sel].(*types.Func)
+		return fn
+	default:
+		return nil
+	}
+}
+
+func checkURL(pass *analysis.Pass, expr ast.Expr) {
+	value := pass.TypesInfo.Types[expr].Value
+	if value == nil || value.Kind() != constant.String {
+		return
+	}
+	rawURL := constant.StringVal(value)
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" {
+		return
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		pass.Reportf(expr.Pos(), "hardcoded validator endpoint %q uses insecure protocol %q; use HTTPS", rawURL, parsed.Scheme)
+	}
+}

--- a/linter/secureprotocol/secureprotocol/secureprotocol_test.go
+++ b/linter/secureprotocol/secureprotocol/secureprotocol_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secureprotocol_test
+
+import (
+	"testing"
+
+	"github.com/google/osv-scalibr/linter/secureprotocol/secureprotocol"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), secureprotocol.Analyzer,
+		"github.com/google/osv-scalibr/veles/secrets/secureprotocoltest")
+}

--- a/linter/secureprotocol/secureprotocol/testdata/src/github.com/google/osv-scalibr/veles/secrets/common/simplevalidate/simplevalidate.go
+++ b/linter/secureprotocol/secureprotocol/testdata/src/github.com/google/osv-scalibr/veles/secrets/common/simplevalidate/simplevalidate.go
@@ -1,0 +1,6 @@
+package simplevalidate
+
+type Validator[S any] struct {
+	Endpoint  string
+	Endpoints []string
+}

--- a/linter/secureprotocol/secureprotocol/testdata/src/github.com/google/osv-scalibr/veles/secrets/secureprotocoltest/secureprotocol.go
+++ b/linter/secureprotocol/secureprotocol/testdata/src/github.com/google/osv-scalibr/veles/secrets/secureprotocoltest/secureprotocol.go
@@ -14,18 +14,18 @@ var _ = &simplevalidate.Validator[string]{
 }
 
 var _ = &simplevalidate.Validator[string]{
-	Endpoint: insecureBase + "/account", // want `hardcoded validator endpoint "http://api.example.com/account" uses insecure protocol "http"; use HTTPS`
+	Endpoint: insecureBase + "/account", // want `hardcoded HTTP validator endpoint "http://api.example.com/account" uses scheme "http"; use HTTPS`
 }
 
 var _ = &simplevalidate.Validator[string]{
 	Endpoints: []string{
 		"https://api.example.com/one",
-		"ftp://api.example.com/two", // want `hardcoded validator endpoint "ftp://api.example.com/two" uses insecure protocol "ftp"; use HTTPS`
+		"http://api.example.com/two", // want `hardcoded HTTP validator endpoint "http://api.example.com/two" uses scheme "http"; use HTTPS`
 	},
 }
 
 func requests(ctx context.Context, dynamicURL string) {
-	_, _ = http.NewRequest(http.MethodGet, "http://api.example.com/account", nil) // want `hardcoded validator endpoint "http://api.example.com/account" uses insecure protocol "http"; use HTTPS`
+	_, _ = http.NewRequest(http.MethodGet, "http://api.example.com/account", nil) // want `hardcoded HTTP validator endpoint "http://api.example.com/account" uses scheme "http"; use HTTPS`
 	_, _ = http.NewRequestWithContext(ctx, http.MethodGet, "https://api.example.com/account", nil)
 	_, _ = http.NewRequest(http.MethodGet, dynamicURL, nil)
 }

--- a/linter/secureprotocol/secureprotocol/testdata/src/github.com/google/osv-scalibr/veles/secrets/secureprotocoltest/secureprotocol.go
+++ b/linter/secureprotocol/secureprotocol/testdata/src/github.com/google/osv-scalibr/veles/secrets/secureprotocoltest/secureprotocol.go
@@ -1,0 +1,31 @@
+package secureprotocoltest
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/osv-scalibr/veles/secrets/common/simplevalidate"
+)
+
+const insecureBase = "http://api.example.com"
+
+var _ = &simplevalidate.Validator[string]{
+	Endpoint: "https://api.example.com/account",
+}
+
+var _ = &simplevalidate.Validator[string]{
+	Endpoint: insecureBase + "/account", // want `hardcoded validator endpoint "http://api.example.com/account" uses insecure protocol "http"; use HTTPS`
+}
+
+var _ = &simplevalidate.Validator[string]{
+	Endpoints: []string{
+		"https://api.example.com/one",
+		"ftp://api.example.com/two", // want `hardcoded validator endpoint "ftp://api.example.com/two" uses insecure protocol "ftp"; use HTTPS`
+	},
+}
+
+func requests(ctx context.Context, dynamicURL string) {
+	_, _ = http.NewRequest(http.MethodGet, "http://api.example.com/account", nil) // want `hardcoded validator endpoint "http://api.example.com/account" uses insecure protocol "http"; use HTTPS`
+	_, _ = http.NewRequestWithContext(ctx, http.MethodGet, "https://api.example.com/account", nil)
+	_, _ = http.NewRequest(http.MethodGet, dynamicURL, nil)
+}

--- a/veles/secrets/digitaloceanapikey/validator.go
+++ b/veles/secrets/digitaloceanapikey/validator.go
@@ -29,7 +29,7 @@ import (
 // If 401 Unauthorized, the key is invalid. Other status codes will result in ValidationFailed.
 func NewValidator() *simplevalidate.Validator[DigitaloceanAPIToken] {
 	return &simplevalidate.Validator[DigitaloceanAPIToken]{
-		Endpoint:   "http://api.digitalocean.com/v2/account",
+		Endpoint:   "https://api.digitalocean.com/v2/account",
 		HTTPMethod: http.MethodGet,
 		HTTPHeaders: func(key DigitaloceanAPIToken) map[string]string {
 			return map[string]string{


### PR DESCRIPTION
The DigitalOcean validator currently verifies potential API keys by sending them over plain HTTP. This PR changes the validation request to use HTTPS instead, preventing API keys from being transmitted unencrypted.

Additionally, I proposed a linter rule to catch similar mistakes in the future. Whether the additional rule is worth adding is open for discussion.