### PR TITLE
python/requirements: support requirements.lock files

### DIFF
--- a/extractor/filesystem/language/python/requirements/requirements.go
+++ b/extractor/filesystem/language/python/requirements/requirements.go
@@ -99,7 +99,9 @@ func (e Extractor) Requirements() *plugin.Capabilities {
 // patterns.
 func (e Extractor) FileRequired(api filesystem.FileAPI) bool {
 	path := api.Path()
-	if filepath.Ext(path) != ".txt" || !strings.Contains(filepath.Base(path), "requirements") {
+	base := filepath.Base(path)
+	isRequirementsTxt := filepath.Ext(path) == ".txt" && strings.Contains(base, "requirements")
+	if !isRequirementsTxt && base != "requirements.lock" {
 		return false
 	}
 

--- a/extractor/filesystem/language/python/requirements/requirements_test.go
+++ b/extractor/filesystem/language/python/requirements/requirements_test.go
@@ -58,6 +58,12 @@ func TestFileRequired(t *testing.T) {
 			wantResultMetric: stats.FileRequiredResultOK,
 		},
 		{
+			name:             "requirements.lock",
+			path:             "RsaCtfTool/requirements.lock",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
 			name:         "non requirements.txt txt file",
 			path:         "requirements-asdf/test.txt",
 			wantRequired: false,
@@ -139,6 +145,41 @@ func TestExtract(t *testing.T) {
 		wantPackages     []*extractor.Package
 		wantResultMetric stats.FileExtractedResult
 	}{
+		{
+			name: "requirements_lock",
+			path: "testdata/requirements.lock",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "aiohttp",
+					Version:  "3.13.2",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/requirements.lock", 1),
+					Metadata: &requirements.Metadata{Requirement: "aiohttp==3.13.2"},
+				},
+				{
+					Name:     "Jinja2",
+					Version:  "3.1.6",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/requirements.lock", 2),
+					Metadata: &requirements.Metadata{Requirement: "Jinja2==3.1.6"},
+				},
+				{
+					Name:     "pydantic_core",
+					Version:  "2.41.5",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/requirements.lock", 3),
+					Metadata: &requirements.Metadata{Requirement: "pydantic_core==2.41.5"},
+				},
+				{
+					Name:     "xformers",
+					Version:  "0.0.32.post1",
+					PURLType: purl.TypePyPi,
+					Location: extractor.LocationFromPathAndLine("testdata/requirements.lock", 4),
+					Metadata: &requirements.Metadata{Requirement: "xformers==0.0.32.post1"},
+				},
+			},
+			wantResultMetric: stats.FileExtractedResultSuccess,
+		},
 		{
 			name: "multiline_and_comments",
 			path: "testdata/multiline_and_comments.txt",

--- a/extractor/filesystem/language/python/requirements/testdata/requirements.lock
+++ b/extractor/filesystem/language/python/requirements/testdata/requirements.lock
@@ -1,0 +1,4 @@
+aiohttp==3.13.2
+Jinja2==3.1.6
+pydantic_core==2.41.5
+xformers==0.0.32.post1


### PR DESCRIPTION
Extend the Python requirements extractor to recognize pip-style requirements.lock files in addition to requirements*.txt.

Add FileRequired and Extract test coverage with pinned PyPI deps.