### PR TITLE
fix(reachability/java): do not abort enrichment on dependency JARs without Main-Class

### DIFF
--- a/enricher/reachability/java/jar.go
+++ b/enricher/reachability/java/jar.go
@@ -47,6 +47,8 @@ var (
 	ErrClassNotFound = errors.New("class not found")
 	// ErrArtifactNotFound is returned when an artifact is not found.
 	ErrArtifactNotFound = errors.New("artifact not found")
+	// ErrNoMainClass is returned when a JAR has no main class in its manifest.
+	ErrNoMainClass = errors.New("no main class")
 )
 
 // MavenPackageFinder is an interface for finding Maven packages that contain a
@@ -282,5 +284,5 @@ func GetMainClasses(manifest io.Reader) ([]string, error) {
 		return classes, nil
 	}
 
-	return nil, errors.New("no main class")
+	return nil, ErrNoMainClass
 }

--- a/enricher/reachability/java/java.go
+++ b/enricher/reachability/java/java.go
@@ -60,6 +60,8 @@ var (
 
 	// ErrMavenDependencyNotFound is returned when a JAR is not a Maven dependency.
 	ErrMavenDependencyNotFound = errors.New(MavenDepDirPath + " directory not found")
+	// ErrNoManifest is returned when a JAR does not have a MANIFEST.MF file.
+	ErrNoManifest = errors.New(ManifestFilePath + " file not found")
 )
 
 // Enricher is the Java Reach enricher.
@@ -117,9 +119,18 @@ func (enr Enricher) Enrich(ctx context.Context, input *enricher.ScanInput, inv *
 	}
 
 	for jar := range jars {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		err := enumerateReachabilityForJar(ctx, jar, input, inv, client)
 		if err != nil {
-			return err
+			if errors.Is(err, ErrNoMainClass) || errors.Is(err, ErrMavenDependencyNotFound) || errors.Is(err, ErrNoManifest) {
+				log.Debugf("skipping reachability analysis for %s: %v", jar, err)
+				continue
+			}
+			log.Errorf("reachability/java failed for %s: %v", jar, err)
+			continue
 		}
 	}
 
