### PR TITLE
fix(pnpmlock): recover dependency groups for lockfileVersion 9 lockfiles

### DIFF
--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock-v9_test.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock-v9_test.go
@@ -67,7 +67,13 @@ func TestExtractor_Extract_v9(t *testing.T) {
 					Location:   extractor.LocationFromPathAndLine("testdata/one-package-dev.v9.yaml", 17),
 					SourceCode: &extractor.SourceCodeIdentifier{},
 					Metadata: &osv.DepGroupMetadata{
-						DepGroupVals: []string{},
+						// acorn is only ever listed under the "." importer's
+						// devDependencies, and lockfileVersion 9.0+ no longer
+						// writes a computed "dev" flag into the packages
+						// section itself (github.com/google/osv-scanner/issues/1298),
+						// so this can only be recovered by walking the
+						// importers -> snapshots graph.
+						DepGroupVals: []string{"dev"},
 					},
 				},
 			},
@@ -355,13 +361,91 @@ func TestExtractor_Extract_v9(t *testing.T) {
 					},
 				},
 				{
-					Name:       "is-number",
-					Version:    "7.0.0",
+					Name:     "is-number",
+					Version:  "7.0.0",
+					PURLType: purl.TypeNPM,
+					Location: extractor.LocationFromPathAndLine("testdata/mixed-groups.v9.yaml", 29),
+					// is-number is only listed under devDependencies and has
+					// no snapshot edges reachable from a production or
+					// optional dependency, so it must be classified as dev.
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+			},
+		},
+		{
+			Name: "transitive dev dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/transitive-dev.v9.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					// acorn is never listed in any importer's dependency maps.
+					// It is reachable only as a dependency of acorn-jsx, which
+					// is a devDependency, so only the walk through "snapshots"
+					// can classify it -- and the snapshot key carries a peer
+					// suffix, "acorn-jsx@5.3.2(acorn@8.11.3)".
+					Name:       "acorn",
+					Version:    "8.11.3",
 					PURLType:   purl.TypeNPM,
-					Location:   extractor.LocationFromPathAndLine("testdata/mixed-groups.v9.yaml", 29),
+					Location:   extractor.LocationFromPathAndLine("testdata/transitive-dev.v9.yaml", 21),
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				{
+					Name:       "acorn-jsx",
+					Version:    "5.3.2",
+					PURLType:   purl.TypeNPM,
+					Location:   extractor.LocationFromPathAndLine("testdata/transitive-dev.v9.yaml", 26),
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
+					},
+				},
+				{
+					Name:       "ansi-regex",
+					Version:    "5.0.1",
+					PURLType:   purl.TypeNPM,
+					Location:   extractor.LocationFromPathAndLine("testdata/transitive-dev.v9.yaml", 31),
 					SourceCode: &extractor.SourceCodeIdentifier{},
 					Metadata: &osv.DepGroupMetadata{
 						DepGroupVals: []string{},
+					},
+				},
+			},
+		},
+		{
+			Name: "package reachable from both a production and a dev dependency",
+			InputConfig: extracttest.ScanInputMockConfig{
+				Path: "testdata/shared-prod-and-dev.v9.yaml",
+			},
+			WantPackages: []*extractor.Package{
+				{
+					// acorn is a direct production dependency here, and also a
+					// dependency of the devDependency acorn-jsx. Production
+					// wins: an implementation that marks everything reachable
+					// from devDependencies would get this wrong.
+					Name:       "acorn",
+					Version:    "8.11.3",
+					PURLType:   purl.TypeNPM,
+					Location:   extractor.LocationFromPathAndLine("testdata/shared-prod-and-dev.v9.yaml", 21),
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{},
+					},
+				},
+				{
+					Name:       "acorn-jsx",
+					Version:    "5.3.2",
+					PURLType:   purl.TypeNPM,
+					Location:   extractor.LocationFromPathAndLine("testdata/shared-prod-and-dev.v9.yaml", 26),
+					SourceCode: &extractor.SourceCodeIdentifier{},
+					Metadata: &osv.DepGroupMetadata{
+						DepGroupVals: []string{"dev"},
 					},
 				},
 			},

--- a/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
+++ b/extractor/filesystem/language/javascript/pnpmlock/pnpmlock.go
@@ -58,14 +58,47 @@ type pnpmLockPackage struct {
 	Dev        bool                      `yaml:"dev"`
 }
 
