### PR TITLE
fix(dotnet/depsjson): ignore files that don't have an object as their root

### DIFF
--- a/extractor/filesystem/language/dotnet/depsjson/depsjson.go
+++ b/extractor/filesystem/language/dotnet/depsjson/depsjson.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -130,9 +132,22 @@ type DepsJSON struct {
 }
 
 func (e Extractor) extractFromInput(input *filesystem.ScanInput) ([]*extractor.Package, error) {
+	content, err := io.ReadAll(input.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read input: %w", err)
+	}
+
+	// assume such JSON files are not the .NET type, e.g. the WordPress
+	// ecosystem has roots/vite-plugin which emits editor.deps.json
+	var probe map[string]any
+	if err := json.Unmarshal(content, &probe); err != nil {
+		//nolint:nilerr // this is a different type of file, not an error
+		return nil, nil
+	}
+
 	var deps DepsJSON
-	decoder := json.NewDecoder(input.Reader)
-	if err := decoder.Decode(&deps); err != nil {
+
+	if err := json.Unmarshal(content, &deps); err != nil {
 		log.Errorf("Error parsing deps.json: %v", err)
 		return nil, err
 	}

--- a/extractor/filesystem/language/dotnet/depsjson/depsjson_test.go
+++ b/extractor/filesystem/language/dotnet/depsjson/depsjson_test.go
@@ -53,6 +53,12 @@ func TestFileRequired(t *testing.T) {
 			wantResultMetric: stats.FileRequiredResultOK,
 		},
 		{
+			name:             "editor.deps.json file",
+			path:             "editor.deps.json",
+			wantRequired:     true,
+			wantResultMetric: stats.FileRequiredResultOK,
+		},
+		{
 			name:             "path application1.deps.json file",
 			path:             "path/to/my/application1.deps.json",
 			wantRequired:     true,
@@ -189,6 +195,12 @@ func TestExtract(t *testing.T) {
 			path:             "testdata/empty",
 			wantErr:          cmpopts.AnyError,
 			wantResultMetric: stats.FileExtractedResultErrorUnknown,
+		},
+		{
+			name:             "editor.deps.json not an object",
+			path:             "testdata/editor.deps.json",
+			wantPackages:     nil,
+			wantResultMetric: stats.FileExtractedResultSuccess,
 		},
 		{
 			name: "valid_application1.deps.json_file_with_an_invalid_package",

--- a/extractor/filesystem/language/dotnet/depsjson/testdata/editor.deps.json
+++ b/extractor/filesystem/language/dotnet/depsjson/testdata/editor.deps.json
@@ -1,0 +1,21 @@
+[
+  "lodash",
+  "moment",
+  "react",
+  "wp-api-fetch",
+  "wp-blob",
+  "wp-blocks",
+  "wp-components",
+  "wp-compose",
+  "wp-data",
+  "wp-date",
+  "wp-edit-post",
+  "wp-editor",
+  "wp-element",
+  "wp-escape-html",
+  "wp-hooks",
+  "wp-i18n",
+  "wp-keycodes",
+  "wp-plugins",
+  "wp-token-list"
+]


### PR DESCRIPTION
Right now `osv-scanner` errors when running recursively on WordPress plugins that have plugins committed as they can have a `*.deps.json` file that gets treated as a .NET based file, but the WordPress version has an array as it's root rather than an object causing a unmarshalling error.

This modifies the extractor to probe the file and only continue with the extraction if it has an object at its root, rather than hard erroring.

An example of this file is https://plugins.trac.wordpress.org/browser/jetpack/trunk/_inc/blocks/editor.deps.json?rev=2100378.

Note I believe nowdays a PHP equivalent is used (e.g. https://plugins.trac.wordpress.org/browser/jetpack/trunk/_inc/blocks/editor.asset.php), but these are still present in some plugins and [`roots/vite-plugin`](https://github.com/roots/vite-plugin) is still using `editor.deps.json`.


