### PR TITLE
fix(veles): accept space-separated ITINs

### DIFF
--- a/veles/sensitiveinformation/itin/detector.go
+++ b/veles/sensitiveinformation/itin/detector.go
@@ -82,7 +82,7 @@ func NewDetector() veles.Detector {
 // Format requirements can found on Wikipedia:
 // https://en.wikipedia.org/wiki/Individual_Taxpayer_Identification_Number
 func validItin(s string) bool {
-	normalized := strings.ReplaceAll(s, "-", "")
+	normalized := strings.NewReplacer("-", "", " ", "").Replace(s)
 	secondSection := normalized[3:5]
 
 	return secondSection != "89" &&

--- a/veles/sensitiveinformation/itin/detector_test.go
+++ b/veles/sensitiveinformation/itin/detector_test.go
@@ -63,6 +63,13 @@ func TestDetect_truePositives(t *testing.T) {
 			},
 		},
 		{
+			name: "match_with_spaces",
+			in:   []byte("900 70 1234"),
+			want: []veles.Secret{
+				itinFinding([]byte("900 70 1234")),
+			},
+		},
+		{
 			name: "keyword_before",
 			in:   []byte("itin: 900-50-1234"),
 			want: []veles.Secret{
@@ -385,8 +392,16 @@ func TestDetect_trueNegatives(t *testing.T) {
 			in:   []byte("900 70-1234"),
 		},
 		{
-			name: "spaced",
-			in:   []byte("900 70 1234"),
+			name: "spaced_fourth_and_fifth_digits_between_ranges",
+			in:   []byte("900 66 1234"),
+		},
+		{
+			name: "spaced_fourth_and_fifth_digits_excluded_89",
+			in:   []byte("900 89 1234"),
+		},
+		{
+			name: "spaced_fourth_and_fifth_digits_excluded_93",
+			in:   []byte("900 93 1234"),
 		},
 		{
 			name: "within_longer_string",


### PR DESCRIPTION
## Problem

`itinRe` matches three formats:

```go
var itinRe = regexp.MustCompile(`\b(9\d{8}|9\d{2}-\d{2}-\d{4}|9\d{2} \d{2} \d{4})\b`)
```

but `validItin` normalized only hyphens before slicing out the group digits:

```go
normalized := strings.ReplaceAll(s, "-", "")
secondSection := normalized[3:5]
```

For the space-separated form the slice lands on a space, so the group never
falls inside a valid range and the value is always rejected. The same ITIN,
written three ways:

```
input="912-70-1234"  normalized="912701234"    secondSection="70"  valid=true
input="912701234"    normalized="912701234"    secondSection="70"  valid=true
input="912 70 1234"  normalized="912 70 1234"  secondSection=" 7"  valid=false
```

So the third regex alternative was unreachable, and every space-separated ITIN
was a false negative.

## Why this is a bug and not intended behaviour

- The regex has listed the spaced form since the detector's first commit
  (`aea1d484`). If spaced ITINs were meant to be rejected, that alternative
  would just be dead weight in the pattern.
- The sibling SSN detector has the identical three-format regex and normalizes
  both separators, and its test suite covers spaced SSNs as true positives
  while still rejecting spaced numbers with an invalid area or group. ITIN is
  the odd one out.
- The original `validItin` had a `len(normalized) != 9` guard, which is what
  actually rejected the spaced form. That guard was removed in `d46b3f22` when
  the leading-9 check moved into the regex; the missing space handling was left
  behind as the only remaining reason spaced ITINs failed.

## Fix

Normalize spaces as well as hyphens, matching the SSN detector exactly:

```go
normalized := strings.NewReplacer("-", "", " ", "").Replace(s)
```

The group-range rules (50-65, 70-88, 90-92, 94-99) are unchanged, and now apply
to all three formats rather than two.

## Tests

`TestDetect_trueNegatives` had a `spaced` case asserting `900 70 1234` produces
no finding. That case documented the defect rather than a policy, so it moves
to `TestDetect_truePositives`, and three spaced negatives are added so the
group-range rules stay exercised on that format:

- `spaced_fourth_and_fifth_digits_between_ranges` - `900 66 1234`
- `spaced_fourth_and_fifth_digits_excluded_89` - `900 89 1234`
- `spaced_fourth_and_fifth_digits_excluded_93` - `900 93 1234` (ATIN range)

If you would rather the detector not report spaced ITINs at all, the consistent
alternative is to drop the `9\d{2} \d{2} \d{4}` alternative from `itinRe`
instead. Happy to switch to that - the current state is the one combination
that cannot be right, since the pattern advertises a format the validator
always discards.

## Verification

- `go test ./veles/...` - all 75 packages pass
- `go vet ./veles/...` - clean
- `gofmt` - clean on both changed files
- `golangci-lint run ./veles/sensitiveinformation/...` - the only findings are
  `gofmt` on a Windows CRLF checkout, and they fire identically on files this PR
  does not touch (`ssn/detector.go`, `sensitiveinformation.go`). The committed
  blobs are LF and gofmt-clean.
- Reverting only `detector.go` and keeping the tests makes
  `TestDetect_truePositives/match_with_spaces` fail (`nil` instead of a
  finding), confirming the test guards the regression.

Environment: Windows 11, go1.26.5.

## AI assistance

AI assistance (Claude Code) was used to locate this defect and draft the patch
and tests. I reviewed every changed line, ran the commands above locally, and
can defend the change end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
