### PR TITLE
Prevent PyPI local registry cache path traversal

### DIFF
--- a/clients/datasource/pypi_registry.go
+++ b/clients/datasource/pypi_registry.go
@@ -111,9 +111,11 @@ func (p *PyPIRegistryAPIClient) get(ctx context.Context, url string, queryIndex 
 	urlPath := urlToPath(url)
 	if urlPath != "" && p.localRegistry != "" {
 		file = filepath.Join(p.localRegistry, urlPath)
-		if content, err := os.ReadFile(file); err == nil {
-			// We can still fetch the file from upstream if error is not nil.
-			return content, nil
+		if root, err := os.OpenRoot(p.localRegistry); err == nil {
+			defer root.Close()
+			if content, err := root.ReadFile(urlPath); err == nil {
+				return content, nil
+			}
 		}
 	}
 

--- a/clients/datasource/pypi_registry_test.go
+++ b/clients/datasource/pypi_registry_test.go
@@ -15,6 +15,7 @@
 package datasource_test
 
 import (
+	"bytes"
 	"net/http"
 	"net/url"
 	"os"
@@ -217,5 +218,40 @@ func TestPyPILocalRegistry(t *testing.T) {
 	}
 	if string(content) != jsonResp {
 		t.Errorf("unexpected file content: got %s, want %s", string(content), jsonResp)
+	}
+}
+
+func TestPyPILocalRegistryPathTraversal(t *testing.T) {
+	tempDir := t.TempDir()
+
+	secretPath := filepath.Join(tempDir, "secret")
+	secretContent := []byte("this is secret")
+
+	if err := os.WriteFile(secretPath, secretContent, 0600); err != nil {
+		t.Fatalf("failed to create secret file: %v", err)
+	}
+
+	srv := clienttest.NewMockHTTPServer(t)
+
+	client, err := datasource.NewPyPIRegistryAPIClient(
+		srv.URL,
+		tempDir,
+		&http.Client{},
+	)
+	if err != nil {
+		t.Fatalf("failed to create PyPI client: %v", err)
+	}
+
+	traversalURL := srv.URL + "/../../secret"
+
+	got, err := client.GetFile(t.Context(), traversalURL)
+
+	// The request should NOT be satisfied from the local filesystem.
+	// With the vulnerable implementation, got == secretContent.
+	if err == nil && bytes.Equal(got, secretContent) {
+		t.Fatalf(
+			"path traversal succeeded: read %q outside the local registry",
+			secretPath,
+		)
 	}
 }


### PR DESCRIPTION
Use os.Root to constrain cached file reads to the configured PyPI registry directory and add a regression test for traversal.