### PR TITLE
extractor/os/apk: add MinimOS ecosystem mapping

### DIFF
--- a/extractor/filesystem/os/ecosystem/ecosystem.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem.go
@@ -44,12 +44,18 @@ func MakeEcosystem(metadata any) osvecosystem.Parsed {
 	case *apkmeta.Metadata:
 		// Check for specific distros that use APK but map to different ecosystems.
 		// These checks must come before the version == "" guard because rolling
-		// distros (Wolfi, Chainguard) may not set VERSION_ID in os-release.
+		// distros (Wolfi, Chainguard, MinimOS) may not set VERSION_ID in os-release.
 		if m.OSID == "wolfi" {
 			return osvecosystem.FromEcosystem(osvconstants.EcosystemWolfi)
 		}
 		if m.OSID == "chainguard" {
 			return osvecosystem.FromEcosystem(osvconstants.EcosystemChainguard)
+		}
+		// MinimOS advisories are published under a single unversioned ecosystem on
+		// OSV.dev, so the VERSION_ID (a rolling build date, e.g. 20241031) is not
+		// used as a suffix.
+		if m.OSID == "minimos" {
+			return osvecosystem.FromEcosystem(osvconstants.EcosystemMinimOS)
 		}
 		version := m.ToDistro()
 		if version == "" {

--- a/extractor/filesystem/os/ecosystem/ecosystem_test.go
+++ b/extractor/filesystem/os/ecosystem/ecosystem_test.go
@@ -105,6 +105,21 @@ func TestMakeEcosystemAPK(t *testing.T) {
 			},
 			want: "Chainguard",
 		},
+		{
+			desc: "MinimOS",
+			metadata: &apkmeta.Metadata{
+				OSID: "minimos",
+			},
+			want: "MinimOS",
+		},
+		{
+			desc: "MinimOS_version_not_used_as_suffix",
+			metadata: &apkmeta.Metadata{
+				OSID:        "minimos",
+				OSVersionID: "20241031",
+			},
+			want: "MinimOS",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
Fixes #2202 (PRP: Accepted)

## Problem

MinimOS is an APK-based distroless distribution that publishes its own advisory feed on OSV.dev under the `MinimOS` ecosystem (`MINI-*` IDs). The `os/apk` extractor already parses MinimOS package databases correctly and already captures `ID=minimos` from `/etc/os-release` into `apkmeta.Metadata.OSID`, but `MakeEcosystem` has no branch for it, so MinimOS packages fall through to `EcosystemAlpine`.

The result is that every MinimOS container scan reports OS packages under the Alpine ecosystem and matches zero `MINI-*` advisories.

## Fix

One `if`-branch in `extractor/filesystem/os/ecosystem/ecosystem.go`, following the existing Wolfi/Chainguard pattern. No new extractor, no new parsing, no new dependencies.

```go
// MinimOS advisories are published under a single unversioned ecosystem on
// OSV.dev, so the VERSION_ID (a rolling build date, e.g. 20241031) is not
// used as a suffix.
if m.OSID == "minimos" {
    return osvecosystem.FromEcosystem(osvconstants.EcosystemMinimOS)
}
```

Two details worth calling out:

* Placement before the `version == ""` guard, same as Wolfi and Chainguard. MinimOS does set `VERSION_ID`, but it is a rolling build-date snapshot and can be absent in stripped images. Checking first also avoids the spurious `VERSION_ID not set in os-release` error log from `ToDistro()`.
* No suffix. OSV.dev tracks MinimOS advisories under the plain `MinimOS` ecosystem rather than `MinimOS:<version>`, so `VERSION_ID` is deliberately not used.

## Verification

`ID=minimos` is what MinimOS actually ships. Copied out of `reg.mini.dev/curl:latest`:

```
ID=minimos
NAME="MinimOS"
PRETTY_NAME="MinimOS"
VERSION_ID="20241031"
HOME_URL="https://minimus.io"
BUG_REPORT_URL="https://support.minimus.io"
```

That image keeps its APK database at `usr/lib/apk/db/installed`, which `os/apk` already accepts. It is also the same ID Grype maps to its `MinimOS` distro type in `grype/distro/type.go`.

Ecosystem name and PURL form, from the OSV.dev API:

```console
$ curl -s https://api.osv.dev/v1/vulns/MINI-26wc-ph53-p7mq | jq '.affected[0].package'
{
  "name": "curl",
  "ecosystem": "MinimOS",
  "purl": "pkg:apk/minimos/curl"
}

$ curl -s https://api.osv.dev/v1/vulns/MINI-4x56-859r-prjq | jq '.affected[0].package'
{
  "name": "openssl",
  "ecosystem": "MinimOS",
  "purl": "pkg:apk/minimos/openssl"
}
```

Both are plain `MinimOS` with no version suffix, and the PURL namespace is `minimos`, which the extractor already emits via `Metadata.ToNamespace()` (it returns `OSID`), so PURL output needs no change.

So `pkg:apk/minimos/curl@8.5.0-r0` and `pkg:apk/minimos/openssl@3.3.0-r0` go from the `Alpine` ecosystem to `MinimOS`, where they match `MINI-26wc-ph53-p7mq` and `MINI-4x56-859r-prjq`.

## No other changes needed

* `osvconstants.EcosystemMinimOS` is already an accepted ecosystem in `inventory/osvecosystem/parsed.go`.
* `semantic/parse.go` already has `case "MinimOS": return ParseAlpineVersion(str)`, so version comparison works as is.
* `docs/supported_inventory_types.md` lists APK distro variants generically. Wolfi, Chainguard, Alpaquita and CleanStart are not listed individually either, so I did not add an entry. Happy to add one if you would rather have it.

## Testing

Two cases added to `TestMakeEcosystemAPK`, mirroring the existing `Wolfi` and `Chainguard` cases:

* `MinimOS`: `OSID: "minimos"` with no `OSVersionID`, expects `MinimOS`.
* `MinimOS_version_not_used_as_suffix`: `OSID: "minimos"`, `OSVersionID: "20241031"`, expects `MinimOS`. This one guards against a version suffix creeping in later.

```console
$ go test ./extractor/filesystem/os/... ./inventory/osvecosystem/... ./semantic/...
ok  	github.com/google/osv-scalibr/extractor/filesystem/os/apk
ok  	github.com/google/osv-scalibr/extractor/filesystem/os/ecosystem
ok  	github.com/google/osv-scalibr/inventory/osvecosystem
ok  	github.com/google/osv-scalibr/semantic
(all other packages pass too)

$ go build ./... && go vet ./extractor/filesystem/os/ecosystem/...
$ gofmt -l extractor/filesystem/os/ecosystem/
```

## One thing you should know before merging

Minimus announced it is ceasing operations and turning off `reg.mini.dev` on 2026-10-22, with its technology going to Echo. I still think this is worth merging: the 64k `MINI-*` advisories stay on OSV.dev, and MinimOS images pulled before that date keep running in production and keep needing to be scanned correctly. But you should weigh that rather than hear it from me after the fact.

It does affect an E2E test, though. I have one ready for osv-scanner in the same shape as the openSUSE Leap one (google/osv-scanner#2937), and it deliberately does not pull from `reg.mini.dev`: it takes the alpine base already pinned in that repo and copies a real MinimOS `os-release` over it, the same trick `test-alpine.Dockerfile` uses. Real MinimOS images are hardened to zero known advisories, so scanning one would assert nothing anyway. The recorded run detects 58 `MINI-*` advisories across busybox, openssl and zlib, with `"ecosystem": "MinimOS"` in the JSON output. I will open it once this lands, or sooner if you prefer to review them together.
