### PR TITLE
Reject tar entries that escape the extraction directory via backslashes

### DIFF
--- a/extractor/filesystem/embeddedfs/common/common.go
+++ b/extractor/filesystem/embeddedfs/common/common.go
@@ -699,12 +699,17 @@ loop:
 			break
 		}
 
-		if symlink.TargetOutsideRoot("/", hdr.Name) {
+		// TargetOutsideRoot is built on the "path" package, where a backslash is an
+		// ordinary filename character. filepath.Join below resolves backslashes as
+		// separators on Windows, so validate a slash-normalized name to keep the two
+		// in agreement.
+		name := strings.ReplaceAll(hdr.Name, `\`, "/")
+		if symlink.TargetOutsideRoot("/", name) {
 			extractErr = errors.New("tar contains invalid entries")
 			break
 		}
 
-		target := filepath.Join(tempDir, hdr.Name)
+		target := filepath.Join(tempDir, filepath.FromSlash(name))
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, 0755); err != nil {

--- a/extractor/filesystem/embeddedfs/common/common_test.go
+++ b/extractor/filesystem/embeddedfs/common/common_test.go
@@ -17,6 +17,7 @@ package common
 import (
 	"archive/tar"
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -112,6 +113,69 @@ func TestTARToTempDir(t *testing.T) {
 
 			if alloc, err := fileAllocatedBytes(fi); err != nil || (alloc >= 0 && alloc > realDataSize*12/10) {
 				t.Errorf("allocated disk bytes = %d (err = %v), want <= %d", alloc, err, realDataSize*12/10)
+			}
+		})
+	}
+}
+
+// createTARWithEntry builds a single-entry tar archive with the given entry name.
+func createTARWithEntry(t *testing.T, entryName string) io.Reader {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	tw := tar.NewWriter(buf)
+	body := []byte("content\n")
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     entryName,
+		Mode:     0644,
+		Size:     int64(len(body)),
+	}); err != nil {
+		t.Fatalf("tar.WriteHeader(%q): %v", entryName, err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatalf("tar.Write(%q): %v", entryName, err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar.Close(): %v", err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}
+
+func TestTARToTempDirRejectsEscapingEntries(t *testing.T) {
+	// Backslashes are separators on Windows, so an entry like `..\x` escapes the
+	// extraction directory there while being an ordinary filename elsewhere. The
+	// validation must reject it on every platform so the check does not depend on
+	// which separator the host happens to use.
+	tests := []struct {
+		name      string
+		entryName string
+	}{
+		{name: "forward slash", entryName: "../escaped.txt"},
+		{name: "backslash", entryName: `..\escaped.txt`},
+		{name: "backslash nested", entryName: `a\..\..\escaped.txt`},
+		{name: "mixed separators", entryName: `..\../escaped.txt`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := TARToTempDir(createTARWithEntry(t, tc.entryName), 0)
+			if tempDir != "" {
+				defer os.RemoveAll(tempDir)
+			}
+			if err == nil {
+				t.Fatalf("TARToTempDir(%q) = nil error, want the entry to be rejected", tc.entryName)
+			}
+			if !strings.Contains(err.Error(), "invalid entries") {
+				t.Fatalf("TARToTempDir(%q) error = %v, want error containing %q",
+					tc.entryName, err, "invalid entries")
+			}
+
+			// Nothing may be created next to the extraction directory either.
+			escaped := filepath.Join(filepath.Dir(tempDir), "escaped.txt")
+			if _, err := os.Lstat(escaped); err == nil {
+				os.Remove(escaped)
+				t.Fatalf("entry %q created %q outside the extraction directory", tc.entryName, escaped)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #2417.

`TARToTempDir` validates each tar entry name with `symlink.TargetOutsideRoot`, which is built on the `path` package where a backslash is an ordinary filename character. It then joins the same name with `filepath.Join`, which does treat backslashes as separators on Windows. So `..\..\evil.txt` is one opaque segment to the validator and a two-level traversal to the writer, and the entry lands outside `tempDir`.

Reproduced on Windows 11 against v0.5.2: a single-entry tar named `..\SCALIBR_POC_MARKER.txt` wrote its contents one level above the extraction directory. The same archive with `../` is correctly rejected, which shows the validation runs and only the separator handling is at fault. Full write-up and PoC in #2417.

### Where the mismatch came from

d64e793f, *"Fix TargetOutsideRoot for Windows"*, changed that function from `filepath` to `path`. That is right for its original caller — image layer scanning works on virtual container paths that always use `/`. The issue is reuse: `TARToTempDir` resolves the names it validates as real OS paths.

### The change

Normalize separators before validating and convert back when joining, so the validator and the writer agree on what a separator is. `common.go` already has a `normalizePath` helper doing the same replacement for another code path.

### Tests

`TestTARToTempDirRejectsEscapingEntries` covers forward slashes, backslashes, nested backslashes and mixed separators, and asserts nothing appears next to the extraction directory.

It runs on every platform rather than being gated behind `runtime.GOOS == "windows"`: the validation should not depend on which separator the host happens to treat as special, and a Linux-only CI run would not have caught this.

Verified both ways:

```
without the fix: FAIL on backslash, backslash_nested, mixed_separators
with the fix:    ok
```

The forward-slash case passes either way — it is the control.

`go test ./extractor/filesystem/embeddedfs/...` is green across all six packages.

### Alternative

Happy to rework this to confine the writes with `os.Root`, as `artifact/image/unpack/unpack.go` already does, if you would prefer the stronger primitive over normalizing the input.
