### PR TITLE
Skip JARs without a main class in Java reachability enricher

### DIFF
--- a/enricher/reachability/java/jar.go
+++ b/enricher/reachability/java/jar.go
@@ -47,6 +47,9 @@ var (
 	ErrClassNotFound = errors.New("class not found")
 	// ErrArtifactNotFound is returned when an artifact is not found.
 	ErrArtifactNotFound = errors.New("artifact not found")
+	// ErrNoMainClass is returned when a JAR's MANIFEST.MF has no Main-Class or
+	// Start-Class entry, so it cannot be a root for reachability analysis.
+	ErrNoMainClass = errors.New("no main class")
 )
 
 // MavenPackageFinder is an interface for finding Maven packages that contain a
@@ -282,5 +285,5 @@ func GetMainClasses(manifest io.Reader) ([]string, error) {
 		return classes, nil
 	}
 
-	return nil, errors.New("no main class")
+	return nil, ErrNoMainClass
 }

--- a/enricher/reachability/java/java.go
+++ b/enricher/reachability/java/java.go
@@ -119,6 +119,13 @@ func (enr Enricher) Enrich(ctx context.Context, input *enricher.ScanInput, inv *
 	for jar := range jars {
 		err := enumerateReachabilityForJar(ctx, jar, input, inv, client)
 		if err != nil {
+			// A JAR without a Main-Class manifest entry cannot be a root for
+			// reachability analysis. Skip it and keep processing the remaining
+			// JARs so that valid roots still produce annotations.
+			if errors.Is(err, ErrNoMainClass) {
+				log.Debug("Skipping JAR without a main class", "jar", jar)
+				continue
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
## Problem

`Enrich` in the `reachability/java` enricher returns on the first JAR whose `enumerateReachabilityForJar` call fails. `GetMainClasses` errors when a JAR's `MANIFEST.MF` has no `Main-Class` (or Spring Boot `Start-Class`) entry — which is true for the large majority of dependency JARs. The scan therefore aborts on the first dependency JAR, and the actual application JARs (the real reachability roots) are never analyzed and produce no reachability annotations.

Fixes #2116.

## Change

- Add a sentinel `ErrNoMainClass` and return it from `GetMainClasses` instead of an ad-hoc error.
- In `Enrich`, treat `ErrNoMainClass` as a per-JAR "not a root" condition: skip the JAR and continue with the remaining JARs so valid roots still produce annotations. All other errors still abort the scan as before.