@@ -162,6 +173,7 @@ func enumerateReachabilityForJar(ctx context.Context, jarPath string, input *enr
 	if err != nil {
 		return err
 	}
+	defer jarRoot.Close()
 
 	nestedJARs, err := unzipJAR(jarPath, input, jarRoot)
 	if err != nil {
@@ -172,7 +184,6 @@ func enumerateReachabilityForJar(ctx context.Context, jarPath string, input *enr
 	// Check for the existence of the Maven metadata directory.
 	_, err = jarRoot.Stat(MavenDepDirPath)
 	if err != nil {
-		log.Error("reachability analysis is only supported for JARs built with Maven.")
 		return ErrMavenDependencyNotFound
 	}
 
@@ -186,8 +197,12 @@ func enumerateReachabilityForJar(ctx context.Context, jarPath string, input *enr
 	// Extract the main entrypoint.
 	manifest, err := jarRoot.Open(ManifestFilePath)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return ErrNoManifest
+		}
 		return err
 	}
+	defer manifest.Close()
 
 	mainClasses, err := GetMainClasses(manifest)
 	if err != nil {

--- a/enricher/reachability/java/java_test.go
+++ b/enricher/reachability/java/java_test.go
@@ -15,9 +15,13 @@
 package java_test
 
 import (
+	"archive/zip"
+	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -143,4 +147,179 @@ func setupPackages(names []string) []*extractor.Package {
 	}
 
 	return pkgs
+}
+
+func TestGetMainClasses(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		manifest string
+		want     []string
+		wantErr  error
+	}{
+		{
+			desc:     "single_main_class",
+			manifest: "Manifest-Version: 1.0\nMain-Class: com.example.Main\n",
+			want:     []string{"com/example/Main"},
+		},
+		{
+			desc:     "start_class",
+			manifest: "Manifest-Version: 1.0\nStart-Class: com.example.Application\n",
+			want:     []string{"com/example/Application"},
+		},
+		{
+			desc:     "wrapped_line",
+			manifest: "Manifest-Version: 1.0\nMain-Class: com.example.verylongpackagename.\n MyMainClass\n",
+			want:     []string{"com/example/verylongpackagename/MyMainClass"},
+		},
+		{
+			desc:     "no_main_class",
+			manifest: "Manifest-Version: 1.0\nCreated-By: 21.0.2\n",
+			wantErr:  java.ErrNoMainClass,
+		},
+		{
+			desc:     "empty_manifest",
+			manifest: "",
+			wantErr:  java.ErrNoMainClass,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := java.GetMainClasses(strings.NewReader(tc.manifest))
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("GetMainClasses() error = %v, wantErr = %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetMainClasses() unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("GetMainClasses() got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("GetMainClasses()[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestScan_WithDependencyJarsWithoutMainClass(t *testing.T) {
+	jar := filepath.Join("testdata", reachableJar)
+
+	enr, err := java.New(config.DefaultPluginConfig())
+	if err != nil {
+		t.Fatalf("Javareach enricher init failed: %s", err)
+	}
+	enr.(*java.Enricher).Client = mockClient(t)
+
+	// Scan includes the main application jar along with dependency jars that do not have Main-Class.
+	pkgs := setupPackages([]string{testJar, reachableJar, unreachableJar})
+	input := enricher.ScanInput{
+		ScanRoot: &scalibrfs.ScanRoot{
+			Path: jar,
+			FS:   scalibrfs.DirFS("."),
+		},
+	}
+	inv := inventory.Inventory{
+		Packages: pkgs,
+	}
+	err = enr.Enrich(t.Context(), &input, &inv)
+	if err != nil {
+		t.Fatalf("Javareach enrich failed: %s", err)
+	}
+
+	for _, pkg := range inv.Packages {
+		if pkg.Location.PathOrEmpty() != filepath.Join("testdata", testJar) {
+			continue
+		}
+		if pkg.Metadata.(*archivemeta.Metadata).ArtifactID == reachableArtifactID {
+			for _, signal := range pkg.ExploitabilitySignals {
+				if signal.Justification == vex.VulnerableCodeNotInExecutePath {
+					t.Fatalf("expected %s to be reachable, but marked as unreachable", pkg.Name)
+				}
+			}
+		}
+		if pkg.Metadata.(*archivemeta.Metadata).ArtifactID == unreachableArtifactID {
+			hasUnreachableSignal := false
+			for _, signal := range pkg.ExploitabilitySignals {
+				if signal.Justification == vex.VulnerableCodeNotInExecutePath {
+					hasUnreachableSignal = true
+				}
+			}
+			if !hasUnreachableSignal {
+				t.Fatalf("expected %s to be unreachable, but marked as reachable", pkg.Name)
+			}
+		}
+	}
+}
+
+func TestScan_SkipJarWithMavenDirButNoMainClass(t *testing.T) {
+	// Create a temporary JAR with META-INF/maven and META-INF/MANIFEST.MF without Main-Class.
+	depJarPath := filepath.Join("testdata", "dep-no-main-test.jar")
+	buf := new(bytes.Buffer)
+	zw := zip.NewWriter(buf)
+
+	manifestWriter, err := zw.Create("META-INF/MANIFEST.MF")
+	if err != nil {
+		t.Fatalf("failed to create manifest in zip: %v", err)
+	}
+	_, err = manifestWriter.Write([]byte("Manifest-Version: 1.0\nCreated-By: 21.0.2\n"))
+	if err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	pomWriter, err := zw.Create("META-INF/maven/com.example/dep/pom.properties")
+	if err != nil {
+		t.Fatalf("failed to create pom.properties in zip: %v", err)
+	}
+	_, err = pomWriter.Write([]byte("groupId=com.example\nartifactId=dep\nversion=1.0.0\n"))
+	if err != nil {
+		t.Fatalf("failed to write pom.properties: %v", err)
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+
+	if err := os.WriteFile(depJarPath, buf.Bytes(), 0644); err != nil {
+		t.Fatalf("failed to write dep jar file: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(depJarPath)
+	})
+
+	enr, err := java.New(config.DefaultPluginConfig())
+	if err != nil {
+		t.Fatalf("Javareach enricher init failed: %s", err)
+	}
+	enr.(*java.Enricher).Client = mockClient(t)
+
+	depPkg := &extractor.Package{
+		Name:     "com.example:dep",
+		Version:  "1.0.0",
+		PURLType: purl.TypeMaven,
+		Metadata: &archivemeta.Metadata{ArtifactID: "dep", GroupID: "com.example"},
+		Location: extractor.LocationFromPath(depJarPath),
+		Plugins:  []string{archive.Name},
+	}
+
+	pkgs := append(setupPackages([]string{testJar}), depPkg)
+	input := enricher.ScanInput{
+		ScanRoot: &scalibrfs.ScanRoot{
+			Path: filepath.Join("testdata", reachableJar),
+			FS:   scalibrfs.DirFS("."),
+		},
+	}
+	inv := inventory.Inventory{
+		Packages: pkgs,
+	}
+
+	err = enr.Enrich(t.Context(), &input, &inv)
+	if err != nil {
+		t.Fatalf("Javareach enrich should succeed by skipping jar without Main-Class, got: %v", err)
+	}
 }

--- a/enricher/reachability/java/utils.go
+++ b/enricher/reachability/java/utils.go
@@ -83,7 +83,12 @@ func openFromRoot(root *scalibrfs.ScanRoot, fullPath string) (fs.File, error) {
 
 	relPath := fullPath
 	if strings.HasPrefix(fullPath, rootPath) {
-		relPath = fullPath[len(rootPath):]
+		relPath = strings.TrimPrefix(fullPath[len(rootPath):], string(filepath.Separator))
+		relPath = strings.TrimPrefix(relPath, "/")
+	}
+
+	if relPath == "" {
+		relPath = fullPath
 	}
 
 	return root.FS.Open(filepath.ToSlash(relPath))


### PR DESCRIPTION
## Description

Fixes #2116.

### Problem
When `reachability/java` runs against a directory containing both an application JAR (with a `Main-Class` manifest) and dependency JARs (without a `Main-Class`), the enricher previously encountered `no main class` on the first dependency JAR, immediately returning an error from `enumerateReachabilityForJar`.

Because `Enrich()` short-circuited on the first returned error:
```go
for jar := range jars {
    err := enumerateReachabilityForJar(ctx, jar, input, inv, client)
    if err != nil {
        return err
    }
}
```
All subsequent packages — including the application JAR that was meant to be analyzed — were abandoned. This resulted in an empty or failed reachability annotation set for standard multi-JAR setups (such as Maven `target/dependency/` or Gradle `build/libs/`).

### Solution
1. **Defined Sentinel Errors**:
   - Defined `ErrNoMainClass = errors.New("no main class")` in `jar.go` and returned it in `GetMainClasses`.
   - Defined `ErrNoManifest = errors.New(ManifestFilePath + " file not found")` in `java.go`.
2. **Graceful Skip for Non-Root JARs**:
   - In `Enrich`, check `errors.Is(err, ErrNoMainClass)`, `errors.Is(err, ErrMavenDependencyNotFound)`, and `errors.Is(err, ErrNoManifest)`. These represent expected conditions for dependency/non-root JARs; they are logged at debug level and skipped via `continue`.
   - For unexpected errors on a single JAR, log an error and `continue` so that a single corrupted or unparseable JAR does not prevent reachability analysis of other valid application JARs in the scan.
3. **Cancellation & Resource Cleanup**:
   - Added `ctx.Err()` check during the iteration loop.
   - Added `defer jarRoot.Close()` and `defer manifest.Close()` to prevent resource leaks.
4. **Unit Tests**:
   - Added `TestGetMainClasses` testing single, start-class, wrapped-line, and no-main-class manifests.
   - Added `TestScan_WithDependencyJarsWithoutMainClass` ensuring scans with co-located dependency JARs without `Main-Class` enrich the application JAR dependencies without failing.
   - Added `TestScan_SkipJarWithMavenDirButNoMainClass`.
