### PR TITLE
fix(gitignore): respect repository boundaries when applying .gitignore

### DIFF
--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -288,6 +288,7 @@ func InitWalkContext(ctx context.Context, config *Config, absScanRoots []*scalib
 		inodesVisited:     0,
 		errorOnFSErrors:   config.ErrorOnFSErrors,
 		extractorOverride: config.ExtractorOverride,
+		repoRootDepth:     -1,
 
 		lastStatus: time.Now(),
 
@@ -363,6 +364,13 @@ type walkContext struct {
 
 	// applicable gitignore patterns for the current and parent directories.
 	gitignores []internal.GitignorePattern
+	// depth (index into gitignores) of the nearest ancestor-or-self directory
+	// that is a git repository root; -1 if not currently inside a detected
+	// git repository, in which case .gitignore files don't apply.
+	repoRootDepth int
+	// repoRootDepth values saved on entry to each currently-open directory, so
+	// the previous value can be restored when leaving a nested repository.
+	repoRootDepthStack []int
 	// Inventories found.
 	inventory inventory.Inventory
 	// Extractor name to file path to runtime errors.
@@ -397,14 +405,18 @@ func walkIndividualPaths(wc *walkContext) error {
 				// Recursively scan the contents of the directory.
 				if wc.useGitignore {
 					// Parse parent dir .gitignore files up to the scan root.
-					gitignores, err := internal.ParseParentGitignores(wc.fs, p)
+					gitignores, repoRootDepth, err := internal.ParseParentGitignores(wc.fs, p)
 					if err != nil {
 						return err
 					}
 					wc.gitignores = gitignores
+					wc.repoRootDepth = repoRootDepth
+					wc.repoRootDepthStack = nil
 				}
 				err = internal.WalkDirUnsorted(wc.fs, p, wc.handleFile, wc.postHandleFile)
 				wc.gitignores = nil
+				wc.repoRootDepth = -1
+				wc.repoRootDepthStack = nil
 				if err != nil {
 					return err
 				}
@@ -452,13 +464,28 @@ func (wc *walkContext) handleFile(path string, d fs.DirEntry, fserr error) error
 	if d.Type().IsDir() {
 		wc.dirsVisited++
 		if wc.useGitignore {
-			gitignores := internal.EmptyGitignore()
+			depth := len(wc.gitignores)
+			wc.repoRootDepthStack = append(wc.repoRootDepthStack, wc.repoRootDepth)
+			var gitignores internal.GitignorePattern
 			var err error
 			if !wc.shouldSkipDir(path) {
-				gitignores, err = internal.ParseDirForGitignore(wc.fs, path)
-				if err != nil {
-					return err
+				if internal.HasGitMarker(wc.fs, path) {
+					// This directory is a (possibly nested) repository root:
+					// patterns inherited from any enclosing repository stop
+					// applying from here on.
+					for i := range wc.gitignores {
+						wc.gitignores[i] = nil
+					}
+					wc.repoRootDepth = depth
 				}
+				if wc.repoRootDepth >= 0 {
+					gitignores, err = internal.ParseDirForGitignore(wc.fs, path)
+					if err != nil {
+						return err
+					}
+				}
+				// else: not currently inside any git repository, so a stray
+				// .gitignore file here doesn't apply.
 			}
 			wc.gitignores = append(wc.gitignores, gitignores)
 		}
@@ -542,6 +569,12 @@ func (wc *walkContext) postHandleFile(path string, d fs.DirEntry) {
 	if len(wc.gitignores) > 0 && d.Type().IsDir() {
 		// Remove .gitignores that applied to this directory.
 		wc.gitignores = wc.gitignores[:len(wc.gitignores)-1]
+	}
+	if len(wc.repoRootDepthStack) > 0 {
+		// Restore the repository-root depth as it was before entering this
+		// directory (e.g. after leaving a nested repository).
+		wc.repoRootDepth = wc.repoRootDepthStack[len(wc.repoRootDepthStack)-1]
+		wc.repoRootDepthStack = wc.repoRootDepthStack[:len(wc.repoRootDepthStack)-1]
 	}
 }
 

--- a/extractor/filesystem/filesystem.go
+++ b/extractor/filesystem/filesystem.go
@@ -570,9 +570,12 @@ func (wc *walkContext) postHandleFile(path string, d fs.DirEntry) {
 		// Remove .gitignores that applied to this directory.
 		wc.gitignores = wc.gitignores[:len(wc.gitignores)-1]
 	}
-	if len(wc.repoRootDepthStack) > 0 {
+	if len(wc.repoRootDepthStack) > 0 && d.Type().IsDir() {
 		// Restore the repository-root depth as it was before entering this
-		// directory (e.g. after leaving a nested repository).
+		// directory (e.g. after leaving a nested repository). Only directories
+		// push onto the stack, so only directories may pop from it: popping on
+		// a file would restore the enclosing directory's value early and leave
+		// its remaining sibling directories with a stale depth.
 		wc.repoRootDepth = wc.repoRootDepthStack[len(wc.repoRootDepthStack)-1]
 		wc.repoRootDepthStack = wc.repoRootDepthStack[:len(wc.repoRootDepthStack)-1]
 	}

--- a/extractor/filesystem/filesystem_test.go
+++ b/extractor/filesystem/filesystem_test.go
@@ -978,17 +978,19 @@ func TestRunFSGitignore(t *testing.T) {
 			mapFS: mapFS{
 				".":               nil,
 				"dir1":            nil,
+				"dir1/.git":       nil,
 				"dir1/file1.txt":  []byte("Content 1"),
 				"dir1/.gitignore": []byte("file1.txt"),
 			},
 			pathToExtract:  "dir1",
 			wantPkg1:       false,
-			wantInodeCount: 3,
+			wantInodeCount: 4,
 		},
 		{
 			desc: "Skip_dir",
 			mapFS: mapFS{
 				".":                  nil,
+				".git":               nil,
 				"dir2":               nil,
 				"dir2/sub":           nil,
 				"dir2/sub/file2.txt": []byte("Content 2"),
@@ -996,7 +998,7 @@ func TestRunFSGitignore(t *testing.T) {
 			},
 			pathToExtract:  "",
 			wantPkg2:       false,
-			wantInodeCount: 4,
+			wantInodeCount: 5,
 		},
 		{
 			desc: "Dont_skip_if_no_match",
@@ -1016,6 +1018,7 @@ func TestRunFSGitignore(t *testing.T) {
 			mapFS: mapFS{
 				".":                  nil,
 				"dir2":               nil,
+				"dir2/.git":          nil,
 				"dir2/sub":           nil,
 				"dir2/sub/file2.txt": []byte("Content 1"),
 				"dir2/.gitignore":    []byte("file2.txt"),
@@ -1028,6 +1031,7 @@ func TestRunFSGitignore(t *testing.T) {
 			desc: "Skip_based_on_child_gitignore",
 			mapFS: mapFS{
 				".":               nil,
+				".git":            nil,
 				"dir1":            nil,
 				"dir2":            nil,
 				"dir2/sub":        nil,
@@ -1039,7 +1043,44 @@ func TestRunFSGitignore(t *testing.T) {
 			pathToExtract:  "",
 			wantPkg1:       false,
 			wantPkg2:       true,
-			wantInodeCount: 7,
+			wantInodeCount: 8,
+		},
+		{
+			// google/osv-scalibr#902: .gitignore files outside of git
+			// repositories must not be applied. This fixture is identical to
+			// "Skip_file" above, except there is no ".git" anywhere, so
+			// file1.txt must NOT be skipped.
+			desc: "No_git_repo_gitignore_does_not_apply",
+			mapFS: mapFS{
+				".":               nil,
+				"dir1":            nil,
+				"dir1/file1.txt":  []byte("Content 1"),
+				"dir1/.gitignore": []byte("file1.txt"),
+			},
+			pathToExtract:  "dir1",
+			wantPkg1:       true,
+			wantInodeCount: 3,
+		},
+		{
+			// google/osv-scalibr#902: .gitignore files from the parent
+			// repository must not be applied to files in a nested git
+			// subrepository (e.g. a submodule). Same fixture as
+			// "Skip_based_on_parent_gitignore" above (dir2/.gitignore ignores
+			// file2.txt in its dir2/sub descendants), except dir2/sub is now
+			// itself a repository root (".git" present) and must therefore
+			// NOT inherit dir2's rule.
+			desc: "Nested_repo_does_not_inherit_parent_gitignore",
+			mapFS: mapFS{
+				".":                  nil,
+				"dir2":               nil,
+				"dir2/sub":           nil,
+				"dir2/sub/.git":      nil,
+				"dir2/sub/file2.txt": []byte("Content 1"),
+				"dir2/.gitignore":    []byte("file2.txt"),
+			},
+			pathToExtract:  "dir2/sub",
+			wantPkg2:       true,
+			wantInodeCount: 3,
 		},
 		{
 			desc: "ignore_sub_dirs",

--- a/extractor/filesystem/internal/gitignore.go
+++ b/extractor/filesystem/internal/gitignore.go
@@ -43,6 +43,16 @@ func GitignoreMatch(gitignores []GitignorePattern, filePath []string, isDir bool
 	return false
 }
 
+// HasGitMarker reports whether the specified directory contains a ".git"
+// entry, marking it as the root of a git repository. A ".git" entry is a
+// directory for a normal checkout, or a file for a submodule or a linked
+// worktree -- either is treated as a repository boundary here.
+func HasGitMarker(fs scalibrfs.FS, dirPath string) bool {
+	dirPath = strings.TrimSuffix(dirPath, "/")
+	_, err := fs.Stat(path.Join(dirPath, ".git"))
+	return err == nil
+}
+
 // ParseDirForGitignore parses .gitignore patterns found in the
 // specified directory.
 func ParseDirForGitignore(fs scalibrfs.FS, dirPath string) (GitignorePattern, error) {
@@ -69,18 +79,42 @@ func ParseDirForGitignore(fs scalibrfs.FS, dirPath string) (GitignorePattern, er
 }
 
 // ParseParentGitignores parses all .gitignore patterns between the current dir
-// and the scan root, excluding the current directory.
-func ParseParentGitignores(fs scalibrfs.FS, dirPath string) ([]GitignorePattern, error) {
+// and the scan root, excluding the current directory. It also returns the
+// depth (0-indexed, matching the returned slice) of the nearest ancestor
+// directory that is itself a git repository root, or -1 if none of the
+// ancestors are inside a git repository.
+//
+// .gitignore files found above that repository root are excluded from the
+// result: gitignore rules only apply within the boundaries of their own
+// repository, so a directory that isn't inside any repository must not have
+// stray .gitignore files applied to it, and a nested repository (e.g. a
+// submodule) must not inherit its parent repository's rules.
+func ParseParentGitignores(fs scalibrfs.FS, dirPath string) ([]GitignorePattern, int, error) {
 	var filePath strings.Builder
 	result := []GitignorePattern{}
 	components := strings.Split(dirPath, "/")
-	for _, dir := range components[:len(components)-1] {
+	repoRootDepth := -1
+	for i, dir := range components[:len(components)-1] {
 		filePath.WriteString(dir + "/")
-		gitignores, err := ParseDirForGitignore(fs, filePath.String())
+		dirStr := filePath.String()
+		if HasGitMarker(fs, dirStr) {
+			repoRootDepth = i
+		}
+		gitignores, err := ParseDirForGitignore(fs, dirStr)
 		if err != nil {
-			return nil, err
+			return nil, -1, err
 		}
 		result = append(result, gitignores)
 	}
-	return result, nil
+	// Nil out any .gitignore found above the nearest repository root (or all
+	// of them, if none of the ancestors are inside a repository) -- they
+	// don't apply to dirPath.
+	boundary := repoRootDepth
+	if boundary < 0 {
+		boundary = len(result)
+	}
+	for i := 0; i < boundary; i++ {
+		result[i] = nil
+	}
+	return result, repoRootDepth, nil
 }

--- a/extractor/filesystem/internal/gitignore.go
+++ b/extractor/filesystem/internal/gitignore.go
@@ -113,7 +113,7 @@ func ParseParentGitignores(fs scalibrfs.FS, dirPath string) ([]GitignorePattern,
 	if boundary < 0 {
 		boundary = len(result)
 	}
-	for i := 0; i < boundary; i++ {
+	for i := range boundary {
 		result[i] = nil
 	}
 	return result, repoRootDepth, nil

--- a/extractor/filesystem/internal/gitignore_test.go
+++ b/extractor/filesystem/internal/gitignore_test.go
@@ -15,10 +15,38 @@
 package internal
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	scalibrfs "github.com/google/osv-scalibr/fs"
 )
+
+// buildFS materializes files into a fresh temp directory and returns an FS
+// rooted there. A nil value creates an (empty) directory; this is used to
+// create ".git" markers, which -- unlike the rest of this package's
+// testdata -- can't be checked into the repository itself: git refuses to
+// track, clone or apply a path with a literal ".git" path component.
+func buildFS(t *testing.T, files map[string][]byte) scalibrfs.FS {
+	t.Helper()
+	root := t.TempDir()
+	for p, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(p))
+		if content == nil {
+			if err := os.MkdirAll(full, 0o755); err != nil {
+				t.Fatalf("os.MkdirAll(%q): %v", full, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("os.MkdirAll(%q): %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, content, 0o644); err != nil {
+			t.Fatalf("os.WriteFile(%q): %v", full, err)
+		}
+	}
+	return scalibrfs.DirFS(root)
+}
 
 func TestGitignoreMatch(t *testing.T) {
 	tests := []struct {
@@ -78,24 +106,34 @@ func TestFindParentGitignores(t *testing.T) {
 	}{
 		{
 			name:      "No_match",
-			path:      []string{"testdata", "path", "to", "file.py"},
+			path:      []string{"repo", "path", "to", "file.py"},
 			wantMatch: false,
 		},
 		{
 			name:      "Match_pattern_from_parent_dir",
-			path:      []string{"testdata", "path", "to", "ignore.txt"},
+			path:      []string{"repo", "path", "to", "ignore.txt"},
 			wantMatch: true,
 		},
 		{
 			name:      "Dont_match_pattern_from_child_dir",
-			path:      []string{"testdata", "subdir", "path", "to", "ignore2.txt"},
+			path:      []string{"repo", "subdir", "path", "to", "ignore2.txt"},
 			wantMatch: false,
 		},
 	}
 
-	patterns, err := ParseParentGitignores(scalibrfs.DirFS("."), "testdata/subdir")
+	// repo/.git marks repo as a repository root so the ancestor .gitignore
+	// files below are actually considered applicable.
+	fsys := buildFS(t, map[string][]byte{
+		"repo/.git":              nil,
+		"repo/.gitignore":        []byte("**/*-ignore\n# Comment\n\nignore.txt\n"),
+		"repo/subdir/.gitignore": []byte("ignore2.txt\n"),
+	})
+	patterns, repoRootDepth, err := ParseParentGitignores(fsys, "repo/subdir")
 	if err != nil {
-		t.Fatalf("ParseParentGitignores(testdata): %v", err)
+		t.Fatalf("ParseParentGitignores(repo/subdir): %v", err)
+	}
+	if repoRootDepth < 0 {
+		t.Fatalf("ParseParentGitignores(repo/subdir) repoRootDepth = %d, want >= 0", repoRootDepth)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,5 +142,74 @@ func TestFindParentGitignores(t *testing.T) {
 				t.Errorf("GitignoreMatch(%v): got %v, want %v", patterns, got, tt.wantMatch)
 			}
 		})
+	}
+}
+
+func TestParseParentGitignoresOutsideRepository(t *testing.T) {
+	// No .git anywhere above "outside", so outside/.gitignore must not apply:
+	// applying .gitignore files found outside of a git repository is one half
+	// of google/osv-scalibr#902.
+	fsys := buildFS(t, map[string][]byte{
+		"outside/.gitignore": []byte("ignore.txt\n"),
+	})
+	patterns, repoRootDepth, err := ParseParentGitignores(fsys, "outside/path/to/ignore.txt")
+	if err != nil {
+		t.Fatalf("ParseParentGitignores(outside/path/to/ignore.txt): %v", err)
+	}
+	if repoRootDepth != -1 {
+		t.Errorf("ParseParentGitignores(outside/path/to/ignore.txt) repoRootDepth = %d, want -1 (no repository found)", repoRootDepth)
+	}
+	if got := GitignoreMatch(patterns, []string{"outside", "path", "to", "ignore.txt"}, false); got {
+		t.Errorf("GitignoreMatch(%v): got true, want false (outside any git repository)", patterns)
+	}
+}
+
+func TestParseParentGitignoresRepositoryBoundaryIsWhereRulesStart(t *testing.T) {
+	// The two halves in one tree, so that dropping every .gitignore is not a
+	// passing answer: "outside" is not a repository and its .gitignore must
+	// be ignored, while "outside/repo" is one and its own .gitignore must
+	// still be honoured.
+	fsys := buildFS(t, map[string][]byte{
+		"outside/.gitignore":      []byte("ignore.txt\n"),
+		"outside/repo/.git":       nil,
+		"outside/repo/.gitignore": []byte("inner.txt\n"),
+	})
+	patterns, repoRootDepth, err := ParseParentGitignores(fsys, "outside/repo/child")
+	if err != nil {
+		t.Fatalf("ParseParentGitignores(outside/repo/child): %v", err)
+	}
+	// outside=0, repo=1; "repo" is the nearest repository root.
+	if want := 1; repoRootDepth != want {
+		t.Errorf("ParseParentGitignores(outside/repo/child) repoRootDepth = %d, want %d", repoRootDepth, want)
+	}
+	if got := GitignoreMatch(patterns, []string{"outside", "repo", "ignore.txt"}, false); got {
+		t.Errorf("GitignoreMatch(ignore.txt) = true, want false: a .gitignore above the repository root must not apply")
+	}
+	if got := GitignoreMatch(patterns, []string{"outside", "repo", "inner.txt"}, false); !got {
+		t.Errorf("GitignoreMatch(inner.txt) = false, want true: the repository's own .gitignore must still apply")
+	}
+}
+
+func TestParseParentGitignoresNestedRepository(t *testing.T) {
+	// nestedrepo is a git repository whose .gitignore ignores "ignore.txt".
+	// nestedrepo/sub is itself a *separate* (e.g. submodule) repository, so
+	// it must not inherit the outer repository's rules -- ignoring files
+	// from a parent repository must not leak into a git subrepository.
+	fsys := buildFS(t, map[string][]byte{
+		"nestedrepo/.git":       nil,
+		"nestedrepo/.gitignore": []byte("ignore.txt\n"),
+		"nestedrepo/sub/.git":   nil,
+	})
+	patterns, repoRootDepth, err := ParseParentGitignores(fsys, "nestedrepo/sub/child")
+	if err != nil {
+		t.Fatalf("ParseParentGitignores(nestedrepo/sub/child): %v", err)
+	}
+	// The nearest repository root is "sub" itself (index 1: nestedrepo=0,
+	// sub=1), not the outer "nestedrepo" repository.
+	if want := 1; repoRootDepth != want {
+		t.Errorf("ParseParentGitignores(nestedrepo/sub/child) repoRootDepth = %d, want %d", repoRootDepth, want)
+	}
+	if got := GitignoreMatch(patterns, []string{"nestedrepo", "sub", "ignore.txt"}, false); got {
+		t.Errorf("GitignoreMatch(%v): got true, want false (parent repository's .gitignore must not apply inside the nested repository)", patterns)
 	}
 }

--- a/extractor/filesystem/walkcontext_gitignore_internal_test.go
+++ b/extractor/filesystem/walkcontext_gitignore_internal_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"io/fs"
+	"testing"
+)
+
+type stubDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (e stubDirEntry) Name() string { return e.name }
+func (e stubDirEntry) IsDir() bool  { return e.isDir }
+func (e stubDirEntry) Type() fs.FileMode {
+	if e.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+func (e stubDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
+
+// TestPostHandleFileOnlyPopsRepoRootDepthForDirectories pins down the
+// push/pop symmetry of repoRootDepthStack. Only directories push onto it, in
+// handleFile, so only directories may pop from it. Popping on a file restores
+// the enclosing directory's value while that directory is still being walked,
+// and every sibling directory visited afterwards then runs with a stale
+// repository-root depth -- with -1 meaning "not inside a repository", their
+// .gitignore files are not read at all.
+//
+// The walk uses readdir order, so whether a file is seen before a sibling
+// directory depends on the filesystem, which makes the effect invisible on
+// some machines and reproducible on others. Asserting on the bookkeeping
+// directly keeps it deterministic.
+func TestPostHandleFileOnlyPopsRepoRootDepthForDirectories(t *testing.T) {
+	wc := &walkContext{
+		useGitignore:       true,
+		repoRootDepth:      3,
+		repoRootDepthStack: []int{7},
+	}
+
+	wc.postHandleFile("dir/file.txt", stubDirEntry{name: "file.txt"})
+	if got, want := wc.repoRootDepth, 3; got != want {
+		t.Errorf("after a file: repoRootDepth = %d, want %d (a file must not restore the enclosing directory's depth)", got, want)
+	}
+	if got, want := len(wc.repoRootDepthStack), 1; got != want {
+		t.Errorf("after a file: len(repoRootDepthStack) = %d, want %d", got, want)
+	}
+
+	wc.postHandleFile("dir", stubDirEntry{name: "dir", isDir: true})
+	if got, want := wc.repoRootDepth, 7; got != want {
+		t.Errorf("after the directory: repoRootDepth = %d, want %d (leaving a directory must restore the saved depth)", got, want)
+	}
+	if got, want := len(wc.repoRootDepthStack), 0; got != want {
+		t.Errorf("after the directory: len(repoRootDepthStack) = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
## Description

Fixes #902 — `.gitignore` parsing ignores repository boundaries, in both directions the issue lists:

* `.gitignore` files that sit outside any git repository are parsed and applied;
* a nested repository (submodule, linked worktree) inherits the enclosing repository's rules.

### The change

`internal.HasGitMarker` reports whether a directory holds a `.git` entry — a directory for a normal checkout, a file for a submodule or a linked worktree; either marks a repository root.

`ParseParentGitignores` now also returns the depth of the nearest ancestor-or-self repository root (`-1` when there is none) and nils out every `.gitignore` found above that root, since those belong to a different repository, or to no repository at all.

The walker tracks the same thing while descending: `walkContext.repoRootDepth`, with a small stack so the value is restored on the way back out of a nested repository. Entering a directory that has a `.git` marker drops the inherited patterns and starts a fresh boundary; while `repoRootDepth` is `-1`, a stray `.gitignore` is not read at all.

## Verification

Go 1.26.3, against `d6ac14e`.

**The check from the previous attempt.** On the earlier PR for this issue (google/osv-scanner#1859) the review was: *"I commented out the `isSubRepository()` function and all the newly added tests still passes just fine?"* That is the right question, so I ran it here before opening this one. Making `HasGitMarker` return `false` unconditionally and changing nothing else:

```
--- FAIL: TestFindParentGitignores
        gitignore_test.go:136: ParseParentGitignores(repo/subdir) repoRootDepth = -1, want >= 0
--- FAIL: TestParseParentGitignoresRepositoryBoundaryIsWhereRulesStart
        gitignore_test.go:183: ParseParentGitignores(outside/repo/child) repoRootDepth = -1, want 1
        gitignore_test.go:189: GitignoreMatch(inner.txt) = false, want true: the repository's own .gitignore must still apply
--- FAIL: TestParseParentGitignoresNestedRepository
        gitignore_test.go:210: ParseParentGitignores(nestedrepo/sub/child) repoRootDepth = -1, want 1
FAIL    github.com/google/osv-scalibr/extractor/filesystem/internal

        filesystem_test.go:1144: ... got inv1: true, want: false
FAIL    github.com/google/osv-scalibr/extractor/filesystem
```

One of the new tests, `TestParseParentGitignoresOutsideRepository`, does still pass with the function neutralised, and I would rather point that out than have it found: on its own it only says "no `.gitignore` applied", which an implementation that drops every `.gitignore` also satisfies. `TestParseParentGitignoresRepositoryBoundaryIsWhereRulesStart` exists for exactly that reason — one tree where the `.gitignore` above the repository root must not apply *and* the repository's own must, so neither "apply everything" nor "apply nothing" passes it.

**With the change in place**, `go vet ./extractor/filesystem/...` is clean, `gofmt -l` on the four touched files is empty, and both packages pass:

```
ok      github.com/google/osv-scalibr/extractor/filesystem/internal
ok      github.com/google/osv-scalibr/extractor/filesystem
```

**Pre-existing failure, for the record.** `extractor/filesystem/os/osrelease` fails in my container both with and without this change — `TestGetOSRelease/permission_error` expects `FileRequired` to hit a permission error, and the container runs as root. It is the only failing package under `./extractor/filesystem/...` on a clean checkout of `main`, and it is untouched here.

## A note on the test fixtures

The new tests build their trees with `t.TempDir()` rather than checking fixtures into `testdata/`, because the fixtures need literal `.git` path components and git will not track, clone or apply those. `TestFindParentGitignores` moved to the same helper for consistency, since its `testdata/` tree now needs a repository marker to stay meaningful; the assertions in it are unchanged.

---

*AI-assisted: I used Claude to help port the change onto current `main` and to draft the tests and this description. I reviewed every line, ran the neutralised-function control described above and the clean-`main` baseline myself, and the analysis and the runs are mine.*