+// pnpmImporterDependency is a single entry under an importer's "dependencies",
+// "optionalDependencies" or "devDependencies" map in a v9+ lockfile.
+type pnpmImporterDependency struct {
+	Specifier string `yaml:"specifier"`
+	Version   string `yaml:"version"`
+}
+
+// pnpmImporter is a single workspace project listed under the top-level
+// "importers" key of a v9+ lockfile (a single-project repo only has one
+// importer, keyed by "."). This is where a v9+ lockfile records whether a
+// dependency was requested for production or for development use — unlike
+// v6/v8, the "packages" section of a v9+ lockfile no longer carries a "dev"
+// flag on each resolved package.
+type pnpmImporter struct {
+	Dependencies         map[string]pnpmImporterDependency `yaml:"dependencies"`
+	OptionalDependencies map[string]pnpmImporterDependency `yaml:"optionalDependencies"`
+	DevDependencies      map[string]pnpmImporterDependency `yaml:"devDependencies"`
+}
+
+// pnpmSnapshot is a single entry under the top-level "snapshots" key of a
+// v9+ lockfile: the resolved dependency graph edges for one specific
+// (package, peer-dependency resolution) pair. Snapshot keys are formatted as
+// "name@version" with zero or more "(peerName@peerVersion)" suffixes, e.g.
+// "tsutils@3.21.0(typescript@4.9.5)".
+type pnpmSnapshot struct {
+	Dependencies         map[string]string `yaml:"dependencies"`
+	OptionalDependencies map[string]string `yaml:"optionalDependencies"`
+}
+
 type pnpmLockfile struct {
-	Version  float64                    `yaml:"lockfileVersion"`
-	Packages map[string]pnpmLockPackage `yaml:"packages,omitempty"`
+	Version   float64                    `yaml:"lockfileVersion"`
+	Packages  map[string]pnpmLockPackage `yaml:"packages,omitempty"`
+	Importers map[string]pnpmImporter    `yaml:"importers,omitempty"`
+	Snapshots map[string]pnpmSnapshot    `yaml:"snapshots,omitempty"`
 }
 
 type pnpmLockfileV6 struct {
-	Version  string                     `yaml:"lockfileVersion"`
-	Packages map[string]pnpmLockPackage `yaml:"packages,omitempty"`
+	Version   string                     `yaml:"lockfileVersion"`
+	Packages  map[string]pnpmLockPackage `yaml:"packages,omitempty"`
+	Importers map[string]pnpmImporter    `yaml:"importers,omitempty"`
+	Snapshots map[string]pnpmSnapshot    `yaml:"snapshots,omitempty"`
 }
 
 // UnmarshalYAML is a custom unmarshalling function for handling v6 lockfiles.
@@ -84,6 +117,8 @@ func (l *pnpmLockfile) UnmarshalYAML(unmarshal func(any) error) error {
 
 	l.Version = parsedVersion
 	l.Packages = lockfileV6.Packages
+	l.Importers = lockfileV6.Importers
+	l.Snapshots = lockfileV6.Snapshots
 
 	return nil
 }
@@ -169,9 +204,101 @@ func parseNameAtVersion(value string) (name string, version string) {
 	return matches[1], matches[2]
 }
 
