### PR TITLE
fix(dotnet/common): support <Version> child element and PackageVersion in MSBuild XML

### DIFF
--- a/extractor/filesystem/language/dotnet/common/common.go
+++ b/extractor/filesystem/language/dotnet/common/common.go
@@ -18,21 +18,33 @@ package common
 import (
 	"encoding/xml"
 	"io"
+	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/purl"
 )
 
-// PackageReference represents a single <PackageReference> element in an MSBuild XML file.
+// PackageReference represents a single <PackageReference> or <PackageVersion> element in an MSBuild XML file.
 type PackageReference struct {
-	Include string `xml:"Include,attr"`
-	Version string `xml:"Version,attr"`
+	Include        string `xml:"Include,attr"`
+	VersionAttr    string `xml:"Version,attr"`
+	VersionElement string `xml:"Version"`
+}
+
+// Version returns the package version, checking the Version attribute first
+// and falling back to the <Version> child element.
+func (p PackageReference) Version() string {
+	if v := strings.TrimSpace(p.VersionAttr); v != "" {
+		return v
+	}
+	return strings.TrimSpace(p.VersionElement)
 }
 
 // ItemGroup represents an <ItemGroup> element containing package references.
 type ItemGroup struct {
 	PackageReferences []PackageReference `xml:"PackageReference"`
+	PackageVersions   []PackageReference `xml:"PackageVersion"`
 }
 
 // Project represents the top-level <Project> element in an MSBuild XML file.
@@ -42,7 +54,7 @@ type Project struct {
 }
 
 // ExtractPackagesFromMSBuildXML decodes an MSBuild-style XML document from r and
-// returns the NuGet packages declared as <PackageReference> elements.
+// returns the NuGet packages declared as <PackageReference> or <PackageVersion> elements.
 // The filePath is recorded in each package's Locations field.
 func ExtractPackagesFromMSBuildXML(r io.Reader, filePath string) ([]*extractor.Package, error) {
 	var proj Project
@@ -54,15 +66,18 @@ func ExtractPackagesFromMSBuildXML(r io.Reader, filePath string) ([]*extractor.P
 
 	var result []*extractor.Package
 	for _, ig := range proj.ItemGroups {
-		for _, pkg := range ig.PackageReferences {
-			if pkg.Include == "" || pkg.Version == "" {
+		pkgs := append([]PackageReference{}, ig.PackageReferences...)
+		pkgs = append(pkgs, ig.PackageVersions...)
+		for _, pkg := range pkgs {
+			version := pkg.Version()
+			if pkg.Include == "" || version == "" {
 				log.Warnf("Skipping package with missing name or version: %+v", pkg)
 				continue
 			}
 
 			result = append(result, &extractor.Package{
 				Name:     pkg.Include,
-				Version:  pkg.Version,
+				Version:  version,
 				PURLType: purl.TypeNuget,
 				Location: extractor.LocationFromPath(filePath),
 			})

--- a/extractor/filesystem/language/dotnet/common/common_test.go
+++ b/extractor/filesystem/language/dotnet/common/common_test.go
@@ -204,6 +204,102 @@ func TestExtractPackagesFromMSBuildXML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "package reference with child version element",
+			xml: `<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.1</Version>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>`,
+			filePath: "project.csproj",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "Newtonsoft.Json",
+					Version:  "13.0.1",
+					PURLType: purl.TypeNuget,
+					Location: extractor.LocationFromPath("project.csproj"),
+				},
+			},
+		},
+		{
+			name: "package reference with child version element containing whitespace",
+			xml: `<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>
+        13.0.1
+      </Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>`,
+			filePath: "project.csproj",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "Newtonsoft.Json",
+					Version:  "13.0.1",
+					PURLType: purl.TypeNuget,
+					Location: extractor.LocationFromPath("project.csproj"),
+				},
+			},
+		},
+		{
+			name: "package reference with both version attribute and child element prefers attribute",
+			xml: `<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2">
+      <Version>13.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>`,
+			filePath: "project.csproj",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "Newtonsoft.Json",
+					Version:  "13.0.2",
+					PURLType: purl.TypeNuget,
+					Location: extractor.LocationFromPath("project.csproj"),
+				},
+			},
+		},
+		{
+			name: "package version element with version attribute",
+			xml: `<Project>
+  <ItemGroup>
+    <PackageVersion Include="LiteDB" Version="5.0.12" />
+  </ItemGroup>
+</Project>`,
+			filePath: "Directory.Packages.props",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "LiteDB",
+					Version:  "5.0.12",
+					PURLType: purl.TypeNuget,
+					Location: extractor.LocationFromPath("Directory.Packages.props"),
+				},
+			},
+		},
+		{
+			name: "package version element with child version element",
+			xml: `<Project>
+  <ItemGroup>
+    <PackageVersion Include="LiteDB">
+      <Version>5.0.12</Version>
+    </PackageVersion>
+  </ItemGroup>
+</Project>`,
+			filePath: "Directory.Packages.props",
+			wantPackages: []*extractor.Package{
+				{
+					Name:     "LiteDB",
+					Version:  "5.0.12",
+					PURLType: purl.TypeNuget,
+					Location: extractor.LocationFromPath("Directory.Packages.props"),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Fixes #2288.

### Problem
In MSBuild project files (`.csproj`, `.vbproj`, `.fsproj`, and `Directory.Packages.props`), dependency metadata can be specified either as an XML attribute or as a child element. Both syntaxes are equivalent in MSBuild.

Previously, `common.PackageReference` only captured `Version` as an XML attribute:
```go
type PackageReference struct {
	Include string `xml:"Include,attr"`
	Version string `xml:"Version,attr"`
}
```
When dependencies were declared with a child `<Version>` element (such as in projects migrated from `packages.config` or projects using `<PrivateAssets>`):
```xml
<PackageReference Include="Newtonsoft.Json">
  <Version>13.0.1</Version>
</PackageReference>
```
The version remained empty, causing `pkg.Include == "" || pkg.Version == ""` to silently drop the package reference from the scan inventory.

Additionally, in NuGet Central Package Management (CPM) files (`Directory.Packages.props`), packages are commonly declared as `<PackageVersion>` items rather than `<PackageReference>`.

### Solution
1. **Support Child `<Version>` Element**:
   - Updated `PackageReference` to capture both `VersionAttr` (`Version,attr`) and `VersionElement` (`Version`).
   - Added `Version()` helper that checks the attribute first and falls back to the child element, trimming any whitespace.
2. **Support `<PackageVersion>` Items**:
   - Added `PackageVersions []PackageReference `xml:"PackageVersion"`` to `ItemGroup` so CPM package declarations are also extracted.
3. **Unit Tests**:
   - Added unit tests in `common_test.go` verifying:
     - Package reference with `<Version>` child element.
     - Child `<Version>` element containing multiline whitespace.
     - Attribute precedence when both attribute and child element exist.
     - `<PackageVersion>` element with attribute syntax.
     - `<PackageVersion>` element with child `<Version>` syntax.
