### PR TITLE
fix(osvlocal): skip advisory affected entries with unrecognized ecosystems

### DIFF
--- a/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go
+++ b/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go
@@ -21,6 +21,7 @@ import (
 	osvutil "github.com/google/osv-scalibr/enricher/vulnmatch/internal/osvutil"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/inventory/osvecosystem"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/semantic"
 	osvpb "github.com/ossf/osv-schema/bindings/go/osvschema"
 )
@@ -148,6 +149,22 @@ func matchVersionOrTag(versions []string, target string) bool {
 	return false
 }
 
+// parseAffectedEcosystem parses an advisory affected[] entry's ecosystem
+// without panicking. The vendored osv-schema ecosystem set is pinned per
+// release while osv.dev's set keeps growing, so a multi-ecosystem advisory can
+// carry an ecosystem this build doesn't recognize. Skip that entry instead of
+// crashing the whole scan.
+func parseAffectedEcosystem(affected *osvpb.Affected) (osvecosystem.Parsed, bool) {
+	ecosystem := affected.GetPackage().GetEcosystem()
+	parsed, err := osvecosystem.Parse(ecosystem)
+	if err != nil {
+		log.Debugf("skipping affected entry with unrecognized ecosystem %q: %v", ecosystem, err)
+		return osvecosystem.Parsed{}, false
+	}
+
+	return parsed, true
+}
+
 // IsAffected returns true if the Vulnerability applies to the package version of the Package
 func IsAffected(v *osvpb.Vulnerability, pkg *extractor.Package) bool {
 	np := osvutil.ParsePackage(pkg)
@@ -165,7 +182,11 @@ func IsAffected(v *osvpb.Vulnerability, pkg *extractor.Package) bool {
 		if affected.GetPackage() == nil {
 			continue
 		}
-		if osvecosystem.MustParse(affected.GetPackage().GetEcosystem()).Equal(np.Ecosystem) &&
+		affectedEcosystem, ok := parseAffectedEcosystem(affected)
+		if !ok {
+			continue
+		}
+		if affectedEcosystem.Equal(np.Ecosystem) &&
 			affected.GetPackage().GetName() == np.Name {
 			if len(affected.GetRanges()) == 0 && len(affected.GetVersions()) == 0 {
 				continue

--- a/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability_test.go
+++ b/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability_test.go
@@ -656,6 +656,45 @@ func TestOSV_EcosystemsWithSuffix(t *testing.T) {
 	}
 }
 
+// TestOSV_IsAffected_UnrecognizedEcosystemDoesNotPanic is a regression test for
+// https://github.com/google/osv-scanner/issues/2867, where IsAffected panicked
+// (`osvecosystem.MustParse`) on a multi-ecosystem advisory carrying an ecosystem
+// the build's pinned osv-schema doesn't recognize. The unrecognized affected[]
+// entry must be skipped rather than crash the scan, and a sibling entry in a
+// recognized ecosystem must still match.
+func TestOSV_IsAffected_UnrecognizedEcosystemDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("IsAffected panicked on unrecognized ecosystem: %v", r)
+		}
+	}()
+
+	vuln := buildOSVWithAffected(
+		// an ecosystem this build's vendored osv-schema does not know - reached
+		// because the package is not in range for the recognized sibling below.
+		&osvpb.Affected{
+			Package: &osvpb.Package{Ecosystem: "SomeFutureEcosystem", Name: "my-package"},
+			Ranges: []*osvpb.Range{
+				buildEcosystemAffectsRange(&osvpb.Event{Introduced: "0"}),
+			},
+		},
+		&osvpb.Affected{
+			Package: &osvpb.Package{Ecosystem: string(osvconstants.EcosystemNPM), Name: "my-package"},
+			Ranges: []*osvpb.Range{
+				buildEcosystemAffectsRange(
+					&osvpb.Event{Introduced: "5.0.0"},
+					&osvpb.Event{Fixed: "6.0.0"},
+				),
+			},
+		},
+	)
+
+	// the unrecognized entry is skipped; the npm entry does not cover 1.0.0
+	expectIsAffected(t, vuln, "1.0.0", false)
+	// the npm entry does cover 5.1.0, proving matching still works post-skip
+	expectIsAffected(t, vuln, "5.1.0", true)
+}
+
 func TestOSV_IsAffected_PackageNameMapping(t *testing.T) {
 	tests := []struct {
 		desc             string


### PR DESCRIPTION
## Overview

Port of google/osv-scanner#2882 (fixes google/osv-scanner#2867), moved here at @another-rex's request since the matcher logic now lives in `enricher/vulnmatch/osvlocal`.

`vulns.IsAffected` panics when an OSV advisory's `affected[].package.ecosystem` is a value that `osvecosystem.MustParse` does not recognize (`enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go:168`). It runs on the match path for every advisory, and the per-ecosystem local-db zips store the full advisory record (every `affected[]` entry, not just the matching one), so a single multi-ecosystem advisory that lists an ecosystem newer than the build's pinned `osv-schema` aborts the entire offline scan.

This is reachable without an attacker: osv.dev's ecosystem set grows over time while each release pins a vendored `osv-schema`, so once a new ecosystem appears in a multi-ecosystem advisory, older builds still pinned in CI panic on it. It is also deterministically triggerable today with a local advisory database.

## Details

Adds a small `parseAffectedEcosystem` helper that uses the non-panicking `osvecosystem.Parse` and skips the `affected[]` entry on error (debug log only, no warning), matching the existing silent nil-package skip directly above it. Recognized entries are matched exactly as before; the default path is unaffected.

## Testing

- Added `TestOSV_IsAffected_UnrecognizedEcosystemDoesNotPanic`: a multi-ecosystem advisory whose first entry uses an unrecognized ecosystem and whose second is a recognized npm range. Asserts no panic, that the unrecognized entry is skipped, and that the recognized sibling still matches. Without the fix it fails with `Failed MustParse: base ecosystem does not exist in osvschema: "SomeFutureEcosystem"`.
- `go test ./enricher/vulnmatch/osvlocal/...` passes; `go vet` clean.
- Pinned `golangci-lint` v2.10: 0 issues.