+// snapshotPeerSuffix matches everything from the first "(peer@version)" group
+// (if any) to the end of a snapshots-section key, so that stripping it turns
+// a resolved snapshot key such as "tsutils@3.21.0(typescript@4.9.5)" back
+// into the bare "name@version" form used as a packages-section key.
+var snapshotPeerSuffix = regexp.MustCompile(`\(.*$`)
+
+// snapshotKeyFor builds the snapshots-section key that a "name" -> "version"
+// dependency edge (as found in an importer's dependency maps, or in another
+// snapshot's own dependency map) resolves to.
+func snapshotKeyFor(name, version string) string {
+	return name + "@" + version
+}
+
+// bareSnapshotKey strips any peer-dependency suffix from a snapshots-section
+// key, turning it into the plain "name@version" form used as a
+// packages-section key.
+func bareSnapshotKey(key string) string {
+	return snapshotPeerSuffix.ReplaceAllString(key, "")
+}
+
+// collectDevOnlyPackages walks the dependency graph recorded in a v9+
+// lockfile's "snapshots" section to determine which resolved packages are
+// reachable *only* through a devDependency, and never through a production
+// dependency (direct or transitive, in any workspace project). It returns
+// the set of bare "name@version" packages-section keys that should be
+// reported with the "dev" dependency group.
+//
+// This graph walk exists because, starting with lockfileVersion 9.0, pnpm no
+// longer writes a computed "dev: true" flag on every transitively-dev
+// package in the "packages" section (see
+// https://github.com/google/osv-scanner/issues/1298) — dev/production
+// status is only recorded once, on each workspace's direct dependencies in
+// "importers", and has to be propagated through "snapshots" by hand.
+func collectDevOnlyPackages(lockfile pnpmLockfile) map[string]bool {
+	var walk func(key string, reached map[string]bool)
+	walk = func(key string, reached map[string]bool) {
+		if reached[key] {
+			return
+		}
+		reached[key] = true
+
+		snapshot, ok := lockfile.Snapshots[key]
+		if !ok {
+			return
+		}
+		for name, version := range snapshot.Dependencies {
+			walk(snapshotKeyFor(name, version), reached)
+		}
+		for name, version := range snapshot.OptionalDependencies {
+			walk(snapshotKeyFor(name, version), reached)
+		}
+	}
+
+	prodReachable := map[string]bool{}
+	devReachable := map[string]bool{}
+
+	for _, importer := range lockfile.Importers {
+		for name, dep := range importer.Dependencies {
+			walk(snapshotKeyFor(name, dep.Version), prodReachable)
+		}
+		for name, dep := range importer.OptionalDependencies {
+			walk(snapshotKeyFor(name, dep.Version), prodReachable)
+		}
+	}
+	for _, importer := range lockfile.Importers {
+		for name, dep := range importer.DevDependencies {
+			walk(snapshotKeyFor(name, dep.Version), devReachable)
+		}
+	}
+
+	devOnly := map[string]bool{}
+	for key := range devReachable {
+		devOnly[bareSnapshotKey(key)] = true
+	}
+	// The same package can appear as several snapshots, one per distinct
+	// peer-dependency resolution. If any variation of it is reachable from
+	// a production dependency, the package as a whole is not dev-only.
+	for key := range prodReachable {
+		delete(devOnly, bareSnapshotKey(key))
+	}
+
+	return devOnly
+}
+
 func parsePnpmLock(lockfile pnpmLockfile, packageLineMap map[string]int, path string) ([]*extractor.Package, error) {
 	packages := make([]*extractor.Package, 0, len(lockfile.Packages))
 	errs := []error{}
+
+	// The "dev" flag on each packages-section entry was removed from the
+	// lockfile format in lockfileVersion 9.0; for those lockfiles dev/prod
+	// status has to be recomputed from the snapshot graph instead.
+	var devOnlyPackages map[string]bool
+	if lockfile.Version >= 9.0 {
+		devOnlyPackages = collectDevOnlyPackages(lockfile)
+	}
 
 	for s, pkg := range lockfile.Packages {
 		name, version, err := extractPnpmPackageNameAndVersion(s, lockfile.Version)
@@ -222,7 +349,11 @@ func parsePnpmLock(lockfile pnpmLockfile, packageLineMap map[string]int, path st
 		}
 
 		depGroups := []string{}
-		if pkg.Dev {
+		if lockfile.Version >= 9.0 {
+			if devOnlyPackages[s] {
+				depGroups = append(depGroups, "dev")
+			}
+		} else if pkg.Dev {
 			depGroups = append(depGroups, "dev")
 		}
 

--- a/extractor/filesystem/language/javascript/pnpmlock/testdata/shared-prod-and-dev.v9.yaml
+++ b/extractor/filesystem/language/javascript/pnpmlock/testdata/shared-prod-and-dev.v9.yaml
@@ -1,0 +1,37 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      acorn:
+        specifier: ^8.11.3
+        version: 8.11.3
+    devDependencies:
+      acorn-jsx:
+        specifier: ^5.3.2
+        version: 5.3.2(acorn@8.11.3)
+
+packages:
+
+  acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+snapshots:
+
+  acorn-jsx@5.3.2(acorn@8.11.3):
+    dependencies:
+      acorn: 8.11.3
+
+  acorn@8.11.3: {}

--- a/extractor/filesystem/language/javascript/pnpmlock/testdata/transitive-dev.v9.yaml
+++ b/extractor/filesystem/language/javascript/pnpmlock/testdata/transitive-dev.v9.yaml
@@ -1,0 +1,43 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      ansi-regex:
+        specifier: ^5.0.0
+        version: 5.0.1
+    devDependencies:
+      acorn-jsx:
+        specifier: ^5.3.2
+        version: 5.3.2(acorn@8.11.3)
+
+packages:
+
+  acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+snapshots:
+
+  acorn-jsx@5.3.2(acorn@8.11.3):
+    dependencies:
+      acorn: 8.11.3
+
+  acorn@8.11.3: {}
+
+  ansi-regex@5.0.1: {}


### PR DESCRIPTION
## Description

Fixes the pnpm side of google/osv-scanner#1298 — dependency-group filtering does not work for pnpm lockfiles. The reporter re-confirmed it is still happening on 2025-09-08.

### Why it happens

Up to lockfileVersion 6/8, pnpm wrote a computed `dev: true` onto every entry in the `packages` section, and the extractor reads it directly. **Starting with lockfileVersion 9.0 that flag is gone.** Dev/production status is recorded once per workspace project, in `importers`, on its *direct* dependencies only, and everything below that has to be derived from the `snapshots` graph.

The extractor still only looks at `pkg.Dev`, so for any v9 lockfile every package comes back with no dependency groups at all — which is exactly what the issue describes.

**This repository's own fixtures already record the bug.** `testdata/one-package-dev.v9.yaml` is a lockfile containing a single package, listed under `devDependencies` and nothing else, and the expected result for it is `DepGroupVals: []`. The same holds for `is-number` in `testdata/mixed-groups.v9.yaml`. Both expectations are corrected in this PR; that correction is the clearest statement of what was wrong.

### The change

`collectDevOnlyPackages` walks the `snapshots` graph twice: once from every importer's `dependencies` and `optionalDependencies`, once from every importer's `devDependencies`. A package is reported as `dev` when it is reachable from the second set and not from the first — so a package pulled in by both a production and a dev dependency stays production, which a "mark everything under devDependencies" implementation would get wrong.

Snapshot keys carry peer-resolution suffixes (`acorn-jsx@5.3.2(acorn@8.11.3)`), so they are reduced to the bare `name@version` form used by the `packages` section before the result is applied. The same package may appear as several snapshots, one per peer resolution; if any of them is reachable from production, the package as a whole is production.

The v6/v8 path is untouched: the new computation only runs for `lockfileVersion >= 9.0`.

## Verification

Go 1.26.3, against `0c60682`.

**With the change:** `go test ./extractor/filesystem/language/javascript/pnpmlock/` passes, `go vet` and `gofmt -l` are clean.

**Without it** — leaving every test in place and making the v9 branch not run — four cases fail:

```
--- FAIL: TestExtractor_Extract_v9/one_package_dev
--- FAIL: TestExtractor_Extract_v9/mixed_groups
--- FAIL: TestExtractor_Extract_v9/transitive_dev_dependency
--- FAIL: TestExtractor_Extract_v9/package_reachable_from_both_a_production_and_a_dev_dependency
```

The first two are the pre-existing fixtures mentioned above, so the failure is not something the new tests invented for themselves.

## Test data

Two fixtures, both built only from packages and integrity hashes that already appear in this directory's fixtures, so nothing here is made up:

* `transitive-dev.v9.yaml` — `ansi-regex` as a production dependency, `acorn-jsx` as a devDependency. `acorn` appears in no importer at all and is reachable only as `acorn-jsx`'s dependency, so it must come back as `dev`; the snapshot key for it is peer-suffixed, which exercises that path too.
* `shared-prod-and-dev.v9.yaml` — `acorn` as a direct production dependency *and* as `acorn-jsx`'s dependency, so it must come back without the `dev` group.

---

*AI-assisted: I used Claude to help port the change onto current `main`, to build the fixtures out of the existing ones and to draft this description. I reviewed every line, ran the neutralised-computation control described above myself, and the analysis and the runs are mine.*
