### PR TITLE
fix(osvlocal): do not panic on packages or advisories the version parser rejects

### DIFF
--- a/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go
+++ b/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go
@@ -21,6 +21,7 @@ import (
 	osvutil "github.com/google/osv-scalibr/enricher/vulnmatch/internal/osvutil"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/inventory/osvecosystem"
+	"github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/semantic"
 	osvpb "github.com/ossf/osv-schema/bindings/go/osvschema"
 )
@@ -45,7 +46,7 @@ func eventVersion(e *osvpb.Event) string {
 	return ""
 }
 
-func rangeContainsVersion(ar *osvpb.Range, pkg *extractor.Package) bool {
+func rangeContainsVersion(vulnID string, ar *osvpb.Range, pkg *extractor.Package) bool {
 	if ar.GetType() != osvpb.Range_ECOSYSTEM && ar.GetType() != osvpb.Range_SEMVER {
 		return false
 	}
@@ -55,7 +56,16 @@ func rangeContainsVersion(ar *osvpb.Range, pkg *extractor.Package) bool {
 	}
 
 	np := osvutil.ParsePackage(pkg)
-	vp := semantic.MustParse(np.Version, string(np.Ecosystem.Ecosystem))
+	ecosystem := string(np.Ecosystem.Ecosystem)
+	vp, err := semantic.Parse(np.Version, ecosystem)
+	if err != nil {
+		// Skip version comparison when the ecosystem has no semantic parser
+		// (e.g. GitHub Actions) or the version is malformed, rather than
+		// panicking and aborting the whole scan. Returning false matches
+		// online-mode behavior.
+		log.Debugf("skipping version comparison for %s package %s@%s: %v", ecosystem, np.Name, np.Version, err)
+		return false
+	}
 
 	sort.Slice(ar.GetEvents(), func(i, j int) bool {
 		a := ar.GetEvents()[i]
@@ -69,8 +79,13 @@ func rangeContainsVersion(ar *osvpb.Range, pkg *extractor.Package) bool {
 			return false
 		}
 
-		// Ignore errors as we assume the version is correct
-		order, _ := semantic.MustParse(eventVersion(a), string(np.Ecosystem.Ecosystem)).CompareStr(eventVersion(b))
+		// Fall back to stable sort order if an advisory event version fails to parse.
+		av, err := semantic.Parse(eventVersion(a), ecosystem)
+		if err != nil {
+			log.Debugf("failed to parse event version %q for advisory %s (ecosystem %s): %v", eventVersion(a), vulnID, ecosystem, err)
+			return false
+		}
+		order, _ := av.CompareStr(eventVersion(b))
 
 		return order < 0
 	})
@@ -96,12 +111,12 @@ func rangeContainsVersion(ar *osvpb.Range, pkg *extractor.Package) bool {
 
 // rangeAffectsVersion checks if the given version is within the range
 // specified by the events of any "Ecosystem" or "Semver" type ranges
-func rangeAffectsVersion(a []*osvpb.Range, pkg *extractor.Package) bool {
+func rangeAffectsVersion(vulnID string, a []*osvpb.Range, pkg *extractor.Package) bool {
 	for _, r := range a {
 		if r.GetType() != osvpb.Range_ECOSYSTEM && r.GetType() != osvpb.Range_SEMVER {
 			return false
 		}
-		if rangeContainsVersion(r, pkg) {
+		if rangeContainsVersion(vulnID, r, pkg) {
 			return true
 		}
 	}
@@ -175,7 +190,7 @@ func IsAffected(v *osvpb.Vulnerability, pkg *extractor.Package) bool {
 				return true
 			}
 
-			if rangeAffectsVersion(affected.GetRanges(), pkg) {
+			if rangeAffectsVersion(v.GetId(), affected.GetRanges(), pkg) {
 				return true
 			}
 

--- a/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability_test.go
+++ b/enricher/vulnmatch/osvlocal/internal/vulns/vulnerability_test.go
@@ -656,6 +656,78 @@ func TestOSV_EcosystemsWithSuffix(t *testing.T) {
 	}
 }
 
+// TestOSV_IsAffected_UnsupportedEcosystemDoesNotPanic is a regression test for
+// https://github.com/google/osv-scanner/issues/2831 as it applies here: a
+// pkg:github package (ecosystem "GitHub Actions") crashed the offline matcher
+// because `semantic.MustParse` panicked on an ecosystem with no version
+// parser. Version comparison is skipped for such packages instead.
+func TestOSV_IsAffected_UnsupportedEcosystemDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("IsAffected panicked on unsupported ecosystem: %v", r)
+		}
+	}()
+
+	vuln := buildOSVWithAffected(
+		&osvpb.Affected{
+			Package: &osvpb.Package{Ecosystem: string(osvconstants.EcosystemGitHubActions), Name: "tj-actions/changed-files"},
+			Ranges: []*osvpb.Range{
+				buildEcosystemAffectsRange(
+					&osvpb.Event{Introduced: "0"},
+					&osvpb.Event{Fixed: "46.0.1"},
+				),
+			},
+		},
+	)
+
+	pkg := &extractor.Package{
+		Name:     "tj-actions/changed-files",
+		Version:  "v45",
+		PURLType: purl.TypeGithub,
+	}
+
+	if vulns.IsAffected(vuln, pkg) {
+		t.Errorf("Expected version comparison to be skipped for an ecosystem without a version parser")
+	}
+}
+
+// TestOSV_IsAffected_MalformedEventVersionDoesNotPanic checks that an advisory
+// whose range event carries a version the ecosystem's parser rejects (here a
+// Debian version with a non-numeric epoch) does not panic the scan.
+func TestOSV_IsAffected_MalformedEventVersionDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("IsAffected panicked on malformed event version: %v", r)
+		}
+	}()
+
+	vuln := buildOSVWithAffected(
+		&osvpb.Affected{
+			Package: &osvpb.Package{Ecosystem: "Debian:12", Name: "my-package"},
+			Ranges: []*osvpb.Range{
+				buildEcosystemAffectsRange(
+					&osvpb.Event{Introduced: "1.0"},
+					&osvpb.Event{Fixed: "x:2.0"},
+					&osvpb.Event{Introduced: "3.0"},
+				),
+			},
+		},
+	)
+
+	pkg := &extractor.Package{
+		Name:     "my-package",
+		Version:  "1.5",
+		PURLType: purl.TypeDebian,
+		Metadata: &dpkgmeta.Metadata{
+			OSID:        "Debian",
+			OSVersionID: "12",
+		},
+	}
+
+	// the outcome for a corrupt advisory is not pinned; the scan surviving it is.
+	_ = vulns.IsAffected(vuln, pkg)
+}
+
 func TestOSV_IsAffected_PackageNameMapping(t *testing.T) {
 	tests := []struct {
 		desc             string


### PR DESCRIPTION
## Overview

`rangeContainsVersion` parses the scanned package's version with `semantic.MustParse` (`enricher/vulnmatch/osvlocal/internal/vulns/vulnerability.go:59`), which panics for any ecosystem `semantic.Parse` has no case for. `pkg:github` packages map to the `GitHub Actions` ecosystem (`extractor/convert.go`), which `osvecosystem` accepts but `semantic` does not. So scanning a repository whose `.github/workflows/*.yml` uses an action that has an osv.dev advisory aborts the entire scan:

```
panic: unsupported ecosystem GitHub Actions
  vulns.rangeContainsVersion   vulnerability.go:59
  vulns.rangeAffectsVersion    vulnerability.go:105
  vulns.IsAffected             vulnerability.go:199
  osvlocal.VulnerabilitiesAffectingPackage  zip.go:266
  osvlocal.(*localMatcher).MatchVulnerabilities  matcher.go:89
```

Reproduced with the `scalibr` binary built from `main`: a scan root containing one workflow with `uses: tj-actions/changed-files@v45`, the real advisory GHSA-mrrh-fwg8-r2c3 in the offline database, and `--plugins github/actions,vulnmatch/osvlocal --plugin-config 'osvlocal:{download:false local_path:"..."}'`. No SBOM is needed; the `github/actions` extractor produces the package.

The same `MustParse` in the event-sort comparator (line 73) panics on an advisory event version the ecosystem's parser rejects, e.g. a Debian version with a non-numeric epoch.

This is the osv-scalibr counterpart of google/osv-scanner#2837 (fixing google/osv-scanner#2831), which was not carried over when the matcher moved here. It is independent of #2429 (that one guards the advisory's *ecosystem name*; this one guards *version* parsing after ecosystem and name have already matched), and the branch is based on `main` so it applies with or without #2429.

## Details

Use `semantic.Parse` at both sites, mirroring #2837:

- package version unparseable: skip version comparison for that range (returning `false` matches online-mode behaviour), debug log
- advisory event version unparseable: fall back to stable sort order, debug log

`rangeContainsVersion` / `rangeAffectsVersion` take the advisory ID so the log line can name it.

## Testing

- `TestOSV_IsAffected_UnsupportedEcosystemDoesNotPanic`: a `pkg:github` package against a `GitHub Actions` advisory with an ECOSYSTEM range. On `main` it fails with `unsupported ecosystem GitHub Actions`.
- `TestOSV_IsAffected_MalformedEventVersionDoesNotPanic`: a `Debian:12` advisory whose `fixed` event is `x:2.0`. On `main` it fails with `invalid version: failed to convert x to a number`.
- `go test ./enricher/vulnmatch/osvlocal/...` passes; `go vet` clean; pinned `golangci-lint` v2.10: 0 issues.
- The workflow reproduction above exits 0 with the fix, all plugins `SUCCEEDED`.
